### PR TITLE
Fix: Eliminate public state drift in Deployer module variables

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -1,14 +1,14 @@
 {
-  "lib/openzeppelin-contracts": {
-    "rev": "4a67c6f3ab2be41487889a020c99e11dedbd6eb4"
-  },
-  "lib/openzeppelin-contracts-upgradeable": {
-    "rev": "62164b46517484f5b734d2c0e7e647de058685bf"
+  "lib/hats-protocol": {
+    "rev": "cccb71a061cdb9095af7d11dfdb47026993d8c4e"
   },
   "lib/forge-std": {
     "rev": "3b20d60d14b343ee4f908cb8079495c07f5e8981"
   },
-  "lib/hats-protocol": {
-    "rev": "cccb71a061cdb9095af7d11dfdb47026993d8c4e"
+  "lib/openzeppelin-contracts-upgradeable": {
+    "rev": "62164b46517484f5b734d2c0e7e647de058685bf"
+  },
+  "lib/openzeppelin-contracts": {
+    "rev": "4a67c6f3ab2be41487889a020c99e11dedbd6eb4"
   }
 }

--- a/src/Deployer.sol
+++ b/src/Deployer.sol
@@ -86,8 +86,6 @@ contract Deployer is Initializable, OwnableUpgradeable {
     }
 
     IHats public hats;
-    EligibilityModule public eligibilityModule;
-    ToggleModule public toggleModule;
 
     // keccak256("poa.deployer.storage") to get a unique, collision-free slot
     bytes32 private constant _STORAGE_SLOT = 0x4f6cf4b446a382b8bde8d35e8ca59cc30d80d9a326b56d1a5212b27a0198fc7f;
@@ -383,13 +381,13 @@ contract Deployer is Initializable, OwnableUpgradeable {
         //  Deploy EligibilityModule with Deployer as initial super admin
         // ─────────────────────────────────────────────────────────────
         address eligibilityModuleAddress = _deployEligibilityModule(orgId, true, address(0));
-        eligibilityModule = EligibilityModule(eligibilityModuleAddress);
+        EligibilityModule eligibilityModule = EligibilityModule(eligibilityModuleAddress);
 
         // ─────────────────────────────────────────────────────────────
         //  Deploy ToggleModule with deployer as initial admin
         // ─────────────────────────────────────────────────────────────
         address toggleModuleAddress = _deployToggleModule(orgId, address(this), true, address(0));
-        toggleModule = ToggleModule(toggleModuleAddress);
+        ToggleModule toggleModule = ToggleModule(toggleModuleAddress);
 
         // Set the toggle module in the eligibility module now that both are deployed
         eligibilityModule.setToggleModule(toggleModuleAddress);
@@ -653,6 +651,19 @@ contract Deployer is Initializable, OwnableUpgradeable {
     // Public getter for orgRegistry
     function orgRegistry() external view returns (address) {
         return address(_layout().orgRegistry);
+    }
+
+    /* ─────────── Module Getters ─────────── */
+    function getEligibilityModule(bytes32 orgId) external view returns (address) {
+        Layout storage l = _layout();
+        bytes32 typeId = keccak256(bytes("EligibilityModule"));
+        return l.orgRegistry.getOrgContract(orgId, typeId);
+    }
+
+    function getToggleModule(bytes32 orgId) external view returns (address) {
+        Layout storage l = _layout();
+        bytes32 typeId = keccak256(bytes("ToggleModule"));
+        return l.orgRegistry.getOrgContract(orgId, typeId);
     }
 
     /* ─────────── Version ─────────── */

--- a/test/DeployerTest.t.sol
+++ b/test/DeployerTest.t.sol
@@ -223,7 +223,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         vm.stopPrank();
 
         // Get the eligibility module and role hat IDs
-        setup.eligibilityModule = address(deployer.eligibilityModule());
+        setup.eligibilityModule = deployer.getEligibilityModule(ORG_ID);
         setup.defaultRoleHat = orgRegistry.getRoleHat(ORG_ID, 0);
         setup.executiveRoleHat = orgRegistry.getRoleHat(ORG_ID, 1);
         setup.memberRoleHat = orgRegistry.getRoleHat(ORG_ID, 2);
@@ -253,7 +253,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         vm.stopPrank();
 
         // Get the eligibility module and role hat IDs
-        setup.eligibilityModule = address(deployer.eligibilityModule());
+        setup.eligibilityModule = deployer.getEligibilityModule(ORG_ID);
         setup.defaultRoleHat = orgRegistry.getRoleHat(ORG_ID, 0);
         setup.executiveRoleHat = orgRegistry.getRoleHat(ORG_ID, 1);
         setup.memberRoleHat = 0; // Not applicable for 2-role setup
@@ -655,15 +655,15 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             topHatId, // admin = parent Top Hat
             "NEW_ROLE", // details
             type(uint32).max, // unlimited supply
-            address(deployer.eligibilityModule()), // eligibility module
-            address(deployer.toggleModule()), // toggle module
+            deployer.getEligibilityModule(ORG_ID), // eligibility module
+            deployer.getToggleModule(ORG_ID), // toggle module
             true, // mutable
             "NEW_ROLE" // data blob
         );
 
         // Configure the new role hat for the executor
-        deployer.eligibilityModule().setWearerEligibility(exec, newRoleHatId, true, true);
-        deployer.toggleModule().setHatStatus(newRoleHatId, true);
+        EligibilityModule(deployer.getEligibilityModule(ORG_ID)).setWearerEligibility(exec, newRoleHatId, true, true);
+        ToggleModule(deployer.getToggleModule(ORG_ID)).setHatStatus(newRoleHatId, true);
 
         // Mint the new role hat to the executor
         IHats(SEPOLIA_HATS).mintHat(newRoleHatId, exec);
@@ -694,7 +694,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         vm.stopPrank();
 
         // Get the eligibility module address directly
-        address eligibilityModuleAddr = address(deployer.eligibilityModule());
+        address eligibilityModuleAddr = deployer.getEligibilityModule(ORG_ID);
 
         // Verify executor is the super admin
         assertEq(EligibilityModule(eligibilityModuleAddr).superAdmin(), exec, "Executor should be the super admin");
@@ -936,7 +936,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         vm.stopPrank();
 
         // Get the eligibility module address
-        address eligibilityModuleAddr = address(deployer.eligibilityModule());
+        address eligibilityModuleAddr = deployer.getEligibilityModule(ORG_ID);
 
         // Get role hat IDs
         uint256 defaultRoleHat = orgRegistry.getRoleHat(ORG_ID, 0);
@@ -1116,7 +1116,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         vm.stopPrank();
 
         // Get the eligibility module address
-        address eligibilityModuleAddr = address(deployer.eligibilityModule());
+        address eligibilityModuleAddr = deployer.getEligibilityModule(ORG_ID);
 
         // Get role hat IDs
         uint256 defaultRoleHat = orgRegistry.getRoleHat(ORG_ID, 0);
@@ -1250,7 +1250,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         vm.stopPrank();
 
         // Get the eligibility module address
-        address eligibilityModuleAddr = address(deployer.eligibilityModule());
+        address eligibilityModuleAddr = deployer.getEligibilityModule(ORG_ID);
 
         // Get role hat IDs
         uint256 defaultRoleHat = orgRegistry.getRoleHat(ORG_ID, 0);
@@ -1316,7 +1316,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         vm.stopPrank();
 
         // Get the eligibility module address
-        address eligibilityModuleAddr = address(deployer.eligibilityModule());
+        address eligibilityModuleAddr = deployer.getEligibilityModule(ORG_ID);
 
         // Get role hat IDs
         uint256 defaultRoleHat = orgRegistry.getRoleHat(ORG_ID, 0);
@@ -1393,7 +1393,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         vm.stopPrank();
 
         // Get the eligibility module address
-        address eligibilityModuleAddr = address(deployer.eligibilityModule());
+        address eligibilityModuleAddr = deployer.getEligibilityModule(ORG_ID);
 
         // Get role hat IDs
         uint256 defaultRoleHat = orgRegistry.getRoleHat(ORG_ID, 0);
@@ -1531,7 +1531,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         vm.stopPrank();
 
         // Get the eligibility module address
-        address eligibilityModuleAddr = address(deployer.eligibilityModule());
+        address eligibilityModuleAddr = deployer.getEligibilityModule(ORG_ID);
 
         // Get role hat IDs
         uint256 defaultRoleHat = orgRegistry.getRoleHat(ORG_ID, 0);


### PR DESCRIPTION
## Summary
- Removes contract-level public `eligibilityModule` and `toggleModule` variables that were storing only the last deployed modules
- Prevents state drift where module addresses would be overwritten with each new org deployment
- Adds proper per-org module getters that retrieve from OrgRegistry

## Problem
The Deployer contract had public state variables `eligibilityModule` and `toggleModule` that were being overwritten with each org deployment. This meant:
- External readers would get wrong/stale module addresses
- Off-chain infrastructure could read incorrect addresses
- The variables only reflected the last deployed org's modules

## Solution
1. **Removed public state variables** - Eliminated the problematic `eligibilityModule` and `toggleModule` public variables
2. **Made modules local** - Converted to local variables within `_setupHatsTree` function
3. **Added view getters** - Created `getEligibilityModule(orgId)` and `getToggleModule(orgId)` functions that properly retrieve modules from OrgRegistry per organization
4. **Updated tests** - Modified all test references to use the new getter functions with orgId parameter

## Test plan
- [x] All existing Deployer tests pass
- [x] Verified modules are properly stored per-org in registry
- [x] Confirmed getters retrieve correct module addresses

🤖 Generated with [Claude Code](https://claude.ai/code)