### PR TITLE
Disable testnet deployment on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       validation-script: 'script/upgrades/ValidateUpgrade.s.sol'
 
       # Automatic Deployments
-      deploy-on-pr: true
+      deploy-on-pr: false
       deploy-on-main: true
       deploy-script: 'script/DeployInfrastructure.s.sol:DeployInfrastructure'
       network-config-path: '.github/deploy-networks.json'

--- a/src/ImplementationRegistry.sol
+++ b/src/ImplementationRegistry.sol
@@ -130,7 +130,7 @@ contract ImplementationRegistry is Initializable, OwnableUpgradeable {
         return _layout().typeIds.length;
     }
 
-    // Public getter for typeIds
+    /// @notice Public getter for typeIds
     function typeIds(uint256 index) external view returns (bytes32) {
         return _layout().typeIds[index];
     }


### PR DESCRIPTION
## Summary
- Disable testnet deployment on pull requests to main (deploy-on-pr: false)
- Update NatSpec documentation in ImplementationRegistry

This prevents automatic testnet deployments when PRs are opened against main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)