### PR TITLE
Add passkey account factory beacon to infrastructure deploy event

### DIFF
--- a/script/DeployInfrastructure.s.sol
+++ b/script/DeployInfrastructure.s.sol
@@ -204,7 +204,10 @@ contract DeployInfrastructure is Script {
         console.log("GlobalAccountRegistry:", globalAccountRegistry);
 
         // Emit InfrastructureDeployed event for subgraph dynamic discovery
-        pm.registerInfrastructure(orgDeployer, orgRegistry, implRegistry, paymasterHub, globalAccountRegistry);
+        address passkeyFactoryBeacon = pm.getBeaconById(keccak256("PasskeyAccountFactory"));
+        pm.registerInfrastructure(
+            orgDeployer, orgRegistry, implRegistry, paymasterHub, globalAccountRegistry, passkeyFactoryBeacon
+        );
         console.log("\n--- Infrastructure Registered (for subgraph indexing) ---");
     }
 

--- a/src/PoaManager.sol
+++ b/src/PoaManager.sol
@@ -27,7 +27,8 @@ contract PoaManager is Ownable(msg.sender) {
         address orgRegistry,
         address implRegistry,
         address paymasterHub,
-        address globalAccountRegistry
+        address globalAccountRegistry,
+        address passkeyAccountFactoryBeacon
     );
 
     constructor(address registryAddr) {
@@ -50,9 +51,17 @@ contract PoaManager is Ownable(msg.sender) {
         address _orgRegistry,
         address _implRegistry,
         address _paymasterHub,
-        address _globalAccountRegistry
+        address _globalAccountRegistry,
+        address _passkeyAccountFactoryBeacon
     ) external onlyOwner {
-        emit InfrastructureDeployed(_orgDeployer, _orgRegistry, _implRegistry, _paymasterHub, _globalAccountRegistry);
+        emit InfrastructureDeployed(
+            _orgDeployer,
+            _orgRegistry,
+            _implRegistry,
+            _paymasterHub,
+            _globalAccountRegistry,
+            _passkeyAccountFactoryBeacon
+        );
     }
 
     /*──────────── Internal utils ───────────*/

--- a/test/PoaManager.t.sol
+++ b/test/PoaManager.t.sol
@@ -32,4 +32,38 @@ contract PoaManagerTest is Test {
         pm.upgradeBeacon("TypeA", address(impl2), "v2");
         assertEq(pm.getCurrentImplementationById(keccak256("TypeA")), address(impl2));
     }
+
+    function testRegisterInfrastructure() public {
+        address orgDeployer = makeAddr("orgDeployer");
+        address orgRegistry = makeAddr("orgRegistry");
+        address implRegistry = makeAddr("implRegistry");
+        address paymasterHub = makeAddr("paymasterHub");
+        address globalAccountRegistry = makeAddr("globalAccountRegistry");
+        address passkeyAccountFactoryBeacon = makeAddr("passkeyAccountFactoryBeacon");
+
+        vm.expectEmit(true, true, true, true);
+        emit PoaManager.InfrastructureDeployed(
+            orgDeployer, orgRegistry, implRegistry, paymasterHub, globalAccountRegistry, passkeyAccountFactoryBeacon
+        );
+
+        pm.registerInfrastructure(
+            orgDeployer, orgRegistry, implRegistry, paymasterHub, globalAccountRegistry, passkeyAccountFactoryBeacon
+        );
+    }
+
+    function testRegisterInfrastructureOnlyOwner() public {
+        address nonOwner = makeAddr("nonOwner");
+        address orgDeployer = makeAddr("orgDeployer");
+        address orgRegistry = makeAddr("orgRegistry");
+        address implRegistry = makeAddr("implRegistry");
+        address paymasterHub = makeAddr("paymasterHub");
+        address globalAccountRegistry = makeAddr("globalAccountRegistry");
+        address passkeyAccountFactoryBeacon = makeAddr("passkeyAccountFactoryBeacon");
+
+        vm.prank(nonOwner);
+        vm.expectRevert();
+        pm.registerInfrastructure(
+            orgDeployer, orgRegistry, implRegistry, paymasterHub, globalAccountRegistry, passkeyAccountFactoryBeacon
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Emit the PasskeyAccountFactory beacon address in the InfrastructureDeployed event for subgraph indexing. The factory is global infrastructure deployed once per chain and used by all orgs to create passkey accounts.

## Changes
- Updated `InfrastructureDeployed` event to include `passkeyAccountFactoryBeacon` parameter
- Updated `registerInfrastructure` function signature to accept and emit the beacon address
- Updated deployment script to fetch and pass the passkey factory beacon
- Added comprehensive tests for the updated functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)