### PR TITLE
Emit HatMetadataUpdated events during org deployment

### DIFF
--- a/src/HatsTreeSetup.sol
+++ b/src/HatsTreeSetup.sol
@@ -91,6 +91,8 @@ contract HatsTreeSetup {
         uint256[] memory regParentHatIds = new uint256[](len);
         bool[] memory regDefaultEligibles = new bool[](len);
         bool[] memory regDefaultStandings = new bool[](len);
+        string[] memory regNames = new string[](len);
+        bytes32[] memory regMetadataCIDs = new bytes32[](len);
 
         // Multi-pass: resolve dependencies and create hats in correct order
         bool[] memory created = new bool[](len);
@@ -137,6 +139,8 @@ contract HatsTreeSetup {
                     regParentHatIds[i] = adminHatId;
                     regDefaultEligibles[i] = role.defaults.eligible;
                     regDefaultStandings[i] = role.defaults.standing;
+                    regNames[i] = role.name;
+                    regMetadataCIDs[i] = role.metadataCID;
 
                     created[i] = true;
                     createdCount++;
@@ -150,9 +154,11 @@ contract HatsTreeSetup {
             }
         }
 
-        // Batch register all hat creations for subgraph indexing (replaces N individual calls)
+        // Batch register all hat creations with metadata for subgraph indexing (replaces N individual calls)
         IEligibilityModule(params.eligibilityModule)
-            .batchRegisterHatCreation(regHatIds, regParentHatIds, regDefaultEligibles, regDefaultStandings);
+            .batchRegisterHatCreationWithMetadata(
+                regHatIds, regParentHatIds, regDefaultEligibles, regDefaultStandings, regNames, regMetadataCIDs
+            );
 
         // Step 5: Collect all eligibility and toggle operations for batch execution
         // Count total eligibility entries needed: 2 per role (executor + deployer) + additional wearers

--- a/src/interfaces/IHatsModules.sol
+++ b/src/interfaces/IHatsModules.sol
@@ -31,6 +31,14 @@ interface IEligibilityModule {
         bool[] calldata defaultEligibles,
         bool[] calldata defaultStandings
     ) external;
+    function batchRegisterHatCreationWithMetadata(
+        uint256[] calldata hatIds,
+        uint256[] calldata parentHatIds,
+        bool[] calldata defaultEligibles,
+        bool[] calldata defaultStandings,
+        string[] calldata names,
+        bytes32[] calldata metadataCIDs
+    ) external;
     function batchConfigureVouching(
         uint256[] calldata hatIds,
         uint32[] calldata quorums,


### PR DESCRIPTION
## Summary
- Add `batchRegisterHatCreationWithMetadata` function to EligibilityModule that emits `HatMetadataUpdated` events with role names and metadataCIDs
- Update HatsTreeSetup to use the new function, passing metadata during hat registration

## Problem
When organizations are deployed, role names and metadata CIDs are passed to the contracts but the subgraph couldn't index them because the `HatMetadataUpdated` event was never emitted during deployment. This caused `role.hat.name` to always be `null` in GraphQL queries.

## Solution
The new `batchRegisterHatCreationWithMetadata` function extends `batchRegisterHatCreation` by also accepting `names` and `metadataCIDs` arrays and emitting `HatMetadataUpdated` events for each hat. This allows the subgraph to index role names at deployment time.

## Changes
- **EligibilityModule.sol**: Added `batchRegisterHatCreationWithMetadata` function
- **HatsTreeSetup.sol**: Updated to collect and pass `names` and `metadataCIDs` arrays to the new function
- **IHatsModules.sol**: Added interface declaration for the new function

## Test plan
- [x] `forge build` succeeds
- [ ] Deploy new org and verify role names appear in subgraph queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)