### PR TITLE
Replace precomputed keccak256 hashes with inline computation

### DIFF
--- a/src/DirectDemocracyVoting.sol
+++ b/src/DirectDemocracyVoting.sol
@@ -63,12 +63,12 @@ contract DirectDemocracyVoting is Initializable {
         uint256 _lock; // Inline reentrancy guard state
     }
 
-    // keccak256("poa.directdemocracy.storage") → unique, collision-free slot
-    bytes32 private constant _STORAGE_SLOT = 0x1da04eb4a741346cdb49b5da943a0c13e79399ef962f913efcd36d95ee6d7c38;
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.directdemocracy.storage");
 
     function _layout() private pure returns (Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
         assembly {
-            s.slot := _STORAGE_SLOT
+            s.slot := slot
         }
     }
 

--- a/src/EducationHub.sol
+++ b/src/EducationHub.sol
@@ -56,12 +56,12 @@ contract EducationHub is Initializable, ContextUpgradeable, ReentrancyGuardUpgra
         uint256[] memberHatIds; // enumeration array for member hats
     }
 
-    // keccak256("poa.educationhub.storage") → unique, collision-free slot
-    bytes32 private constant _STORAGE_SLOT = 0x5dc09eed2545e1c49e29265cd02140e8b217f2e2a19c33f42e35fa06d63dcb0a;
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.educationhub.storage");
 
     function _layout() private pure returns (Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
         assembly {
-            s.slot := _STORAGE_SLOT
+            s.slot := slot
         }
     }
 

--- a/src/EligibilityModule.sol
+++ b/src/EligibilityModule.sol
@@ -96,13 +96,13 @@ contract EligibilityModule is Initializable, IHatsEligibility {
         mapping(uint256 => address[]) roleApplicants; // hatId => array of applicant addresses
     }
 
-    // keccak256("poa.eligibilitymodule.storage") → unique, collision-free slot
-    bytes32 private constant _STORAGE_SLOT = 0x8f7c0d6a29b3e7e2f1a0c9b8d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a0b9c8d7e6;
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.eligibilitymodule.storage");
 
     /// @dev Use assembly for gas-optimized storage access
     function _layout() private pure returns (Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
         assembly {
-            s.slot := _STORAGE_SLOT
+            s.slot := slot
         }
     }
 

--- a/src/Executor.sol
+++ b/src/Executor.sol
@@ -44,12 +44,12 @@ contract Executor is Initializable, OwnableUpgradeable, PausableUpgradeable, Ree
         mapping(address => bool) authorizedHatMinters; // contracts authorized to request hat minting
     }
 
-    // keccak256("poa.executor.storage") → unique, collision-free slot
-    bytes32 private constant _STORAGE_SLOT = 0x4a2328a3c3b056def98e04ebb0cc7ccc084886f7998dd0a6d16fd24be55ffa5d;
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.executor.storage");
 
     function _layout() private pure returns (Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
         assembly {
-            s.slot := _STORAGE_SLOT
+            s.slot := slot
         }
     }
 

--- a/src/HybridVoting.sol
+++ b/src/HybridVoting.sol
@@ -72,12 +72,12 @@ contract HybridVoting is Initializable {
         uint256 _lock; // Inline reentrancy guard state
     }
 
-    // keccak256("poa.hybridvoting.v2.storage") → unique, collision-free slot for v2
-    bytes32 private constant _STORAGE_SLOT = 0x7a3e8e3d8e9c8f7b6a5d4c3b2a1908070605040302010009080706050403020a;
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.hybridvoting.v2.storage");
 
     function _layout() private pure returns (Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
         assembly {
-            s.slot := _STORAGE_SLOT
+            s.slot := slot
         }
     }
 

--- a/src/ImplementationRegistry.sol
+++ b/src/ImplementationRegistry.sol
@@ -31,12 +31,12 @@ contract ImplementationRegistry is Initializable, OwnableUpgradeable {
         bytes32[] typeIds;
     }
 
-    // keccak256("poa.implementationregistry.storage") to get a unique, collision-free slot
-    bytes32 private constant _STORAGE_SLOT = 0x5f9c962a1b4199db74b9968808a6126c9e2ae410e9b0e0c406e3de1c293c43d1;
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.implementationregistry.storage");
 
     function _layout() private pure returns (Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
         assembly {
-            s.slot := _STORAGE_SLOT
+            s.slot := slot
         }
     }
 

--- a/src/OrgDeployer.sol
+++ b/src/OrgDeployer.sol
@@ -130,11 +130,12 @@ contract OrgDeployer is Initializable {
 
     IHats public hats;
 
-    bytes32 private constant _STORAGE_SLOT = 0x9f1e8f9f8d4c3b2a1e7f6d5c4b3a2e1f0d9c8b7a6e5f4d3c2b1a0e9f8d7c6b5a;
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.orgdeployer.storage");
 
     function _layout() private pure returns (Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
         assembly {
-            s.slot := _STORAGE_SLOT
+            s.slot := slot
         }
     }
 

--- a/src/OrgRegistry.sol
+++ b/src/OrgRegistry.sol
@@ -67,12 +67,12 @@ contract OrgRegistry is Initializable, OwnableUpgradeable {
         IHats hats;
     }
 
-    // keccak256("poa.orgregistry.storage") to get a unique, collision-free slot
-    bytes32 private constant _STORAGE_SLOT = 0x3ffb0627b419b7b77c77f589dd229844c112a8c125dceec0d56dda0674b35489;
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.orgregistry.storage");
 
     function _layout() private pure returns (Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
         assembly {
-            s.slot := _STORAGE_SLOT
+            s.slot := slot
         }
     }
 

--- a/src/ParticipationToken.sol
+++ b/src/ParticipationToken.sol
@@ -52,12 +52,12 @@ contract ParticipationToken is Initializable, ERC20VotesUpgradeable, ReentrancyG
         uint256[] approverHatIds; // enumeration array for approver hats
     }
 
-    // keccak256("poa.participationtoken.storage") → unique, collision-free slot
-    bytes32 private constant _STORAGE_SLOT = 0xc49c4cc718f2f9e8d168c340989dd4f66bf6674fc7217665b075b167908f4ee1;
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.participationtoken.storage");
 
     function _layout() private pure returns (Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
         assembly {
-            s.slot := _STORAGE_SLOT
+            s.slot := slot
         }
     }
 

--- a/src/PasskeyAccount.sol
+++ b/src/PasskeyAccount.sol
@@ -73,12 +73,12 @@ contract PasskeyAccount is Initializable, IAccount, IPasskeyAccount {
         bytes32[] pendingRecoveryIds;
     }
 
-    // keccak256("poa.passkeyaccount.storage")
-    bytes32 private constant _STORAGE_SLOT = 0x7cfc8294c1be3fa32b08d50f0668cc2726e1306f195499e2d5283b8967b03fef;
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.passkeyaccount.storage");
 
     function _layout() private pure returns (Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
         assembly {
-            s.slot := _STORAGE_SLOT
+            s.slot := slot
         }
     }
 

--- a/src/PasskeyAccountFactory.sol
+++ b/src/PasskeyAccountFactory.sol
@@ -67,12 +67,12 @@ contract PasskeyAccountFactory is Initializable {
         mapping(address => bool) deployedAccounts;
     }
 
-    // keccak256("poa.passkeyaccountfactory.storage")
-    bytes32 private constant _STORAGE_SLOT = 0x827e9908968f666e42b67f932c7b1de44a3c55e267a1f6ed05a8d68576716a25;
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.passkeyaccountfactory.storage");
 
     function _layout() private pure returns (Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
         assembly {
-            s.slot := _STORAGE_SLOT
+            s.slot := slot
         }
     }
 

--- a/src/PaymasterHub.sol
+++ b/src/PaymasterHub.sol
@@ -134,8 +134,8 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
         address orgRegistrar; // authorized contract that can register orgs (e.g. OrgDeployer)
     }
 
-    // keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.main")) - 1))
-    bytes32 private constant MAIN_STORAGE_LOCATION = 0x79313178bb7ec733585695efb4bda9fb0a2460b07c17173a160d53a584d7fdf1;
+    bytes32 private constant MAIN_STORAGE_LOCATION =
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.main")) - 1));
 
     // ============ Storage Structs ============
 
@@ -224,44 +224,24 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
     }
 
     // ============ ERC-7201 Storage Locations ============
-    // keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.orgs")) - 1))
-    bytes32 private constant ORGS_STORAGE_LOCATION = 0x1577b5f3d975f3e4c3ad36823cfc47ce59d96a4692a043664a68f0cf2b1a08e5;
-
-    // keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.feeCaps")) - 1))
+    bytes32 private constant ORGS_STORAGE_LOCATION =
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.orgs")) - 1));
     bytes32 private constant FEECAPS_STORAGE_LOCATION =
-        0x31c1f70de237698620907d8a0468bf5356fb50f4719bfcd111876a981cbccb5c;
-
-    // keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.rules")) - 1))
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.feeCaps")) - 1));
     bytes32 private constant RULES_STORAGE_LOCATION =
-        0xbe2280b3d3247ad137be1f9de7cbb32fc261644cda199a3a24b0a06528ef326f;
-
-    // keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.budgets")) - 1))
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.rules")) - 1));
     bytes32 private constant BUDGETS_STORAGE_LOCATION =
-        0xf14d4c678226f6697d18c9cd634533b58566936459364e55f23c57845d71389e;
-
-    // keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.bounty")) - 1))
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.budgets")) - 1));
     bytes32 private constant BOUNTY_STORAGE_LOCATION =
-        0x5aefd14c2f5001261e819816e3c40d9d9cc763af84e5df87cd5955f0f5cfd09e;
-
-    // keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.financials")) - 1))
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.bounty")) - 1));
     bytes32 private constant FINANCIALS_STORAGE_LOCATION =
-        0xc5d8b6edce490eeae75e971366b4e3a6142abb5df4486ab4290826e6cd008210;
-
-    // keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.solidarity")) - 1))
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.financials")) - 1));
     bytes32 private constant SOLIDARITY_STORAGE_LOCATION =
-        0xa83be0d588222d6e3c8e88a987c1439474749e44cafa67ced60ef5911863ad5b;
-
-    // keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.graceperiod")) - 1))
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.solidarity")) - 1));
     bytes32 private constant GRACEPERIOD_STORAGE_LOCATION =
-        0xb32fa2cc2be738bb7360ed872bdb5f34f0611b5e6c897349c7f50d1becdb3984;
-
-    // keccak256("poa.paymasterhub.usedvouches")
-    bytes32 private constant USEDVOUCHES_STORAGE_LOCATION =
-        0x86e9dc53a59330278f5c7228b9372eecbe7ed09b3412489de7fe1e046b46bbaa;
-
-    // keccak256("poa.paymasterhub.onboarding")
-    bytes32 private constant ONBOARDING_STORAGE_LOCATION =
-        0x4b1e497b56331764ad6bf7b8c88df82cd3770c256224ec222ba11219a197de90;
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.graceperiod")) - 1));
+    bytes32 private constant USEDVOUCHES_STORAGE_LOCATION = keccak256("poa.paymasterhub.usedvouches");
+    bytes32 private constant ONBOARDING_STORAGE_LOCATION = keccak256("poa.paymasterhub.onboarding");
 
     // ============ Constructor ============
     /// @custom:oz-upgrades-unsafe-allow constructor
@@ -1364,20 +1344,23 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
 
     // ============ Storage Accessors ============
     function _getMainStorage() private pure returns (MainStorage storage $) {
+        bytes32 slot = MAIN_STORAGE_LOCATION;
         assembly {
-            $.slot := MAIN_STORAGE_LOCATION
+            $.slot := slot
         }
     }
 
     function _getOrgsStorage() private pure returns (mapping(bytes32 => OrgConfig) storage $) {
+        bytes32 slot = ORGS_STORAGE_LOCATION;
         assembly {
-            $.slot := ORGS_STORAGE_LOCATION
+            $.slot := slot
         }
     }
 
     function _getFeeCapsStorage() private pure returns (mapping(bytes32 => FeeCaps) storage $) {
+        bytes32 slot = FEECAPS_STORAGE_LOCATION;
         assembly {
-            $.slot := FEECAPS_STORAGE_LOCATION
+            $.slot := slot
         }
     }
 
@@ -1386,50 +1369,58 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
         pure
         returns (mapping(bytes32 => mapping(address => mapping(bytes4 => Rule))) storage $)
     {
+        bytes32 slot = RULES_STORAGE_LOCATION;
         assembly {
-            $.slot := RULES_STORAGE_LOCATION
+            $.slot := slot
         }
     }
 
     function _getBudgetsStorage() private pure returns (mapping(bytes32 => mapping(bytes32 => Budget)) storage $) {
+        bytes32 slot = BUDGETS_STORAGE_LOCATION;
         assembly {
-            $.slot := BUDGETS_STORAGE_LOCATION
+            $.slot := slot
         }
     }
 
     function _getBountyStorage() private pure returns (mapping(bytes32 => Bounty) storage $) {
+        bytes32 slot = BOUNTY_STORAGE_LOCATION;
         assembly {
-            $.slot := BOUNTY_STORAGE_LOCATION
+            $.slot := slot
         }
     }
 
     function _getFinancialsStorage() private pure returns (mapping(bytes32 => OrgFinancials) storage $) {
+        bytes32 slot = FINANCIALS_STORAGE_LOCATION;
         assembly {
-            $.slot := FINANCIALS_STORAGE_LOCATION
+            $.slot := slot
         }
     }
 
     function _getSolidarityStorage() private pure returns (SolidarityFund storage $) {
+        bytes32 slot = SOLIDARITY_STORAGE_LOCATION;
         assembly {
-            $.slot := SOLIDARITY_STORAGE_LOCATION
+            $.slot := slot
         }
     }
 
     function _getGracePeriodStorage() private pure returns (GracePeriodConfig storage $) {
+        bytes32 slot = GRACEPERIOD_STORAGE_LOCATION;
         assembly {
-            $.slot := GRACEPERIOD_STORAGE_LOCATION
+            $.slot := slot
         }
     }
 
     function _getUsedVouchesStorage() private pure returns (mapping(bytes32 => mapping(address => bool)) storage $) {
+        bytes32 slot = USEDVOUCHES_STORAGE_LOCATION;
         assembly {
-            $.slot := USEDVOUCHES_STORAGE_LOCATION
+            $.slot := slot
         }
     }
 
     function _getOnboardingStorage() private pure returns (OnboardingConfig storage $) {
+        bytes32 slot = ONBOARDING_STORAGE_LOCATION;
         assembly {
-            $.slot := ONBOARDING_STORAGE_LOCATION
+            $.slot := slot
         }
     }
 

--- a/src/PaymentManager.sol
+++ b/src/PaymentManager.sol
@@ -50,12 +50,12 @@ contract PaymentManager is IPaymentManager, Initializable, OwnableUpgradeable, R
         uint256 distributionCounter;
     }
 
-    // keccak256("poa.paymentmanager.storage") → unique, collision-free slot
-    bytes32 private constant _STORAGE_SLOT = 0x3e5fec24aa4dc4e5aee2e025e51e1392c72a2500577559fae9665c6d52bd6a31;
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.paymentmanager.storage");
 
     function _layout() private pure returns (Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
         assembly {
-            s.slot := _STORAGE_SLOT
+            s.slot := slot
         }
     }
 

--- a/src/QuickJoin.sol
+++ b/src/QuickJoin.sol
@@ -62,12 +62,12 @@ contract QuickJoin is Initializable, ContextUpgradeable, ReentrancyGuardUpgradea
         uint256 salt;
     }
 
-    // keccak256("poa.quickjoin.storage")
-    bytes32 private constant _STORAGE_SLOT = 0x566f0545117c69d7a3001f74fa210927792975a5c779e9cbf2876fbc68ef7fa2;
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.quickjoin.storage");
 
     function _layout() private pure returns (Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
         assembly {
-            s.slot := _STORAGE_SLOT
+            s.slot := slot
         }
     }
 

--- a/src/TaskManager.sol
+++ b/src/TaskManager.sol
@@ -129,11 +129,12 @@ contract TaskManager is Initializable, ContextUpgradeable {
         mapping(uint256 => uint256) projectPermHatRefCount; // hat ID => number of projects with non-zero project mask
     }
 
-    bytes32 private constant _STORAGE_SLOT = 0x30bc214cbc65463577eb5b42c88d60986e26fc81ad89a2eb74550fb255f1e712;
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.taskmanager.storage");
 
     function _layout() private pure returns (Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
         assembly {
-            s.slot := _STORAGE_SLOT
+            s.slot := slot
         }
     }
 

--- a/src/ToggleModule.sol
+++ b/src/ToggleModule.sol
@@ -29,12 +29,12 @@ contract ToggleModule is Initializable {
         mapping(uint256 => bool) hatActive;
     }
 
-    // keccak256("poa.togglemodule.storage") → unique, collision-free slot
-    bytes32 private constant _STORAGE_SLOT = 0x48a7efb8656f02a8591e22e17dff92b9ee0d73547a5595fbb83f382a43ba28cf;
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.togglemodule.storage");
 
     function _layout() private pure returns (Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
         assembly {
-            s.slot := _STORAGE_SLOT
+            s.slot := slot
         }
     }
 

--- a/src/UniversalAccountRegistry.sol
+++ b/src/UniversalAccountRegistry.sol
@@ -26,12 +26,12 @@ contract UniversalAccountRegistry is Initializable, OwnableUpgradeable {
         mapping(bytes32 => address) ownerOfUsernameHash;
     }
 
-    // keccak256("poa.universalaccountregistry.storage") to unique, collision-free slot
-    bytes32 private constant _STORAGE_SLOT = 0x7930448747c45b59575e0d27c83e46a902e6071fea71aa7dda420fff16e39ee5;
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.universalaccountregistry.storage");
 
     function _layout() private pure returns (Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
         assembly {
-            s.slot := _STORAGE_SLOT
+            s.slot := slot
         }
     }
 

--- a/src/libs/HybridVotingConfig.sol
+++ b/src/libs/HybridVotingConfig.sol
@@ -5,7 +5,7 @@ import "../HybridVoting.sol";
 import "./VotingErrors.sol";
 
 library HybridVotingConfig {
-    bytes32 private constant _STORAGE_SLOT = 0x7a3e8e3d8e9c8f7b6a5d4c3b2a1908070605040302010009080706050403020a;
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.hybridvoting.v2.storage");
 
     uint8 public constant MAX_CLASSES = 8;
 
@@ -14,8 +14,9 @@ library HybridVotingConfig {
     );
 
     function _layout() private pure returns (HybridVoting.Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
         assembly {
-            s.slot := _STORAGE_SLOT
+            s.slot := slot
         }
     }
 

--- a/src/libs/HybridVotingCore.sol
+++ b/src/libs/HybridVotingCore.sol
@@ -9,7 +9,7 @@ import {IHats} from "lib/hats-protocol/src/Interfaces/IHats.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 library HybridVotingCore {
-    bytes32 private constant _STORAGE_SLOT = 0x7a3e8e3d8e9c8f7b6a5d4c3b2a1908070605040302010009080706050403020a;
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.hybridvoting.v2.storage");
 
     event VoteCast(
         uint256 indexed id,
@@ -23,8 +23,9 @@ library HybridVotingCore {
     event ProposalExecuted(uint256 indexed id, uint256 indexed winningIdx, uint256 numCalls);
 
     function _layout() private pure returns (HybridVoting.Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
         assembly {
-            s.slot := _STORAGE_SLOT
+            s.slot := slot
         }
     }
 

--- a/src/libs/HybridVotingProposals.sol
+++ b/src/libs/HybridVotingProposals.sol
@@ -10,7 +10,7 @@ import {IExecutor} from "../Executor.sol";
 import {IHats} from "lib/hats-protocol/src/Interfaces/IHats.sol";
 
 library HybridVotingProposals {
-    bytes32 private constant _STORAGE_SLOT = 0x7a3e8e3d8e9c8f7b6a5d4c3b2a1908070605040302010009080706050403020a;
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.hybridvoting.v2.storage");
 
     uint8 public constant MAX_OPTIONS = 50;
     uint8 public constant MAX_CALLS = 20;
@@ -29,8 +29,9 @@ library HybridVotingProposals {
     );
 
     function _layout() private pure returns (HybridVoting.Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
         assembly {
-            s.slot := _STORAGE_SLOT
+            s.slot := slot
         }
     }
 

--- a/src/libs/ModuleTypes.sol
+++ b/src/libs/ModuleTypes.sol
@@ -4,60 +4,30 @@ pragma solidity ^0.8.20;
 /**
  * @title ModuleTypes
  * @author POA Team
- * @notice Central registry of module type identifiers (pre-computed keccak256 hashes)
- * @dev These constants represent keccak256(moduleName) pre-computed at compile time
- *      to eliminate runtime hashing and minimize bytecode size.
+ * @notice Central registry of module type identifiers (keccak256 hashes computed at compile time)
+ * @dev These constants represent keccak256(moduleName) computed inline by the compiler.
  *
  *      Design rationale:
  *      - PoaManager internally uses bytes32 typeIds (keccak256 of module names)
  *      - OrgRegistry requires bytes32 typeIds for contract registration
- *      - Pre-computing these hashes eliminates redundant runtime computation
- *      - Using constants instead of functions reduces deployment gas
+ *      - Inline keccak256 ensures correctness verified by the compiler
  *
  *      Migration notes:
  *      - Legacy code using string-based lookups remains compatible via PoaManager.getBeacon(string)
  *      - New code should use typeId-based lookups via PoaManager.getBeaconById(bytes32)
  */
 library ModuleTypes {
-    // Pre-computed keccak256 hashes of module names
-    // These values MUST match exactly with the type names registered in PoaManager
-
-    /// @dev keccak256("Executor")
-    bytes32 constant EXECUTOR_ID = 0xeb35d5f9843d4076628c4747d195abdd0312e0b8b8f5812a706f3d25ea0b1074;
-
-    /// @dev keccak256("QuickJoin")
-    bytes32 constant QUICK_JOIN_ID = 0x4784d0eb49be96744b28df0ac228d16d518300f3918df72816b3b561765905e2;
-
-    /// @dev keccak256("ParticipationToken")
-    bytes32 constant PARTICIPATION_TOKEN_ID = 0x61653188976d6d9ecf5e33b147788ec0830eac3e633a227b8852151b9bc260ff;
-
-    /// @dev keccak256("TaskManager")
-    bytes32 constant TASK_MANAGER_ID = 0x32f7a2c64ebedb84c7786a459012ac8953c5a63d5dcc8715f2fa3e32bdb3b434;
-
-    /// @dev keccak256("EducationHub")
-    bytes32 constant EDUCATION_HUB_ID = 0xa871f070b566fe185ede7c7d071cb2f92e7c75c6a2912b6f37c86a50cdc6bad3;
-
-    /// @dev keccak256("HybridVoting")
-    bytes32 constant HYBRID_VOTING_ID = 0xb8dd67d452899bbfb87b5b09ad416a7e087658a191da37d41f9ea7dee2fa659a;
-
-    /// @dev keccak256("EligibilityModule")
-    bytes32 constant ELIGIBILITY_MODULE_ID = 0x4227a68d7c497034bee963ad52ac7718fa79a916edc119c0f7e6589c8b2d4ea7;
-
-    /// @dev keccak256("ToggleModule")
-    bytes32 constant TOGGLE_MODULE_ID = 0x75dfb681d193a73a66b628a5adc66bb1ca7bb3feb9a5692cd0a1560ccd9b851a;
-
-    /// @dev keccak256("PaymentManager")
-    bytes32 constant PAYMENT_MANAGER_ID = 0x27c0a50afefb382eb18d87e6a049659a778b9a2f11c89b8723c63e6fab6fa323;
-
-    /// @dev keccak256("PaymasterHub")
-    bytes32 constant PAYMASTER_HUB_ID = 0x846374a1b9aebfa243bcd01b2b2c7d94ce66a1b22f9ed17ed1d6fd61a8c93891;
-
-    /// @dev keccak256("DirectDemocracyVoting")
-    bytes32 constant DIRECT_DEMOCRACY_VOTING_ID = 0xf7339bb8aed66291ac713d0a14749e830b09b2288976ec5d45de7e64df0f2aeb;
-
-    /// @dev keccak256("PasskeyAccount")
-    bytes32 constant PASSKEY_ACCOUNT_ID = 0xda41a9794e00ddb18f1b3c615f12a80255bfb0a79706263eee63314d8f817c10;
-
-    /// @dev keccak256("PasskeyAccountFactory")
-    bytes32 constant PASSKEY_ACCOUNT_FACTORY_ID = 0x82da23c7ff6e2ce257dee836273bf72af382187589631ce71ae1388c80777930;
+    bytes32 constant EXECUTOR_ID = keccak256("Executor");
+    bytes32 constant QUICK_JOIN_ID = keccak256("QuickJoin");
+    bytes32 constant PARTICIPATION_TOKEN_ID = keccak256("ParticipationToken");
+    bytes32 constant TASK_MANAGER_ID = keccak256("TaskManager");
+    bytes32 constant EDUCATION_HUB_ID = keccak256("EducationHub");
+    bytes32 constant HYBRID_VOTING_ID = keccak256("HybridVoting");
+    bytes32 constant ELIGIBILITY_MODULE_ID = keccak256("EligibilityModule");
+    bytes32 constant TOGGLE_MODULE_ID = keccak256("ToggleModule");
+    bytes32 constant PAYMENT_MANAGER_ID = keccak256("PaymentManager");
+    bytes32 constant PAYMASTER_HUB_ID = keccak256("PaymasterHub");
+    bytes32 constant DIRECT_DEMOCRACY_VOTING_ID = keccak256("DirectDemocracyVoting");
+    bytes32 constant PASSKEY_ACCOUNT_ID = keccak256("PasskeyAccount");
+    bytes32 constant PASSKEY_ACCOUNT_FACTORY_ID = keccak256("PasskeyAccountFactory");
 }


### PR DESCRIPTION
## Summary
Replace all storage slot hex constants with inline `keccak256("namespace")` calls for compile-time verification. Update ModuleTypes constants and PaymasterHub storage locations. Adapt all `_layout()` functions to work with Solidity's inline assembly restrictions.

## Changes
- **16 contracts**: Storage slots now computed inline via `keccak256()`
- **3 libraries**: Synchronized with parent contracts (HybridVoting suite)
- **PaymasterHub**: 11 storage locations updated (8 ERC-7201 patterns verified to match old values, 2 simple slots, 1 main)
- **ModuleTypes**: 13 module type IDs now inline with compiler verification
- **Assembly pattern**: Load constants into stack variables before use in assembly blocks

## Verification
- All 862 tests passing
- Build clean with zero errors
- Code formatted with `forge fmt`
- PaymasterHub ERC-7201 hashes verified to match old precomputed values
- No old hex references remain in codebase

⚠️ **Note**: 6 storage slots changed values because old hex was incorrect/hand-crafted. If contracts are deployed behind upgrade proxies with existing state, migration handling is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)