### PR TITLE
chore: update SPDX license identifiers to AGPL-3.0-only

### DIFF
--- a/script/DeployInfrastructure.s.sol
+++ b/script/DeployInfrastructure.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Script.sol";

--- a/script/DeployOrg.s.sol
+++ b/script/DeployOrg.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Script.sol";

--- a/script/RunOrgActions.s.sol
+++ b/script/RunOrgActions.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Script.sol";

--- a/script/RunOrgActionsAdvanced.s.sol
+++ b/script/RunOrgActionsAdvanced.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Script.sol";

--- a/script/upgrades/ValidateUpgrade.s.sol
+++ b/script/upgrades/ValidateUpgrade.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Script.sol";

--- a/scripts/ComputeStorageLocations.sol
+++ b/scripts/ComputeStorageLocations.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.24;
 
 import "forge-std/Script.sol";

--- a/scripts/GenerateDistributionMerkle.s.sol
+++ b/scripts/GenerateDistributionMerkle.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Script.sol";

--- a/src/DirectDemocracyVoting.sol
+++ b/src/DirectDemocracyVoting.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 /* ──────────────────  OpenZeppelin v5.3 Upgradeables  ────────────────── */

--- a/src/EducationHub.sol
+++ b/src/EducationHub.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 /*──────── OpenZeppelin v5.3 Upgradeables ────────*/

--- a/src/EligibilityModule.sol
+++ b/src/EligibilityModule.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.19;
 
 import "../lib/hats-protocol/src/Interfaces/IHats.sol";

--- a/src/HatsTreeSetup.sol
+++ b/src/HatsTreeSetup.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import {IHats} from "@hats-protocol/src/Interfaces/IHats.sol";

--- a/src/HybridVoting.sol
+++ b/src/HybridVoting.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.30;
 
 /*  OpenZeppelin v5.3 Upgradeables  */

--- a/src/OrgDeployer.sol
+++ b/src/OrgDeployer.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "@openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";

--- a/src/PasskeyAccount.sol
+++ b/src/PasskeyAccount.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.24;
 
 /*──────────────────── OpenZeppelin Upgradeables ────────────────────*/

--- a/src/PasskeyAccountFactory.sol
+++ b/src/PasskeyAccountFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.24;
 
 /*──────────────────── OpenZeppelin ────────────────────────────────────*/

--- a/src/PaymasterHub.sol
+++ b/src/PaymasterHub.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.24;
 
 import {IPaymaster} from "./interfaces/IPaymaster.sol";

--- a/src/PaymasterHubLens.sol
+++ b/src/PaymasterHubLens.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.24;
 
 import {IPaymaster} from "./interfaces/IPaymaster.sol";

--- a/src/PaymentManager.sol
+++ b/src/PaymentManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import {IPaymentManager} from "./interfaces/IPaymentManager.sol";

--- a/src/QuickJoin.sol
+++ b/src/QuickJoin.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.21;
 
 /*────────────────────────── OpenZeppelin v5.3 Upgradeables ────────────────────*/

--- a/src/SwitchableBeacon.sol
+++ b/src/SwitchableBeacon.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 interface IBeacon {

--- a/src/TaskManager.sol
+++ b/src/TaskManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 /*──────── OpenZeppelin v5.3 Upgradeables ────────*/

--- a/src/ToggleModule.sol
+++ b/src/ToggleModule.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.19;
 
 import "@openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";

--- a/src/factories/AccessFactory.sol
+++ b/src/factories/AccessFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import {SwitchableBeacon} from "../SwitchableBeacon.sol";

--- a/src/factories/GovernanceFactory.sol
+++ b/src/factories/GovernanceFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import {IHats} from "@hats-protocol/src/Interfaces/IHats.sol";

--- a/src/factories/ModulesFactory.sol
+++ b/src/factories/ModulesFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import {SwitchableBeacon} from "../SwitchableBeacon.sol";

--- a/src/interfaces/IAccount.sol
+++ b/src/interfaces/IAccount.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.24;
 
 import {PackedUserOperation} from "./PackedUserOperation.sol";

--- a/src/interfaces/IEntryPoint.sol
+++ b/src/interfaces/IEntryPoint.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.24;
 
 interface IEntryPoint {

--- a/src/interfaces/IHatsModules.sol
+++ b/src/interfaces/IHatsModules.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 interface IEligibilityModule {

--- a/src/interfaces/IPasskeyAccount.sol
+++ b/src/interfaces/IPasskeyAccount.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.24;
 
 /**

--- a/src/interfaces/IPaymaster.sol
+++ b/src/interfaces/IPaymaster.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.24;
 
 import {PackedUserOperation} from "./PackedUserOperation.sol";

--- a/src/interfaces/IPaymentManager.sol
+++ b/src/interfaces/IPaymentManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 /**

--- a/src/interfaces/PackedUserOperation.sol
+++ b/src/interfaces/PackedUserOperation.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.24;
 
 struct PackedUserOperation {

--- a/src/lens/DirectDemocracyVotingLens.sol
+++ b/src/lens/DirectDemocracyVotingLens.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.30;
 
 import {DirectDemocracyVoting} from "../DirectDemocracyVoting.sol";

--- a/src/lens/HybridVotingLens.sol
+++ b/src/lens/HybridVotingLens.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.30;
 
 import {HybridVoting} from "../HybridVoting.sol";

--- a/src/lens/TaskManagerLens.sol
+++ b/src/lens/TaskManagerLens.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import {ValidationLib} from "../libs/ValidationLib.sol";

--- a/src/libs/BeaconDeploymentLib.sol
+++ b/src/libs/BeaconDeploymentLib.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import {SwitchableBeacon} from "../SwitchableBeacon.sol";

--- a/src/libs/BudgetLib.sol
+++ b/src/libs/BudgetLib.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 /**

--- a/src/libs/HatManager.sol
+++ b/src/libs/HatManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import {IHats} from "lib/hats-protocol/src/Interfaces/IHats.sol";

--- a/src/libs/HybridVotingConfig.sol
+++ b/src/libs/HybridVotingConfig.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.30;
 
 import "../HybridVoting.sol";

--- a/src/libs/HybridVotingCore.sol
+++ b/src/libs/HybridVotingCore.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.30;
 
 import "../HybridVoting.sol";

--- a/src/libs/HybridVotingProposals.sol
+++ b/src/libs/HybridVotingProposals.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.30;
 
 import "../HybridVoting.sol";

--- a/src/libs/ModuleDeploymentLib.sol
+++ b/src/libs/ModuleDeploymentLib.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";

--- a/src/libs/ModuleTypes.sol
+++ b/src/libs/ModuleTypes.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 /**

--- a/src/libs/P256Verifier.sol
+++ b/src/libs/P256Verifier.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 /**

--- a/src/libs/RoleConfigStructs.sol
+++ b/src/libs/RoleConfigStructs.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 /**

--- a/src/libs/RoleResolver.sol
+++ b/src/libs/RoleResolver.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "../OrgRegistry.sol";

--- a/src/libs/TaskPerm.sol
+++ b/src/libs/TaskPerm.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 /**

--- a/src/libs/ValidationLib.sol
+++ b/src/libs/ValidationLib.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.30;
 
 /**

--- a/src/libs/VotingErrors.sol
+++ b/src/libs/VotingErrors.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 library VotingErrors {

--- a/src/libs/VotingMath.sol
+++ b/src/libs/VotingMath.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 /**

--- a/src/libs/WebAuthnLib.sol
+++ b/src/libs/WebAuthnLib.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import {P256Verifier} from "./P256Verifier.sol";

--- a/test/BatchFunctionsTest.t.sol
+++ b/test/BatchFunctionsTest.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";

--- a/test/DeployerTest.t.sol
+++ b/test/DeployerTest.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.17;
 
 /*──────────── forge‑std helpers ───────────*/

--- a/test/DirectDemocracyVoting.t.sol
+++ b/test/DirectDemocracyVoting.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";

--- a/test/EducationHub.t.sol
+++ b/test/EducationHub.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";

--- a/test/Executor.t.sol
+++ b/test/Executor.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";

--- a/test/HatManagerTest.t.sol
+++ b/test/HatManagerTest.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";

--- a/test/ImplementationRegistry.t.sol
+++ b/test/ImplementationRegistry.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";

--- a/test/OrgRegistry.t.sol
+++ b/test/OrgRegistry.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";

--- a/test/P256ForkTest.t.sol
+++ b/test/P256ForkTest.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";

--- a/test/P256SignatureTest.t.sol
+++ b/test/P256SignatureTest.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";

--- a/test/ParticipationToken.t.sol
+++ b/test/ParticipationToken.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";

--- a/test/Passkey.t.sol
+++ b/test/Passkey.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.24;
 
 /*──────────── forge-std helpers ───────────*/

--- a/test/PasskeyPaymasterIntegration.t.sol
+++ b/test/PasskeyPaymasterIntegration.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.24;
 
 import {Test, console2} from "forge-std/Test.sol";

--- a/test/PaymasterHub.t.sol.skip
+++ b/test/PaymasterHub.t.sol.skip
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.24;
 
 import {Test, console2} from "forge-std/Test.sol";

--- a/test/PaymasterHubIntegration.t.sol.skip
+++ b/test/PaymasterHubIntegration.t.sol.skip
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.24;
 
 import {Test, console2} from "forge-std/Test.sol";

--- a/test/PaymasterHubInvariants.t.sol.skip
+++ b/test/PaymasterHubInvariants.t.sol.skip
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.24;
 
 import {Test, console2} from "forge-std/Test.sol";

--- a/test/PaymasterHubSolidarity.t.sol
+++ b/test/PaymasterHubSolidarity.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.24;
 
 import {Test, console2} from "forge-std/Test.sol";

--- a/test/PaymentManager.t.sol
+++ b/test/PaymentManager.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";

--- a/test/PaymentManagerMerkle.t.sol
+++ b/test/PaymentManagerMerkle.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";

--- a/test/PoaManager.t.sol
+++ b/test/PoaManager.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";

--- a/test/QuickJoin.t.sol
+++ b/test/QuickJoin.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.21;
 
 import "forge-std/Test.sol";

--- a/test/RoleResolverTest.t.sol
+++ b/test/RoleResolverTest.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.17;
 
 import "forge-std/Test.sol";

--- a/test/SwitchableBeacon.t.sol
+++ b/test/SwitchableBeacon.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";

--- a/test/TaskManager.t.sol
+++ b/test/TaskManager.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";

--- a/test/UniversalAccountRegistry.t.sol
+++ b/test/UniversalAccountRegistry.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";

--- a/test/VerifyHatsSetup.t.sol
+++ b/test/VerifyHatsSetup.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";

--- a/test/VotingMath.t.sol
+++ b/test/VotingMath.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";

--- a/test/VotingMathVerification.sol
+++ b/test/VotingMathVerification.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import "../src/libs/VotingMath.sol";

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/test/mocks/MockHats.sol
+++ b/test/mocks/MockHats.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 import {IHats} from "lib/hats-protocol/src/Interfaces/IHats.sol";

--- a/upgrades/baseline/DirectDemocracyVoting.sol
+++ b/upgrades/baseline/DirectDemocracyVoting.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.8.13 ^0.8.20 ^0.8.30;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/baseline/EducationHub.sol
+++ b/upgrades/baseline/EducationHub.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.16 >=0.8.13 ^0.8.20 ^0.8.30;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/baseline/EligibilityModule.sol
+++ b/upgrades/baseline/EligibilityModule.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.8.13 ^0.8.19 ^0.8.20;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/baseline/HatsTreeSetup.sol
+++ b/upgrades/baseline/HatsTreeSetup.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.8.13 ^0.8.17 ^0.8.20 ^0.8.30;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/baseline/HybridVoting.sol
+++ b/upgrades/baseline/HybridVoting.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.16 >=0.8.13 ^0.8.20 ^0.8.30;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/baseline/OrgDeployer.sol
+++ b/upgrades/baseline/OrgDeployer.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.11 >=0.4.16 >=0.8.13 ^0.8.20 ^0.8.21 ^0.8.22 ^0.8.30;
 
 // lib/openzeppelin-contracts/contracts/utils/Errors.sol

--- a/upgrades/baseline/PasskeyAccount.sol
+++ b/upgrades/baseline/PasskeyAccount.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20 ^0.8.24;
 
 // src/interfaces/IPasskeyAccount.sol

--- a/upgrades/baseline/PasskeyAccountFactory.sol
+++ b/upgrades/baseline/PasskeyAccountFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.11 >=0.4.16 ^0.8.20 ^0.8.21 ^0.8.22 ^0.8.24;
 
 // lib/openzeppelin-contracts/contracts/utils/Errors.sol

--- a/upgrades/baseline/PaymasterHub.sol
+++ b/upgrades/baseline/PaymasterHub.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.11 >=0.4.16 >=0.8.13 ^0.8.20 ^0.8.21 ^0.8.24;
 
 // lib/openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol

--- a/upgrades/baseline/PaymasterHubLens.sol
+++ b/upgrades/baseline/PaymasterHubLens.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.16 >=0.8.13 ^0.8.24;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/baseline/PaymentManager.sol
+++ b/upgrades/baseline/PaymentManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.16 >=0.6.2 ^0.8.20;
 
 // lib/openzeppelin-contracts/contracts/utils/cryptography/Hashes.sol

--- a/upgrades/baseline/QuickJoin.sol
+++ b/upgrades/baseline/QuickJoin.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.8.13 ^0.8.20 ^0.8.21;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/baseline/SwitchableBeacon.sol
+++ b/upgrades/baseline/SwitchableBeacon.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 // src/SwitchableBeacon.sol

--- a/upgrades/baseline/TaskManager.sol
+++ b/upgrades/baseline/TaskManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.16 >=0.6.2 >=0.8.13 ^0.8.20 ^0.8.30;
 
 // src/libs/BudgetLib.sol

--- a/upgrades/baseline/ToggleModule.sol
+++ b/upgrades/baseline/ToggleModule.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.19 ^0.8.20;
 
 // lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol

--- a/upgrades/current/DirectDemocracyVoting.sol
+++ b/upgrades/current/DirectDemocracyVoting.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.8.13 ^0.8.20 ^0.8.30;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/current/EducationHub.sol
+++ b/upgrades/current/EducationHub.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.16 >=0.8.13 ^0.8.20 ^0.8.30;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/current/EligibilityModule.sol
+++ b/upgrades/current/EligibilityModule.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.8.13 ^0.8.19 ^0.8.20;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/current/HatsTreeSetup.sol
+++ b/upgrades/current/HatsTreeSetup.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.8.13 ^0.8.17 ^0.8.20 ^0.8.30;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/current/HybridVoting.sol
+++ b/upgrades/current/HybridVoting.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.16 >=0.8.13 ^0.8.20 ^0.8.30;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/current/OrgDeployer.sol
+++ b/upgrades/current/OrgDeployer.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.11 >=0.4.16 >=0.8.13 ^0.8.20 ^0.8.21 ^0.8.22 ^0.8.30;
 
 // lib/openzeppelin-contracts/contracts/utils/Errors.sol

--- a/upgrades/current/PasskeyAccount.sol
+++ b/upgrades/current/PasskeyAccount.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20 ^0.8.24;
 
 // src/interfaces/IPasskeyAccount.sol

--- a/upgrades/current/PasskeyAccountFactory.sol
+++ b/upgrades/current/PasskeyAccountFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.11 >=0.4.16 ^0.8.20 ^0.8.21 ^0.8.22 ^0.8.24;
 
 // lib/openzeppelin-contracts/contracts/utils/Errors.sol

--- a/upgrades/current/PaymasterHub.sol
+++ b/upgrades/current/PaymasterHub.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.11 >=0.4.16 >=0.8.13 ^0.8.20 ^0.8.21 ^0.8.24;
 
 // lib/openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol

--- a/upgrades/current/PaymasterHubLens.sol
+++ b/upgrades/current/PaymasterHubLens.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.16 >=0.8.13 ^0.8.24;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/current/PaymentManager.sol
+++ b/upgrades/current/PaymentManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.16 >=0.6.2 ^0.8.20;
 
 // lib/openzeppelin-contracts/contracts/utils/cryptography/Hashes.sol

--- a/upgrades/current/QuickJoin.sol
+++ b/upgrades/current/QuickJoin.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.8.13 ^0.8.20 ^0.8.21;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/current/SwitchableBeacon.sol
+++ b/upgrades/current/SwitchableBeacon.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 // src/SwitchableBeacon.sol

--- a/upgrades/current/TaskManager.sol
+++ b/upgrades/current/TaskManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.16 >=0.6.2 >=0.8.13 ^0.8.20 ^0.8.30;
 
 // src/libs/BudgetLib.sol

--- a/upgrades/current/ToggleModule.sol
+++ b/upgrades/current/ToggleModule.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.19 ^0.8.20;
 
 // lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol

--- a/upgrades/previous/DirectDemocracyVoting.sol
+++ b/upgrades/previous/DirectDemocracyVoting.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.8.13 ^0.8.20 ^0.8.30;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/previous/EducationHub.sol
+++ b/upgrades/previous/EducationHub.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.16 >=0.8.13 ^0.8.20 ^0.8.30;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/previous/EligibilityModule.sol
+++ b/upgrades/previous/EligibilityModule.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.8.13 ^0.8.19 ^0.8.20;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/previous/HatsTreeSetup.sol
+++ b/upgrades/previous/HatsTreeSetup.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.8.13 ^0.8.17 ^0.8.20 ^0.8.30;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/previous/HybridVoting.sol
+++ b/upgrades/previous/HybridVoting.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.16 >=0.8.13 ^0.8.20 ^0.8.30;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/previous/OrgDeployer.sol
+++ b/upgrades/previous/OrgDeployer.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.11 >=0.4.16 >=0.8.13 ^0.8.20 ^0.8.21 ^0.8.22 ^0.8.30;
 
 // lib/openzeppelin-contracts/contracts/utils/Errors.sol

--- a/upgrades/previous/PasskeyAccount.sol
+++ b/upgrades/previous/PasskeyAccount.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20 ^0.8.24;
 
 // src/interfaces/IPasskeyAccount.sol

--- a/upgrades/previous/PasskeyAccountFactory.sol
+++ b/upgrades/previous/PasskeyAccountFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.11 >=0.4.16 ^0.8.20 ^0.8.21 ^0.8.22 ^0.8.24;
 
 // lib/openzeppelin-contracts/contracts/utils/Errors.sol

--- a/upgrades/previous/PaymasterHub.sol
+++ b/upgrades/previous/PaymasterHub.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.11 >=0.4.16 >=0.8.13 ^0.8.20 ^0.8.21 ^0.8.24;
 
 // lib/openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol

--- a/upgrades/previous/PaymasterHubLens.sol
+++ b/upgrades/previous/PaymasterHubLens.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.16 >=0.8.13 ^0.8.24;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/previous/PaymentManager.sol
+++ b/upgrades/previous/PaymentManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.16 >=0.6.2 ^0.8.20;
 
 // lib/openzeppelin-contracts/contracts/utils/cryptography/Hashes.sol

--- a/upgrades/previous/QuickJoin.sol
+++ b/upgrades/previous/QuickJoin.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.8.13 ^0.8.20 ^0.8.21;
 
 // lib/hats-protocol/src/Interfaces/HatsErrors.sol

--- a/upgrades/previous/SwitchableBeacon.sol
+++ b/upgrades/previous/SwitchableBeacon.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
 // src/SwitchableBeacon.sol

--- a/upgrades/previous/TaskManager.sol
+++ b/upgrades/previous/TaskManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.4.16 >=0.6.2 >=0.8.13 ^0.8.20 ^0.8.30;
 
 // src/libs/BudgetLib.sol

--- a/upgrades/previous/ToggleModule.sol
+++ b/upgrades/previous/ToggleModule.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.19 ^0.8.20;
 
 // lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol


### PR DESCRIPTION
Change all license identifiers from MIT and UNLICENSED to AGPL-3.0-only
across all Solidity contracts, tests, scripts, and related files.