### PR TITLE
Allow custom DAO roles at deployment

### DIFF
--- a/src/Deployer.sol
+++ b/src/Deployer.sol
@@ -165,23 +165,11 @@ contract Deployer is Initializable, OwnableUpgradeable {
         address executorAddr,
         string memory orgName,
         bool autoUp,
-        address customImpl
+        address customImpl,
+        string[] memory roleNames,
+        string[] memory roleImages,
+        bool[] memory roleCanVote
     ) internal returns (address membershipProxy) {
-        /* build minimal default role‑set */
-        string[] memory names = new string[](2);
-        string[] memory images = new string[](2);
-        bool[] memory canVote = new bool[](2);
-
-        names[0] = "DEFAULT";
-        names[1] = "EXECUTIVE";
-
-        // Set meaningful image URIs for each role
-        images[0] = "ipfs://default-role-image"; // Placeholder URI for default role
-        images[1] = "ipfs://executive-role-image"; // Placeholder URI for executive role
-
-        canVote[0] = true;
-        canVote[1] = true;
-
         bytes32[] memory execRoles = new bytes32[](1);
         execRoles[0] = keccak256("EXECUTIVE");
 
@@ -189,9 +177,9 @@ contract Deployer is Initializable, OwnableUpgradeable {
             "initialize(address,string,string[],string[],bool[],bytes32[])",
             executorAddr,
             orgName,
-            names,
-            images,
-            canVote,
+            roleNames,
+            roleImages,
+            roleCanVote,
             execRoles
         );
 
@@ -315,7 +303,10 @@ contract Deployer is Initializable, OwnableUpgradeable {
         uint8 quorumPct,
         uint8 ddSplit,
         bool quadratic,
-        uint256 minBal
+        uint256 minBal,
+        string[] calldata roleNames,
+        string[] calldata roleImages,
+        bool[] calldata roleCanVote
     )
         external
         returns (
@@ -343,7 +334,8 @@ contract Deployer is Initializable, OwnableUpgradeable {
         executorAddr = _deployExecutor(orgId, executorEOA, autoUpgrade, address(0));
 
         /* 2. Membership NFT */
-        membership = _deployMembership(orgId, executorAddr, orgName, autoUpgrade, address(0));
+        membership =
+            _deployMembership(orgId, executorAddr, orgName, autoUpgrade, address(0), roleNames, roleImages, roleCanVote);
 
         /* 3. QuickJoin */
         quickJoin =

--- a/test/DeployerTest.t.sol
+++ b/test/DeployerTest.t.sol
@@ -67,8 +67,18 @@ contract DeployerTest is Test {
         returns (address hybrid, address exec, address member, address qj, address token, address tm, address hub)
     {
         vm.startPrank(orgOwner);
-        (hybrid, exec, member, qj, token, tm, hub) =
-            deployer.deployFullOrg(ORG_ID, orgOwner, "Hybrid DAO", accountRegProxy, true, 50, 50, false, 4 ether);
+        string[] memory names = new string[](2);
+        names[0] = "DEFAULT";
+        names[1] = "EXECUTIVE";
+        string[] memory images = new string[](2);
+        images[0] = "ipfs://default-role-image";
+        images[1] = "ipfs://executive-role-image";
+        bool[] memory voting = new bool[](2);
+        voting[0] = true;
+        voting[1] = true;
+        (hybrid, exec, member, qj, token, tm, hub) = deployer.deployFullOrg(
+            ORG_ID, orgOwner, "Hybrid DAO", accountRegProxy, true, 50, 50, false, 4 ether, names, images, voting
+        );
         vm.stopPrank();
     }
 
@@ -173,6 +183,16 @@ contract DeployerTest is Test {
         /*–––– deploy a full org via the new flow ––––*/
         vm.startPrank(orgOwner);
 
+        string[] memory names = new string[](2);
+        names[0] = "DEFAULT";
+        names[1] = "EXECUTIVE";
+        string[] memory images = new string[](2);
+        images[0] = "ipfs://default-role-image";
+        images[1] = "ipfs://executive-role-image";
+        bool[] memory voting = new bool[](2);
+        voting[0] = true;
+        voting[1] = true;
+
         (
             address _hybrid,
             address _executor,
@@ -181,7 +201,9 @@ contract DeployerTest is Test {
             address _token,
             address _taskMgr,
             address _eduHub
-        ) = deployer.deployFullOrg(ORG_ID, orgOwner, "Hybrid DAO", accountRegProxy, true, 50, 50, false, 4 ether);
+        ) = deployer.deployFullOrg(
+            ORG_ID, orgOwner, "Hybrid DAO", accountRegProxy, true, 50, 50, false, 4 ether, names, images, voting
+        );
 
         vm.stopPrank();
 
@@ -259,7 +281,18 @@ contract DeployerTest is Test {
         address other = address(99);
         vm.startPrank(other);
         vm.expectRevert(abi.encodeWithSignature("OrgExistsMismatch()"));
-        deployer.deployFullOrg(ORG_ID, other, "Hybrid DAO", accountRegProxy, true, 50, 50, false, 4 ether);
+        string[] memory names = new string[](2);
+        names[0] = "DEFAULT";
+        names[1] = "EXECUTIVE";
+        string[] memory images = new string[](2);
+        images[0] = "ipfs://default-role-image";
+        images[1] = "ipfs://executive-role-image";
+        bool[] memory voting = new bool[](2);
+        voting[0] = true;
+        voting[1] = true;
+        deployer.deployFullOrg(
+            ORG_ID, other, "Hybrid DAO", accountRegProxy, true, 50, 50, false, 4 ether, names, images, voting
+        );
         vm.stopPrank();
     }
 }


### PR DESCRIPTION
## Summary
- add role parameters to `_deployMembership`
- pass custom role configuration via `deployFullOrg`
- update deployment tests to use custom roles

## Testing
- `forge build --offline`
- `forge test --offline`