### PR TITLE
feat: Add InfrastructureDeployed event for subgraph dynamic discovery

### DIFF
--- a/script/DeployInfrastructure.s.sol
+++ b/script/DeployInfrastructure.s.sol
@@ -198,13 +198,7 @@ contract DeployInfrastructure is Script {
         console.log("GlobalAccountRegistry:", globalAccountRegistry);
 
         // Emit InfrastructureDeployed event for subgraph dynamic discovery
-        pm.registerInfrastructure(
-            orgDeployer,
-            orgRegistry,
-            implRegistry,
-            paymasterHub,
-            globalAccountRegistry
-        );
+        pm.registerInfrastructure(orgDeployer, orgRegistry, implRegistry, paymasterHub, globalAccountRegistry);
         console.log("\n--- Infrastructure Registered (for subgraph indexing) ---");
     }
 

--- a/src/PoaManager.sol
+++ b/src/PoaManager.sol
@@ -52,13 +52,7 @@ contract PoaManager is Ownable(msg.sender) {
         address _paymasterHub,
         address _globalAccountRegistry
     ) external onlyOwner {
-        emit InfrastructureDeployed(
-            _orgDeployer,
-            _orgRegistry,
-            _implRegistry,
-            _paymasterHub,
-            _globalAccountRegistry
-        );
+        emit InfrastructureDeployed(_orgDeployer, _orgRegistry, _implRegistry, _paymasterHub, _globalAccountRegistry);
     }
 
     /*──────────── Internal utils ───────────*/


### PR DESCRIPTION
## Summary
- Add `InfrastructureDeployed` event to PoaManager with 5 address parameters
- Add `registerInfrastructure()` function that emits the event (owner-only)
- Call `registerInfrastructure()` at end of `DeployInfrastructure.s.sol`

## Changes

### PoaManager.sol
```solidity
event InfrastructureDeployed(
    address orgDeployer,
    address orgRegistry,
    address implRegistry,
    address paymasterHub,
    address globalAccountRegistry
);

function registerInfrastructure(...) external onlyOwner {
    emit InfrastructureDeployed(...);
}
```

### DeployInfrastructure.s.sol
After all infrastructure is deployed, calls `registerInfrastructure()` to announce proxy addresses.

## Why
This enables the subgraph to dynamically discover infrastructure proxy addresses without hardcoding them. The subgraph only needs the PoaManager address as input.

## Related
- Subgraph PR: https://github.com/PerpetualOrganizationArchitect/subgraph-pop/pull/27

## Test plan
- [ ] Run forge tests
- [ ] Deploy to testnet
- [ ] Verify InfrastructureDeployed event is emitted with correct addresses
- [ ] Verify subgraph picks up the event and creates data sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)