### PR TITLE
fix: remove broken artifact download and add subgraph indexing logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,31 +32,3 @@ jobs:
       PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
       RPC_URL: ${{ secrets.HOODI_RPC_URL }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # Auto-commit infrastructure.json after mainnet deployment
-  commit-infrastructure:
-    needs: foundry-cicd
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download deployment artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: deployment-artifacts
-          path: script/
-        continue-on-error: true
-
-      - name: Commit infrastructure.json if changed
-        run: |
-          if [ -f script/infrastructure.json ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add script/infrastructure.json
-            if ! git diff --staged --quiet; then
-              git commit -m "chore: update infrastructure.json [skip ci]"
-              git pull --rebase origin main
-              git push
-            fi
-          fi

--- a/script/DeployInfrastructure.s.sol
+++ b/script/DeployInfrastructure.s.sol
@@ -200,6 +200,9 @@ contract DeployInfrastructure is Script {
 
     function _outputAddresses() internal {
         console.log("\n=== DEPLOYMENT COMPLETE ===");
+        console.log("\n--- Start Block (for subgraph indexing) ---");
+        console.log("START_BLOCK:", block.number);
+
         console.log("\n--- Key Addresses for Org Deployment ---");
         console.log("OrgDeployer:", orgDeployer);
         console.log("GlobalAccountRegistry:", globalAccountRegistry);
@@ -209,6 +212,25 @@ contract DeployInfrastructure is Script {
         console.log("OrgRegistry:", orgRegistry);
         console.log("ImplementationRegistry:", implRegistry);
         console.log("HatsProtocol:", HATS_PROTOCOL);
+
+        // Log all beacon addresses for subgraph indexing
+        console.log("\n--- Beacon Addresses (for subgraph indexing) ---");
+        PoaManager pm = PoaManager(poaManager);
+        console.log("BEACON_ImplementationRegistry:", pm.getBeaconById(keccak256("ImplementationRegistry")));
+        console.log("BEACON_OrgRegistry:", pm.getBeaconById(keccak256("OrgRegistry")));
+        console.log("BEACON_OrgDeployer:", pm.getBeaconById(keccak256("OrgDeployer")));
+        console.log("BEACON_PaymasterHub:", pm.getBeaconById(keccak256("PaymasterHub")));
+        console.log("BEACON_HybridVoting:", pm.getBeaconById(keccak256("HybridVoting")));
+        console.log("BEACON_DirectDemocracyVoting:", pm.getBeaconById(keccak256("DirectDemocracyVoting")));
+        console.log("BEACON_Executor:", pm.getBeaconById(keccak256("Executor")));
+        console.log("BEACON_QuickJoin:", pm.getBeaconById(keccak256("QuickJoin")));
+        console.log("BEACON_ParticipationToken:", pm.getBeaconById(keccak256("ParticipationToken")));
+        console.log("BEACON_TaskManager:", pm.getBeaconById(keccak256("TaskManager")));
+        console.log("BEACON_EducationHub:", pm.getBeaconById(keccak256("EducationHub")));
+        console.log("BEACON_PaymentManager:", pm.getBeaconById(keccak256("PaymentManager")));
+        console.log("BEACON_UniversalAccountRegistry:", pm.getBeaconById(keccak256("UniversalAccountRegistry")));
+        console.log("BEACON_EligibilityModule:", pm.getBeaconById(keccak256("EligibilityModule")));
+        console.log("BEACON_ToggleModule:", pm.getBeaconById(keccak256("ToggleModule")));
 
         // Write addresses to JSON file for easy org deployment
         string memory addressesJson = string.concat(

--- a/src/PoaManager.sol
+++ b/src/PoaManager.sol
@@ -1,7 +1,7 @@
 // SPDX‑License‑Identifier: MIT
 pragma solidity ^0.8.17;
 
-/*───────────────────────  PoaManager  ─────────────────────────*/
+/*───────────────────────  PoaManager v1.0.1  ─────────────────────────*/
 import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./ImplementationRegistry.sol";


### PR DESCRIPTION
## Summary

Removed non-functional `commit-infrastructure` CI job that attempted to download artifacts that don't exist. Added comprehensive logging of beacon addresses and start block to the deployment script for subgraph indexing.

## Changes

- Removed broken artifact download job from CI workflow
- Added start block logging to deployment output
- Added beacon address logging for all infrastructure contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)