### PR TITLE
feat: Add PaymasterHub integration for per-org gas sponsorship

### DIFF
--- a/src/PaymasterHub.sol
+++ b/src/PaymasterHub.sol
@@ -7,6 +7,7 @@ import {PackedUserOperation, UserOpLib} from "./interfaces/PackedUserOperation.s
 import {IHats} from "lib/hats-protocol/src/Interfaces/IHats.sol";
 import {ReentrancyGuard} from "lib/openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol";
 import {IERC165} from "lib/openzeppelin-contracts/contracts/utils/introspection/IERC165.sol";
+import {Initializable} from "@openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
 
 /**
  * @title PaymasterHub
@@ -15,7 +16,7 @@ import {IERC165} from "lib/openzeppelin-contracts/contracts/utils/introspection/
  * @dev Implements ERC-7201 storage pattern with comprehensive security features
  * @custom:security-contact security@poa.org
  */
-contract PaymasterHub is IPaymaster, ReentrancyGuard, IERC165 {
+contract PaymasterHub is IPaymaster, ReentrancyGuard, IERC165, Initializable {
     using UserOpLib for bytes32;
 
     // ============ Custom Errors ============
@@ -76,8 +77,8 @@ contract PaymasterHub is IPaymaster, ReentrancyGuard, IERC165 {
     event UserOpPosted(bytes32 indexed opHash, address indexed postedBy);
     event EmergencyWithdraw(address indexed to, uint256 amount);
 
-    // ============ Immutables ============
-    address public immutable ENTRY_POINT;
+    // ============ Storage (moved from immutable for proxy compatibility) ============
+    address public ENTRY_POINT;
 
     // ============ Storage Structs ============
     struct Config {
@@ -136,8 +137,14 @@ contract PaymasterHub is IPaymaster, ReentrancyGuard, IERC165 {
     bytes32 private constant BOUNTY_STORAGE_LOCATION =
         0x5aefd14c2f5001261e819816e3c40d9d9cc763af84e5df87cd5955f0f5cfd09e;
 
-    // ============ Constructor ============
-    constructor(address _entryPoint, address _hats, uint256 _adminHatId) {
+    // ============ Constructor (disabled for proxy) ============
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    // ============ Initializer ============
+    function initialize(address _entryPoint, address _hats, uint256 _adminHatId) public initializer {
         if (_entryPoint == address(0)) revert ZeroAddress();
         if (_hats == address(0)) revert ZeroAddress();
         if (_adminHatId == 0) revert ZeroAddress();

--- a/src/libs/ModuleDeploymentLib.sol
+++ b/src/libs/ModuleDeploymentLib.sol
@@ -84,6 +84,10 @@ interface IToggleModuleInit {
     function initialize(address admin) external;
 }
 
+interface IPaymasterHubInit {
+    function initialize(address entryPoint, address hats, uint256 adminHatId) external;
+}
+
 library ModuleDeploymentLib {
     error InvalidAddress();
     error EmptyInit();
@@ -246,5 +250,20 @@ library ModuleDeploymentLib {
             IHybridVotingInit.initialize.selector, config.hats, executorAddr, creatorHats, targets, quorumPct, classes
         );
         hvProxy = deployCore(config, ModuleTypes.HYBRID_VOTING_ID, init, lastRegister, beacon);
+    }
+
+    function deployPaymasterHub(
+        DeployConfig memory config,
+        address entryPoint,
+        uint256 adminHatId,
+        address beacon
+    ) internal returns (address pmProxy) {
+        bytes memory init = abi.encodeWithSelector(
+            IPaymasterHubInit.initialize.selector,
+            entryPoint,
+            config.hats,
+            adminHatId
+        );
+        pmProxy = deployCore(config, ModuleTypes.PAYMASTER_HUB_ID, init, false, beacon);
     }
 }

--- a/src/libs/ModuleTypes.sol
+++ b/src/libs/ModuleTypes.sol
@@ -45,4 +45,7 @@ library ModuleTypes {
 
     /// @dev keccak256("ToggleModule")
     bytes32 constant TOGGLE_MODULE_ID = 0x75dfb681d193a73a66b628a5adc66bb1ca7bb3feb9a5692cd0a1560ccd9b851a;
+
+    /// @dev keccak256("PaymasterHub")
+    bytes32 constant PAYMASTER_HUB_ID = 0x846374a1b9aebfa243bcd01b2b2c7d94ce66a1b22f9ed17ed1d6fd61a8c93891;
 }

--- a/test/PaymasterHubDeployment.t.sol
+++ b/test/PaymasterHubDeployment.t.sol
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+
+// Import required contracts
+import {Deployer} from "../src/Deployer.sol";
+import {PaymasterHub} from "../src/PaymasterHub.sol";
+import {ModuleDeploymentLib, IHybridVotingInit} from "../src/libs/ModuleDeploymentLib.sol";
+import {ModuleTypes} from "../src/libs/ModuleTypes.sol";
+import {OrgRegistry} from "../src/OrgRegistry.sol";
+import {PoaManager} from "../src/PoaManager.sol";
+import {ImplementationRegistry} from "../src/ImplementationRegistry.sol";
+import {IHats} from "@hats-protocol/src/Interfaces/IHats.sol";
+import {HatsTreeSetup} from "../src/HatsTreeSetup.sol";
+import {UniversalAccountRegistry} from "../src/UniversalAccountRegistry.sol";
+import {HybridVoting} from "../src/HybridVoting.sol";
+import {Executor} from "../src/Executor.sol";
+import {ParticipationToken} from "../src/ParticipationToken.sol";
+import {QuickJoin} from "../src/QuickJoin.sol";
+import {TaskManager} from "../src/TaskManager.sol";
+import {EducationHub} from "../src/EducationHub.sol";
+import {EligibilityModule} from "../src/EligibilityModule.sol";
+import {ToggleModule} from "../src/ToggleModule.sol";
+import {SwitchableBeacon} from "../src/SwitchableBeacon.sol";
+import {IEntryPoint} from "../src/interfaces/IEntryPoint.sol";
+
+// Mock EntryPoint for testing
+contract MockEntryPoint is IEntryPoint {
+    mapping(address => uint256) private _deposits;
+
+    function depositTo(address account) external payable override {
+        _deposits[account] += msg.value;
+    }
+
+    function withdrawTo(address payable withdrawAddress, uint256 withdrawAmount) external override {
+        require(_deposits[msg.sender] >= withdrawAmount, "Insufficient deposit");
+        _deposits[msg.sender] -= withdrawAmount;
+        withdrawAddress.transfer(withdrawAmount);
+    }
+
+    function balanceOf(address account) external view override returns (uint256) {
+        return _deposits[account];
+    }
+}
+
+// Test contract for PaymasterHub deployment
+contract PaymasterHubDeploymentTest is Test {
+    // Core contracts
+    ImplementationRegistry implRegistry;
+    PoaManager poaManager;
+    OrgRegistry orgRegistry;
+    Deployer deployer;
+    address hatsTreeSetup;
+    
+    // Implementations
+    PaymasterHub paymasterImpl;
+    HybridVoting hybridImpl;
+    Executor execImpl;
+    ParticipationToken pTokenImpl;
+    QuickJoin quickJoinImpl;
+    TaskManager taskMgrImpl;
+    EducationHub eduHubImpl;
+    EligibilityModule eligModuleImpl;
+    ToggleModule toggleModuleImpl;
+    UniversalAccountRegistry accountRegImpl;
+    
+    // Test addresses
+    address public constant poaAdmin = address(1);
+    address public constant orgOwner = address(2);
+    address public constant user1 = address(3);
+    address public constant user2 = address(4);
+    address public constant SEPOLIA_HATS = 0x3bc1A0Ad72417f2d411118085256fC53CBdDd137;
+    
+    // Test IDs
+    bytes32 public constant ORG_ID = keccak256("PAYMASTER-TEST-ORG");
+    bytes32 public constant GLOBAL_REG_ID = keccak256("POA-GLOBAL-ACCOUNT-REGISTRY");
+    
+    // Mock EntryPoint
+    MockEntryPoint mockEntryPoint;
+    
+    function setUp() public {
+        // Deploy mock EntryPoint
+        mockEntryPoint = new MockEntryPoint();
+        
+        // Deploy core infrastructure
+        implRegistry = new ImplementationRegistry();
+        poaManager = new PoaManager();
+        orgRegistry = new OrgRegistry();
+        
+        // Deploy and initialize Hats
+        deployCodeTo("Hats.sol", SEPOLIA_HATS);
+        IHats hats = IHats(SEPOLIA_HATS);
+        
+        // Deploy HatsTreeSetup
+        hatsTreeSetup = address(new HatsTreeSetup());
+        
+        // Initialize PoaManager with ImplementationRegistry
+        vm.prank(poaAdmin);
+        poaManager.initialize(address(implRegistry), poaAdmin);
+        
+        // Deploy implementations
+        paymasterImpl = new PaymasterHub();
+        hybridImpl = new HybridVoting();
+        execImpl = new Executor();
+        pTokenImpl = new ParticipationToken();
+        quickJoinImpl = new QuickJoin();
+        taskMgrImpl = new TaskManager();
+        eduHubImpl = new EducationHub();
+        eligModuleImpl = new EligibilityModule();
+        toggleModuleImpl = new ToggleModule();
+        accountRegImpl = new UniversalAccountRegistry();
+        
+        // Register implementations
+        vm.startPrank(poaAdmin);
+        implRegistry.registerImplementation("PaymasterHub", address(paymasterImpl));
+        implRegistry.registerImplementation("HybridVoting", address(hybridImpl));
+        implRegistry.registerImplementation("Executor", address(execImpl));
+        implRegistry.registerImplementation("ParticipationToken", address(pTokenImpl));
+        implRegistry.registerImplementation("QuickJoin", address(quickJoinImpl));
+        implRegistry.registerImplementation("TaskManager", address(taskMgrImpl));
+        implRegistry.registerImplementation("EducationHub", address(eduHubImpl));
+        implRegistry.registerImplementation("EligibilityModule", address(eligModuleImpl));
+        implRegistry.registerImplementation("ToggleModule", address(toggleModuleImpl));
+        
+        // Create beacons in PoaManager
+        poaManager.createBeacon("PaymasterHub");
+        poaManager.createBeacon("HybridVoting");
+        poaManager.createBeacon("Executor");
+        poaManager.createBeacon("ParticipationToken");
+        poaManager.createBeacon("QuickJoin");
+        poaManager.createBeacon("TaskManager");
+        poaManager.createBeacon("EducationHub");
+        poaManager.createBeacon("EligibilityModule");
+        poaManager.createBeacon("ToggleModule");
+        vm.stopPrank();
+        
+        // Deploy and initialize OrgRegistry
+        vm.prank(poaAdmin);
+        orgRegistry.initialize(poaAdmin, address(poaManager));
+        
+        // Deploy global account registry proxy
+        address accountRegProxy = address(accountRegImpl);
+        
+        // Deploy and initialize Deployer
+        deployer = new Deployer();
+        deployer.initialize(address(poaManager), address(orgRegistry), SEPOLIA_HATS, hatsTreeSetup);
+    }
+    
+    function testDeployOrgWithoutPaymaster() public {
+        vm.startPrank(orgOwner);
+        
+        // Prepare deployment parameters
+        string[] memory roleNames = new string[](2);
+        roleNames[0] = "DEFAULT";
+        roleNames[1] = "EXECUTIVE";
+        
+        string[] memory roleImages = new string[](2);
+        roleImages[0] = "ipfs://default";
+        roleImages[1] = "ipfs://executive";
+        
+        bool[] memory roleCanVote = new bool[](2);
+        roleCanVote[0] = true;
+        roleCanVote[1] = true;
+        
+        IHybridVotingInit.ClassConfig[] memory votingClasses = new IHybridVotingInit.ClassConfig[](1);
+        uint256[] memory hatIds = new uint256[](0);
+        votingClasses[0] = IHybridVotingInit.ClassConfig({
+            strategy: IHybridVotingInit.ClassStrategy.DIRECT,
+            slicePct: 100,
+            quadratic: false,
+            minBalance: 0,
+            asset: address(0),
+            hatIds: hatIds
+        });
+        
+        Deployer.RoleAssignments memory roleAssignments = _buildDefaultRoleAssignments();
+        
+        // PaymasterConfig with disabled paymaster
+        Deployer.PaymasterConfig memory pmConfig = Deployer.PaymasterConfig({
+            enabled: false,
+            entryPoint: address(0),
+            initialDeposit: 0,
+            initialBounty: 0,
+            enableBounty: false,
+            maxBountyPerOp: 0,
+            bountyPctCap: 0
+        });
+        
+        // Deploy organization without paymaster
+        (address hybrid, address exec,,,,,address paymaster) = deployer.deployFullOrg(
+            ORG_ID,
+            "Test Org",
+            address(accountRegImpl),
+            true,
+            50,
+            votingClasses,
+            roleNames,
+            roleImages,
+            roleCanVote,
+            roleAssignments,
+            pmConfig
+        );
+        
+        vm.stopPrank();
+        
+        // Verify deployment
+        assertEq(paymaster, address(0), "Paymaster should not be deployed when disabled");
+        assertTrue(hybrid != address(0), "HybridVoting should be deployed");
+        assertTrue(exec != address(0), "Executor should be deployed");
+    }
+    
+    function testDeployOrgWithPaymaster() public {
+        vm.deal(orgOwner, 10 ether);
+        vm.startPrank(orgOwner);
+        
+        // Prepare deployment parameters
+        string[] memory roleNames = new string[](2);
+        roleNames[0] = "DEFAULT";
+        roleNames[1] = "EXECUTIVE";
+        
+        string[] memory roleImages = new string[](2);
+        roleImages[0] = "ipfs://default";
+        roleImages[1] = "ipfs://executive";
+        
+        bool[] memory roleCanVote = new bool[](2);
+        roleCanVote[0] = true;
+        roleCanVote[1] = true;
+        
+        IHybridVotingInit.ClassConfig[] memory votingClasses = new IHybridVotingInit.ClassConfig[](1);
+        uint256[] memory hatIds = new uint256[](0);
+        votingClasses[0] = IHybridVotingInit.ClassConfig({
+            strategy: IHybridVotingInit.ClassStrategy.DIRECT,
+            slicePct: 100,
+            quadratic: false,
+            minBalance: 0,
+            asset: address(0),
+            hatIds: hatIds
+        });
+        
+        Deployer.RoleAssignments memory roleAssignments = _buildDefaultRoleAssignments();
+        
+        // PaymasterConfig with enabled paymaster and funding
+        Deployer.PaymasterConfig memory pmConfig = Deployer.PaymasterConfig({
+            enabled: true,
+            entryPoint: address(mockEntryPoint),
+            initialDeposit: 1 ether,
+            initialBounty: 0.5 ether,
+            enableBounty: true,
+            maxBountyPerOp: 0.01 ether,
+            bountyPctCap: 1000 // 10%
+        });
+        
+        // Deploy organization with paymaster
+        (address hybrid, address exec,,,,,address paymaster) = deployer.deployFullOrg{value: 1.5 ether}(
+            ORG_ID,
+            "Test Org",
+            address(accountRegImpl),
+            true,
+            50,
+            votingClasses,
+            roleNames,
+            roleImages,
+            roleCanVote,
+            roleAssignments,
+            pmConfig
+        );
+        
+        vm.stopPrank();
+        
+        // Verify deployment
+        assertTrue(paymaster != address(0), "Paymaster should be deployed when enabled");
+        assertTrue(hybrid != address(0), "HybridVoting should be deployed");
+        assertTrue(exec != address(0), "Executor should be deployed");
+        
+        // Verify PaymasterHub configuration
+        PaymasterHub paymasterHub = PaymasterHub(payable(paymaster));
+        assertEq(paymasterHub.ENTRY_POINT(), address(mockEntryPoint), "EntryPoint should be set");
+        
+        // Verify funding
+        assertEq(mockEntryPoint.balanceOf(paymaster), 1 ether, "EntryPoint deposit should be funded");
+        assertEq(paymaster.balance, 0.5 ether, "Bounty pool should be funded");
+        
+        // Verify bounty configuration
+        PaymasterHub.Bounty memory bounty = paymasterHub.bountyInfo();
+        assertTrue(bounty.enabled, "Bounty should be enabled");
+        assertEq(bounty.maxBountyWeiPerOp, 0.01 ether, "Max bounty per op should be set");
+        assertEq(bounty.pctBpCap, 1000, "Bounty percentage cap should be set");
+    }
+    
+    function testDeployOrgWithInsufficientFunding() public {
+        vm.deal(orgOwner, 0.5 ether); // Not enough for requested funding
+        vm.startPrank(orgOwner);
+        
+        // Prepare deployment parameters
+        string[] memory roleNames = new string[](2);
+        roleNames[0] = "DEFAULT";
+        roleNames[1] = "EXECUTIVE";
+        
+        string[] memory roleImages = new string[](2);
+        roleImages[0] = "ipfs://default";
+        roleImages[1] = "ipfs://executive";
+        
+        bool[] memory roleCanVote = new bool[](2);
+        roleCanVote[0] = true;
+        roleCanVote[1] = true;
+        
+        IHybridVotingInit.ClassConfig[] memory votingClasses = new IHybridVotingInit.ClassConfig[](1);
+        uint256[] memory hatIds = new uint256[](0);
+        votingClasses[0] = IHybridVotingInit.ClassConfig({
+            strategy: IHybridVotingInit.ClassStrategy.DIRECT,
+            slicePct: 100,
+            quadratic: false,
+            minBalance: 0,
+            asset: address(0),
+            hatIds: hatIds
+        });
+        
+        Deployer.RoleAssignments memory roleAssignments = _buildDefaultRoleAssignments();
+        
+        // PaymasterConfig requesting more funds than available
+        Deployer.PaymasterConfig memory pmConfig = Deployer.PaymasterConfig({
+            enabled: true,
+            entryPoint: address(mockEntryPoint),
+            initialDeposit: 1 ether,
+            initialBounty: 0.5 ether,
+            enableBounty: true,
+            maxBountyPerOp: 0.01 ether,
+            bountyPctCap: 1000
+        });
+        
+        // Should revert due to insufficient funding
+        vm.expectRevert(abi.encodeWithSelector(Deployer.InsufficientFunding.selector));
+        deployer.deployFullOrg{value: 0.5 ether}(
+            ORG_ID,
+            "Test Org",
+            address(accountRegImpl),
+            true,
+            50,
+            votingClasses,
+            roleNames,
+            roleImages,
+            roleCanVote,
+            roleAssignments,
+            pmConfig
+        );
+        
+        vm.stopPrank();
+    }
+    
+    function testPaymasterUpgradeability() public {
+        vm.deal(orgOwner, 2 ether);
+        vm.startPrank(orgOwner);
+        
+        // Deploy with auto-upgrade enabled
+        string[] memory roleNames = new string[](1);
+        roleNames[0] = "ADMIN";
+        
+        string[] memory roleImages = new string[](1);
+        roleImages[0] = "ipfs://admin";
+        
+        bool[] memory roleCanVote = new bool[](1);
+        roleCanVote[0] = true;
+        
+        IHybridVotingInit.ClassConfig[] memory votingClasses = new IHybridVotingInit.ClassConfig[](0);
+        Deployer.RoleAssignments memory roleAssignments = _buildSingleRoleAssignments();
+        
+        Deployer.PaymasterConfig memory pmConfig = Deployer.PaymasterConfig({
+            enabled: true,
+            entryPoint: address(mockEntryPoint),
+            initialDeposit: 0,
+            initialBounty: 0,
+            enableBounty: false,
+            maxBountyPerOp: 0,
+            bountyPctCap: 0
+        });
+        
+        (,address exec,,,,,address paymaster) = deployer.deployFullOrg(
+            ORG_ID,
+            "Test Org",
+            address(accountRegImpl),
+            true, // auto-upgrade enabled
+            50,
+            votingClasses,
+            roleNames,
+            roleImages,
+            roleCanVote,
+            roleAssignments,
+            pmConfig
+        );
+        
+        vm.stopPrank();
+        
+        // Get the beacon from OrgRegistry
+        address beacon = orgRegistry.getOrgBeacon(ORG_ID, ModuleTypes.PAYMASTER_HUB_ID);
+        assertTrue(beacon != address(0), "Beacon should exist");
+        
+        // Verify beacon is in mirror mode (auto-upgrade)
+        SwitchableBeacon switchableBeacon = SwitchableBeacon(beacon);
+        assertTrue(switchableBeacon.isMirrorMode(), "Beacon should be in mirror mode for auto-upgrade");
+        
+        // Verify beacon owner is the executor
+        assertEq(switchableBeacon.owner(), exec, "Beacon should be owned by executor");
+    }
+    
+    // Helper function to build default role assignments
+    function _buildDefaultRoleAssignments() internal pure returns (Deployer.RoleAssignments memory) {
+        uint256[] memory defaultRole = new uint256[](1);
+        defaultRole[0] = 0;
+        
+        uint256[] memory executiveRole = new uint256[](1);
+        executiveRole[0] = 1;
+        
+        return Deployer.RoleAssignments({
+            quickJoinRoles: defaultRole,
+            tokenMemberRoles: defaultRole,
+            tokenApproverRoles: executiveRole,
+            taskCreatorRoles: executiveRole,
+            educationCreatorRoles: executiveRole,
+            educationMemberRoles: defaultRole,
+            proposalCreatorRoles: executiveRole
+        });
+    }
+    
+    // Helper function for single role assignments
+    function _buildSingleRoleAssignments() internal pure returns (Deployer.RoleAssignments memory) {
+        uint256[] memory adminRole = new uint256[](1);
+        adminRole[0] = 0;
+        
+        return Deployer.RoleAssignments({
+            quickJoinRoles: adminRole,
+            tokenMemberRoles: adminRole,
+            tokenApproverRoles: adminRole,
+            taskCreatorRoles: adminRole,
+            educationCreatorRoles: adminRole,
+            educationMemberRoles: adminRole,
+            proposalCreatorRoles: adminRole
+        });
+    }
+}

--- a/test/PaymasterHubIntegrationDeployment.t.sol
+++ b/test/PaymasterHubIntegrationDeployment.t.sol
@@ -1,0 +1,502 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {PaymasterHub} from "../src/PaymasterHub.sol";
+import {Deployer} from "../src/Deployer.sol";
+import {IPaymaster} from "../src/interfaces/IPaymaster.sol";
+import {PackedUserOperation} from "../src/interfaces/PackedUserOperation.sol";
+import {IHats} from "lib/hats-protocol/src/Interfaces/IHats.sol";
+import {ModuleDeploymentLib, IHybridVotingInit} from "../src/libs/ModuleDeploymentLib.sol";
+import {ModuleTypes} from "../src/libs/ModuleTypes.sol";
+import {OrgRegistry} from "../src/OrgRegistry.sol";
+import {PoaManager} from "../src/PoaManager.sol";
+import {ImplementationRegistry} from "../src/ImplementationRegistry.sol";
+import {HatsTreeSetup} from "../src/HatsTreeSetup.sol";
+import {UniversalAccountRegistry} from "../src/UniversalAccountRegistry.sol";
+import {HybridVoting} from "../src/HybridVoting.sol";
+import {Executor} from "../src/Executor.sol";
+import {ParticipationToken} from "../src/ParticipationToken.sol";
+import {QuickJoin} from "../src/QuickJoin.sol";
+import {TaskManager} from "../src/TaskManager.sol";
+import {EducationHub} from "../src/EducationHub.sol";
+import {EligibilityModule} from "../src/EligibilityModule.sol";
+import {ToggleModule} from "../src/ToggleModule.sol";
+
+// Mock contracts for integration testing
+contract MockEntryPoint {
+    mapping(address => uint256) private _deposits;
+    address public lastPaymaster;
+
+    function depositTo(address account) external payable {
+        _deposits[account] += msg.value;
+    }
+
+    function withdrawTo(address payable withdrawAddress, uint256 withdrawAmount) external {
+        require(_deposits[msg.sender] >= withdrawAmount, "Insufficient deposit");
+        _deposits[msg.sender] -= withdrawAmount;
+        withdrawAddress.transfer(withdrawAmount);
+    }
+
+    function balanceOf(address account) external view returns (uint256) {
+        return _deposits[account];
+    }
+
+    // Simulate UserOp validation
+    function simulateValidation(
+        address paymaster,
+        PackedUserOperation memory userOp,
+        bytes32 userOpHash,
+        uint256 maxCost
+    ) external returns (bytes memory context, uint256 validationData) {
+        lastPaymaster = paymaster;
+        return IPaymaster(paymaster).validatePaymasterUserOp(userOp, userOpHash, maxCost);
+    }
+
+    // Simulate postOp
+    function simulatePostOp(
+        address paymaster,
+        IPaymaster.PostOpMode mode,
+        bytes memory context,
+        uint256 actualGasCost
+    ) external {
+        IPaymaster(paymaster).postOp(mode, context, actualGasCost);
+    }
+}
+
+contract MockAccount {
+    address public owner;
+    
+    constructor(address _owner) {
+        owner = _owner;
+    }
+    
+    function execute(address target, uint256 value, bytes memory data) external returns (bytes memory) {
+        require(msg.sender == owner, "Only owner");
+        (bool success, bytes memory result) = target.call{value: value}(data);
+        require(success, "Execution failed");
+        return result;
+    }
+}
+
+contract PaymasterHubIntegrationDeploymentTest is Test {
+    // Core contracts
+    ImplementationRegistry implRegistry;
+    PoaManager poaManager;
+    OrgRegistry orgRegistry;
+    Deployer deployer;
+    address hatsTreeSetup;
+    MockEntryPoint mockEntryPoint;
+    IHats hats;
+    
+    // Implementations
+    PaymasterHub paymasterImpl;
+    HybridVoting hybridImpl;
+    Executor execImpl;
+    ParticipationToken pTokenImpl;
+    QuickJoin quickJoinImpl;
+    TaskManager taskMgrImpl;
+    EducationHub eduHubImpl;
+    EligibilityModule eligModuleImpl;
+    ToggleModule toggleModuleImpl;
+    UniversalAccountRegistry accountRegImpl;
+    
+    // Test addresses
+    address public constant poaAdmin = address(1);
+    address public constant orgOwner = address(2);
+    address public constant memberUser = address(3);
+    address public constant executiveUser = address(4);
+    address public constant bundler = address(5);
+    address public constant SEPOLIA_HATS = 0x3bc1A0Ad72417f2d411118085256fC53CBdDd137;
+    
+    // Test IDs
+    bytes32 public constant ORG_ID = keccak256("INTEGRATION-TEST-ORG");
+    
+    // DAO contracts
+    address paymaster;
+    address executor;
+    address hybrid;
+    uint256 memberHatId;
+    uint256 executiveHatId;
+    
+    function setUp() public {
+        // Deploy mock EntryPoint
+        mockEntryPoint = new MockEntryPoint();
+        
+        // Deploy core infrastructure
+        implRegistry = new ImplementationRegistry();
+        poaManager = new PoaManager();
+        orgRegistry = new OrgRegistry();
+        
+        // Deploy and initialize Hats
+        deployCodeTo("Hats.sol", SEPOLIA_HATS);
+        hats = IHats(SEPOLIA_HATS);
+        
+        // Deploy HatsTreeSetup
+        hatsTreeSetup = address(new HatsTreeSetup());
+        
+        // Initialize PoaManager
+        vm.prank(poaAdmin);
+        poaManager.initialize(address(implRegistry), poaAdmin);
+        
+        // Deploy implementations
+        paymasterImpl = new PaymasterHub();
+        hybridImpl = new HybridVoting();
+        execImpl = new Executor();
+        pTokenImpl = new ParticipationToken();
+        quickJoinImpl = new QuickJoin();
+        taskMgrImpl = new TaskManager();
+        eduHubImpl = new EducationHub();
+        eligModuleImpl = new EligibilityModule();
+        toggleModuleImpl = new ToggleModule();
+        accountRegImpl = new UniversalAccountRegistry();
+        
+        // Register implementations
+        vm.startPrank(poaAdmin);
+        implRegistry.registerImplementation("PaymasterHub", address(paymasterImpl));
+        implRegistry.registerImplementation("HybridVoting", address(hybridImpl));
+        implRegistry.registerImplementation("Executor", address(execImpl));
+        implRegistry.registerImplementation("ParticipationToken", address(pTokenImpl));
+        implRegistry.registerImplementation("QuickJoin", address(quickJoinImpl));
+        implRegistry.registerImplementation("TaskManager", address(taskMgrImpl));
+        implRegistry.registerImplementation("EducationHub", address(eduHubImpl));
+        implRegistry.registerImplementation("EligibilityModule", address(eligModuleImpl));
+        implRegistry.registerImplementation("ToggleModule", address(toggleModuleImpl));
+        
+        // Create beacons
+        poaManager.createBeacon("PaymasterHub");
+        poaManager.createBeacon("HybridVoting");
+        poaManager.createBeacon("Executor");
+        poaManager.createBeacon("ParticipationToken");
+        poaManager.createBeacon("QuickJoin");
+        poaManager.createBeacon("TaskManager");
+        poaManager.createBeacon("EducationHub");
+        poaManager.createBeacon("EligibilityModule");
+        poaManager.createBeacon("ToggleModule");
+        vm.stopPrank();
+        
+        // Initialize OrgRegistry
+        vm.prank(poaAdmin);
+        orgRegistry.initialize(poaAdmin, address(poaManager));
+        
+        // Deploy and initialize Deployer
+        deployer = new Deployer();
+        deployer.initialize(address(poaManager), address(orgRegistry), SEPOLIA_HATS, hatsTreeSetup);
+        
+        // Deploy a full DAO with PaymasterHub
+        _deployDAOWithPaymaster();
+    }
+    
+    function _deployDAOWithPaymaster() internal {
+        vm.deal(orgOwner, 10 ether);
+        vm.startPrank(orgOwner);
+        
+        // Prepare deployment parameters
+        string[] memory roleNames = new string[](2);
+        roleNames[0] = "MEMBER";
+        roleNames[1] = "EXECUTIVE";
+        
+        string[] memory roleImages = new string[](2);
+        roleImages[0] = "ipfs://member";
+        roleImages[1] = "ipfs://executive";
+        
+        bool[] memory roleCanVote = new bool[](2);
+        roleCanVote[0] = true;
+        roleCanVote[1] = true;
+        
+        IHybridVotingInit.ClassConfig[] memory votingClasses = new IHybridVotingInit.ClassConfig[](1);
+        uint256[] memory hatIds = new uint256[](0);
+        votingClasses[0] = IHybridVotingInit.ClassConfig({
+            strategy: IHybridVotingInit.ClassStrategy.DIRECT,
+            slicePct: 100,
+            quadratic: false,
+            minBalance: 0,
+            asset: address(0),
+            hatIds: hatIds
+        });
+        
+        // Role assignments
+        uint256[] memory memberRole = new uint256[](1);
+        memberRole[0] = 0;
+        
+        uint256[] memory executiveRole = new uint256[](1);
+        executiveRole[0] = 1;
+        
+        Deployer.RoleAssignments memory roleAssignments = Deployer.RoleAssignments({
+            quickJoinRoles: memberRole,
+            tokenMemberRoles: memberRole,
+            tokenApproverRoles: executiveRole,
+            taskCreatorRoles: executiveRole,
+            educationCreatorRoles: executiveRole,
+            educationMemberRoles: memberRole,
+            proposalCreatorRoles: executiveRole
+        });
+        
+        // PaymasterConfig with funding
+        Deployer.PaymasterConfig memory pmConfig = Deployer.PaymasterConfig({
+            enabled: true,
+            entryPoint: address(mockEntryPoint),
+            initialDeposit: 2 ether,
+            initialBounty: 1 ether,
+            enableBounty: true,
+            maxBountyPerOp: 0.01 ether,
+            bountyPctCap: 1000 // 10%
+        });
+        
+        // Deploy DAO
+        address quickJoin;
+        address token;
+        address taskManager;
+        address educationHub;
+        (hybrid, executor, quickJoin, token, taskManager, educationHub, paymaster) = 
+            deployer.deployFullOrg{value: 3 ether}(
+                ORG_ID,
+                "Integration Test DAO",
+                address(accountRegImpl),
+                true,
+                50,
+                votingClasses,
+                roleNames,
+                roleImages,
+                roleCanVote,
+                roleAssignments,
+                pmConfig
+            );
+        
+        vm.stopPrank();
+        
+        // Get hat IDs
+        memberHatId = orgRegistry.getRoleHat(ORG_ID, 0);
+        executiveHatId = orgRegistry.getRoleHat(ORG_ID, 1);
+        
+        // Mint hats to test users
+        vm.startPrank(executor);
+        hats.mintHat(memberHatId, memberUser);
+        hats.mintHat(executiveHatId, executiveUser);
+        vm.stopPrank();
+    }
+    
+    function testPaymasterValidatesUserOpForMember() public {
+        // Setup: Create a mock account for the member
+        MockAccount account = new MockAccount(memberUser);
+        
+        // Configure PaymasterHub rules
+        vm.prank(executor);
+        PaymasterHub(payable(paymaster)).setRule(
+            address(account),
+            bytes4(keccak256("execute(address,uint256,bytes)")),
+            true,
+            100000
+        );
+        
+        // Configure budget for member hat
+        bytes32 subjectKey = keccak256(abi.encodePacked(uint8(1), bytes20(uint160(memberHatId))));
+        vm.prank(executor);
+        PaymasterHub(payable(paymaster)).setBudget(subjectKey, 1 ether, 1 days);
+        
+        // Create UserOperation
+        PackedUserOperation memory userOp = _createUserOp(
+            address(account),
+            address(account),
+            abi.encodeWithSignature("execute(address,uint256,bytes)", address(0), 0, ""),
+            memberHatId
+        );
+        
+        // Validate UserOperation as EntryPoint
+        vm.prank(address(mockEntryPoint));
+        (bytes memory context, uint256 validationData) = PaymasterHub(payable(paymaster))
+            .validatePaymasterUserOp(userOp, keccak256("test"), 0.1 ether);
+        
+        // Verify validation passed
+        assertEq(validationData, 0, "Validation should pass");
+        assertTrue(context.length > 0, "Context should be returned");
+    }
+    
+    function testPaymasterRejectsUserOpForNonMember() public {
+        // Setup: Create a mock account for a non-member
+        address nonMember = address(999);
+        MockAccount account = new MockAccount(nonMember);
+        
+        // Configure PaymasterHub rules
+        vm.prank(executor);
+        PaymasterHub(payable(paymaster)).setRule(
+            address(account),
+            bytes4(keccak256("execute(address,uint256,bytes)")),
+            true,
+            100000
+        );
+        
+        // Configure budget for member hat
+        bytes32 subjectKey = keccak256(abi.encodePacked(uint8(1), bytes20(uint160(memberHatId))));
+        vm.prank(executor);
+        PaymasterHub(payable(paymaster)).setBudget(subjectKey, 1 ether, 1 days);
+        
+        // Create UserOperation with member hat but non-member sender
+        PackedUserOperation memory userOp = _createUserOp(
+            address(account),
+            address(account),
+            abi.encodeWithSignature("execute(address,uint256,bytes)", address(0), 0, ""),
+            memberHatId
+        );
+        
+        // Should revert for ineligible user
+        vm.prank(address(mockEntryPoint));
+        vm.expectRevert(abi.encodeWithSelector(PaymasterHub.Ineligible.selector));
+        PaymasterHub(payable(paymaster)).validatePaymasterUserOp(userOp, keccak256("test"), 0.1 ether);
+    }
+    
+    function testPaymasterBountyPayment() public {
+        // Setup account and rules
+        MockAccount account = new MockAccount(executiveUser);
+        
+        vm.prank(executor);
+        PaymasterHub(payable(paymaster)).setRule(
+            address(account),
+            bytes4(keccak256("execute(address,uint256,bytes)")),
+            true,
+            100000
+        );
+        
+        // Configure budget for executive hat
+        bytes32 subjectKey = keccak256(abi.encodePacked(uint8(1), bytes20(uint160(executiveHatId))));
+        vm.prank(executor);
+        PaymasterHub(payable(paymaster)).setBudget(subjectKey, 1 ether, 1 days);
+        
+        // Create UserOperation with mailbox commit (indicating bounty)
+        PackedUserOperation memory userOp = _createUserOpWithBounty(
+            address(account),
+            address(account),
+            abi.encodeWithSignature("execute(address,uint256,bytes)", address(0), 0, ""),
+            executiveHatId,
+            uint64(block.timestamp)
+        );
+        
+        // Validate as EntryPoint
+        vm.prank(address(mockEntryPoint));
+        (bytes memory context,) = PaymasterHub(payable(paymaster))
+            .validatePaymasterUserOp(userOp, keccak256("test"), 0.1 ether);
+        
+        // Record bundler balance before
+        uint256 bundlerBalanceBefore = bundler.balance;
+        
+        // Simulate postOp with bundler as tx.origin
+        vm.prank(address(mockEntryPoint), bundler);
+        PaymasterHub(payable(paymaster)).postOp(
+            IPaymaster.PostOpMode.opSucceeded,
+            context,
+            0.05 ether // actual gas cost
+        );
+        
+        // Verify bounty was paid
+        uint256 expectedBounty = (0.05 ether * 1000) / 10000; // 10% of gas cost
+        assertEq(bundler.balance - bundlerBalanceBefore, expectedBounty, "Bounty should be paid to bundler");
+    }
+    
+    function testPaymasterBudgetEnforcement() public {
+        // Setup account
+        MockAccount account = new MockAccount(memberUser);
+        
+        vm.prank(executor);
+        PaymasterHub(payable(paymaster)).setRule(
+            address(account),
+            bytes4(keccak256("execute(address,uint256,bytes)")),
+            true,
+            100000
+        );
+        
+        // Set a small budget
+        bytes32 subjectKey = keccak256(abi.encodePacked(uint8(1), bytes20(uint160(memberHatId))));
+        vm.prank(executor);
+        PaymasterHub(payable(paymaster)).setBudget(subjectKey, 0.01 ether, 1 days);
+        
+        // Create UserOperation
+        PackedUserOperation memory userOp = _createUserOp(
+            address(account),
+            address(account),
+            abi.encodeWithSignature("execute(address,uint256,bytes)", address(0), 0, ""),
+            memberHatId
+        );
+        
+        // First operation should succeed
+        vm.prank(address(mockEntryPoint));
+        (bytes memory context1,) = PaymasterHub(payable(paymaster))
+            .validatePaymasterUserOp(userOp, keccak256("test1"), 0.005 ether);
+        
+        // Update usage via postOp
+        vm.prank(address(mockEntryPoint));
+        PaymasterHub(payable(paymaster)).postOp(
+            IPaymaster.PostOpMode.opSucceeded,
+            context1,
+            0.005 ether
+        );
+        
+        // Second operation should fail due to budget exceeded
+        vm.prank(address(mockEntryPoint));
+        vm.expectRevert(abi.encodeWithSelector(PaymasterHub.BudgetExceeded.selector));
+        PaymasterHub(payable(paymaster)).validatePaymasterUserOp(
+            userOp,
+            keccak256("test2"),
+            0.01 ether // This would exceed the budget
+        );
+    }
+    
+    // Helper functions
+    function _createUserOp(
+        address sender,
+        address target,
+        bytes memory callData,
+        uint256 hatId
+    ) internal pure returns (PackedUserOperation memory) {
+        // Encode paymaster data
+        bytes memory paymasterAndData = abi.encodePacked(
+            address(0), // paymaster address placeholder (20 bytes)
+            uint8(1), // version
+            uint8(1), // subject type (hat)
+            bytes20(uint160(hatId)), // subject ID
+            uint32(0), // rule ID (generic)
+            uint64(0) // no mailbox commit
+        );
+        
+        return PackedUserOperation({
+            sender: sender,
+            nonce: 0,
+            initCode: "",
+            callData: callData,
+            accountGasLimits: bytes32(uint256(100000) << 128 | 50000),
+            preVerificationGas: 21000,
+            gasFees: bytes32(uint256(10 gwei) << 128 | 1 gwei),
+            paymasterAndData: paymasterAndData,
+            signature: ""
+        });
+    }
+    
+    function _createUserOpWithBounty(
+        address sender,
+        address target,
+        bytes memory callData,
+        uint256 hatId,
+        uint64 mailboxCommit
+    ) internal pure returns (PackedUserOperation memory) {
+        // Encode paymaster data with mailbox commit
+        bytes memory paymasterAndData = abi.encodePacked(
+            address(0), // paymaster address placeholder (20 bytes)
+            uint8(1), // version
+            uint8(1), // subject type (hat)
+            bytes20(uint160(hatId)), // subject ID
+            uint32(0), // rule ID (generic)
+            mailboxCommit // mailbox commit for bounty
+        );
+        
+        return PackedUserOperation({
+            sender: sender,
+            nonce: 0,
+            initCode: "",
+            callData: callData,
+            accountGasLimits: bytes32(uint256(100000) << 128 | 50000),
+            preVerificationGas: 21000,
+            gasFees: bytes32(uint256(10 gwei) << 128 | 1 gwei),
+            paymasterAndData: paymasterAndData,
+            signature: ""
+        });
+    }
+}


### PR DESCRIPTION
## Summary

This PR integrates the PaymasterHub (ERC-4337 paymaster) into the DAO deployment system, enabling each organization to have its own upgradeable paymaster for gas sponsorship.

### Key Features
- **Per-org deployment**: Each DAO gets its own PaymasterHub instance
- **Upgradeability**: Uses SwitchableBeacon pattern for controlled upgrades  
- **Initial funding**: Support for funding during deployment (EntryPoint deposits + bounty pool)
- **Role-based access**: Admin control via Hats roles (executives manage the paymaster)
- **Bounty system**: Optional bundler incentives with configurable parameters

### Implementation Details

#### 1. PaymasterHub Refactoring
- Made compatible with proxy pattern by replacing immutable storage
- Added Initializable inheritance and initializer pattern
- Maintains all existing ERC-4337 functionality

#### 2. Deployment Integration  
- Added `PaymasterConfig` struct for configuration
- PaymasterHub deployed after Hats tree setup to get proper admin roles
- Beacon ownership transferred to executor for DAO governance
- Made `deployFullOrg()` payable to accept initial funding

#### 3. Module Registration
- Added `PAYMASTER_HUB_ID` to ModuleTypes library
- Extended ModuleDeploymentLib with `deployPaymasterHub()` function
- Follows existing module deployment patterns

### Testing
- `PaymasterHubDeployment.t.sol`: Tests deployment scenarios
- `PaymasterHubIntegrationDeployment.t.sol`: Full integration tests with UserOperations
- Tests cover funding, budget enforcement, bounty payments, and role-based access

## Test Plan

- [x] Verify PaymasterHub deploys correctly with DAO
- [x] Test initial funding flows (EntryPoint + bounty)
- [x] Verify role-based access control via Hats
- [x] Test UserOp validation and budget enforcement
- [x] Verify bounty payment mechanism
- [x] Test upgrade control via SwitchableBeacon
- [ ] Run full test suite: `forge test`
- [ ] Deploy to testnet and verify functionality

🤖 Generated with [Claude Code](https://claude.ai/code)