### PR TITLE
fix: ERC-4337 v0.7 compatibility for PaymasterHub

### DIFF
--- a/script/DeployInfrastructure.s.sol
+++ b/script/DeployInfrastructure.s.sol
@@ -177,6 +177,16 @@ contract DeployInfrastructure is Script {
         PoaManager(poaManager).adminCall(paymasterHub, abi.encodeWithSignature("unpauseSolidarityDistribution()"));
         console.log("Solidarity distribution unpaused for onboarding");
 
+        // Override default maxGasPerCreation (compared against maxCost in wei, not gas units)
+        PoaManager(poaManager)
+            .adminCall(
+                paymasterHub,
+                abi.encodeWithSignature(
+                    "setOnboardingConfig(uint128,uint128,bool)", uint128(0.01 ether), uint128(1000), true
+                )
+            );
+        console.log("Onboarding config set: maxCost=0.01 ETH, dailyLimit=1000");
+
         // Deploy OrgDeployer proxy (universalPasskeyFactory set later after deployment)
         address deployerBeacon = PoaManager(poaManager).getBeaconById(keccak256("OrgDeployer"));
         bytes memory deployerInit = abi.encodeWithSignature(

--- a/src/PaymasterHub.sol
+++ b/src/PaymasterHub.sol
@@ -276,9 +276,11 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
         grace.maxSpendDuringGrace = 0.01 ether; // ~$30 worth of gas (~3000 tx on cheap L2s)
         grace.minDepositRequired = 0.003 ether; // ~$10 minimum deposit
 
-        // Initialize onboarding config (enabled, ~200k gas per creation, 1000 accounts/day)
+        // Initialize onboarding config (enabled, max cost per creation, 1000 accounts/day)
+        // NOTE: maxGasPerCreation is compared against maxCost (in wei) from the EntryPoint,
+        // so the value must be denominated in wei, not gas units.
         OnboardingConfig storage onboarding = _getOnboardingStorage();
-        onboarding.maxGasPerCreation = 200000; // ~200k gas for account creation
+        onboarding.maxGasPerCreation = 0.01 ether; // ~$30 worth of gas at typical L1 prices
         onboarding.dailyCreationLimit = 1000; // 1000 accounts per day
         onboarding.enabled = true;
 
@@ -633,7 +635,12 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
      * @param context Context from validatePaymasterUserOp
      * @param actualGasCost Actual gas cost to be reimbursed
      */
-    function postOp(IPaymaster.PostOpMode mode, bytes calldata context, uint256 actualGasCost)
+    function postOp(
+        IPaymaster.PostOpMode mode,
+        bytes calldata context,
+        uint256 actualGasCost,
+        uint256 /* actualUserOpFeePerGas */
+    )
         external
         override
         onlyEntryPoint
@@ -1109,7 +1116,7 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
     /**
      * @notice Configure POA onboarding for account creation from solidarity fund
      * @dev Only PoaManager can modify onboarding parameters
-     * @param _maxGasPerCreation Maximum gas allowed per account creation (~200k)
+     * @param _maxGasPerCreation Maximum cost in wei allowed per account creation
      * @param _dailyCreationLimit Maximum accounts that can be created per day globally
      * @param _enabled Whether onboarding sponsorship is active
      */

--- a/src/interfaces/IPaymaster.sol
+++ b/src/interfaces/IPaymaster.sol
@@ -14,5 +14,6 @@ interface IPaymaster {
         external
         returns (bytes memory context, uint256 validationData);
 
-    function postOp(PostOpMode mode, bytes calldata context, uint256 actualGasCost) external;
+    function postOp(PostOpMode mode, bytes calldata context, uint256 actualGasCost, uint256 actualUserOpFeePerGas)
+        external;
 }

--- a/test/PaymasterHubSolidarity.t.sol
+++ b/test/PaymasterHubSolidarity.t.sol
@@ -1408,7 +1408,7 @@ contract PaymasterHubSolidarityTest is Test {
         (bytes memory context,) = hub.validatePaymasterUserOp(userOp, keccak256("hash"), MAX_COST);
         vm.recordLogs();
         vm.prank(address(entryPoint));
-        hub.postOp(IPaymaster.PostOpMode.opReverted, context, 50_000);
+        hub.postOp(IPaymaster.PostOpMode.opReverted, context, 50_000, 1);
         Vm.Log[] memory logs = vm.getRecordedLogs();
         bytes32 creationEventSig = keccak256("OnboardingAccountCreated(address,uint256)");
         for (uint256 i = 0; i < logs.length; i++) {
@@ -1434,7 +1434,7 @@ contract PaymasterHubSolidarityTest is Test {
         (bytes memory context1,) = hub.validatePaymasterUserOp(userOp1, keccak256("hash1"), MAX_COST);
         // Failed op — counter was incremented in validation but refunded in postOp
         vm.prank(address(entryPoint));
-        hub.postOp(IPaymaster.PostOpMode.opReverted, context1, 50_000);
+        hub.postOp(IPaymaster.PostOpMode.opReverted, context1, 50_000, 1);
         // Second onboarding should succeed because the failed op's slot was refunded
         address account2 = address(0xaa02);
         bytes memory pmData2 =
@@ -1445,7 +1445,7 @@ contract PaymasterHubSolidarityTest is Test {
         (bytes memory context2,) = hub.validatePaymasterUserOp(userOp2, keccak256("hash2"), MAX_COST);
         // Successful op — counter stays incremented (no refund)
         vm.prank(address(entryPoint));
-        hub.postOp(IPaymaster.PostOpMode.opSucceeded, context2, 50_000);
+        hub.postOp(IPaymaster.PostOpMode.opSucceeded, context2, 50_000, 1);
         // Third onboarding should now be blocked (limit of 1 reached)
         address account3 = address(0xaa03);
         bytes memory pmData3 =


### PR DESCRIPTION
## Summary
- **postOp signature mismatch**: v0.7 EntryPoint calls `postOp(uint8,bytes,uint256,uint256)` but IPaymaster.sol only had the v0.6 3-param signature — different selectors (`0x7c627b21` vs `0xa9a23409`) meant `postOp` was never matched, causing immediate revert on every sponsored operation
- **maxGasPerCreation unit mismatch**: Onboarding config compared `maxGasPerCreation` (200000 gas units) against `maxCost` (wei from EntryPoint), always reverting with `GasTooHigh()`. Fixed default to `0.01 ether`
- **Deploy script**: Added `setOnboardingConfig` call with proper wei-denominated max cost so fresh deployments work out of the box

## Test plan
- [x] All 880 tests pass
- [ ] Redeploy infrastructure with updated script
- [ ] Verify passkey account creation works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)