### PR TITLE
fix: register factory proxy instead of beacon for subgraph

### DIFF
--- a/script/DeployInfrastructure.s.sol
+++ b/script/DeployInfrastructure.s.sol
@@ -236,9 +236,8 @@ contract DeployInfrastructure is Script {
         console.log("UniversalPasskeyFactory set on OrgDeployer");
 
         // Emit InfrastructureDeployed event for subgraph dynamic discovery
-        address passkeyFactoryBeacon = pm.getBeaconById(keccak256("PasskeyAccountFactory"));
         pm.registerInfrastructure(
-            orgDeployer, orgRegistry, implRegistry, paymasterHub, globalAccountRegistry, passkeyFactoryBeacon
+            orgDeployer, orgRegistry, implRegistry, paymasterHub, globalAccountRegistry, universalPasskeyFactory
         );
         console.log("\n--- Infrastructure Registered (for subgraph indexing) ---");
     }

--- a/script/MainDeploy.s.sol
+++ b/script/MainDeploy.s.sol
@@ -252,14 +252,13 @@ contract DeployHomeChain is DeployHelper {
         console.log("UniversalPasskeyFactory:", infra.universalPasskeyFactory);
 
         // Register infrastructure for subgraph indexing
-        address passkeyFactoryBeacon = pm.getBeaconById(keccak256("PasskeyAccountFactory"));
         pm.registerInfrastructure(
             infra.orgDeployer,
             infra.orgRegistry,
             infra.implRegistry,
             infra.paymasterHub,
             infra.globalAccountRegistry,
-            passkeyFactoryBeacon
+            infra.universalPasskeyFactory
         );
 
         console.log("--- Infrastructure Complete ---");


### PR DESCRIPTION
## Summary
- Both `MainDeploy.s.sol` and `DeployInfrastructure.s.sol` were passing the PasskeyAccountFactory **beacon** address to `registerInfrastructure()` instead of the factory **proxy** address
- The subgraph indexes this address and returns it as the factory to the frontend
- The frontend then calls `getAddress()` on the beacon, which reverts because the beacon only has `implementation()`/`upgradeTo()`/`owner()` — not factory functions
- Fix: pass `infra.universalPasskeyFactory` (the proxy) instead of `passkeyFactoryBeacon` (the beacon)

## Test plan
- [ ] After redeploying, verify `registerInfrastructure` emits the factory proxy address (not the beacon)
- [ ] Verify the subgraph indexes the correct factory proxy address
- [ ] Verify `getAddress()` works when called on the indexed address

🤖 Generated with [Claude Code](https://claude.com/claude-code)