### PR TITLE
fix: use production foundry profile for deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   foundry-cicd:
-    uses: BreadchainCoop/etherform/.github/workflows/_foundry-cicd.yml@214cc6e48a9d8084f32de5192754c3c078d588fa
+    uses: BreadchainCoop/etherform/.github/workflows/_foundry-cicd.yml@e4ef95fbf0a980a069587c729a34bd1947e88bd9
     with:
       # CI Options
       check-formatting: true
@@ -31,6 +31,7 @@ jobs:
       deploy-on-pr: false
       deploy-on-main: true
       deploy-script: 'script/DeployInfrastructure.s.sol:DeployInfrastructure'
+      deployment-foundry-profile: 'production'
       network-config-path: '.github/deploy-networks.json'
       indexing-wait: 90
       flatten-contracts: true

--- a/src/TaskManager.sol
+++ b/src/TaskManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.20;
 
-/*──────── OpenZeppelin v5.3 Upgradeables ────────*/
+/*──────── OpenZeppelin Upgradeables ────────*/
 import {Initializable} from "@openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
 import {ContextUpgradeable} from "@openzeppelin-contracts-upgradeable/contracts/utils/ContextUpgradeable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";


### PR DESCRIPTION
## Summary
- Updates etherform ref to include the new `deployment-foundry-profile` input ([etherform PR #24](https://github.com/BreadchainCoop/etherform/pull/24))
- Passes `deployment-foundry-profile: 'production'` so deployments build with the Solidity optimizer enabled

## Problem
The mainnet deployment in CI [run #22553456128](https://github.com/PerpetualOrganizationArchitect/POP/actions/runs/22553456128) failed because 4 contracts exceed the EIP-170 24,576 byte contract size limit:

| Contract | Size | Over by |
|---|---|---|
| PaymasterHub | 42,856 | +18,280 |
| EligibilityModule | 33,033 | +8,457 |
| TaskManager | 28,492 | +3,916 |
| OrgDeployer | 26,329 | +1,753 |

The default foundry profile has the optimizer disabled (due to a `vm.roll()` test bug workaround), so contracts are built unoptimized. The `[profile.production]` in `foundry.toml` enables the optimizer, which reduces contract sizes by ~37%.

## Fix
The etherform reusable workflow now accepts a `deployment-foundry-profile` input that sets `FOUNDRY_PROFILE` during deployment. This CI config passes `'production'` so deployments use the optimized profile while tests continue using the default profile.

## Test plan
- [ ] Verify CI passes on this PR (tests use default profile, deployment step uses production profile)
- [ ] Once etherform PR #24 is merged, update the workflow ref to point to etherform main

Generated with [Claude Code](https://claude.com/claude-code)