### PR TITLE
feat: add paymaster funding and config to org deployment

### DIFF
--- a/script/DeployOrg.s.sol
+++ b/script/DeployOrg.s.sol
@@ -560,6 +560,19 @@ contract DeployOrg is Script {
         // Build bootstrap config for initial projects/tasks
         params.bootstrap = _buildBootstrapConfig(config.bootstrap);
 
+        // Default paymaster config (no auto-whitelist, no fee caps, skip operator role)
+        params.paymasterConfig = OrgDeployer.PaymasterConfig({
+            operatorRoleIndex: type(uint256).max,
+            autoWhitelistContracts: false,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            maxCallGas: 0,
+            maxVerificationGas: 0,
+            maxPreVerificationGas: 0,
+            defaultBudgetCapPerEpoch: 0,
+            defaultBudgetEpochLen: 0
+        });
+
         return params;
     }
 

--- a/script/MainDeploy.s.sol
+++ b/script/MainDeploy.s.sol
@@ -380,6 +380,7 @@ contract DeployHomeChain is DeployHelper {
         params.educationHubConfig = ModulesFactory.EducationHubConfig({enabled: true});
         params.passkeyEnabled = false;
         // bootstrap is left default (empty)
+        params.paymasterConfig.operatorRoleIndex = type(uint256).max; // skip operator, topHat-only
 
         console.log("\nDeploying governance org: Poa");
 

--- a/script/RunOrgActions.s.sol
+++ b/script/RunOrgActions.s.sol
@@ -960,6 +960,18 @@ contract RunOrgActions is Script {
         // Build bootstrap config for initial projects/tasks
         params.bootstrap = _buildBootstrapConfig(config.bootstrap);
 
+        params.paymasterConfig = OrgDeployer.PaymasterConfig({
+            operatorRoleIndex: type(uint256).max,
+            autoWhitelistContracts: false,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            maxCallGas: 0,
+            maxVerificationGas: 0,
+            maxPreVerificationGas: 0,
+            defaultBudgetCapPerEpoch: 0,
+            defaultBudgetEpochLen: 0
+        });
+
         return params;
     }
 

--- a/script/RunOrgActionsAdvanced.s.sol
+++ b/script/RunOrgActionsAdvanced.s.sol
@@ -1077,6 +1077,18 @@ contract RunOrgActionsAdvanced is Script {
         // Build bootstrap config for initial projects/tasks
         params.bootstrap = _buildBootstrapConfig(config.bootstrap);
 
+        params.paymasterConfig = OrgDeployer.PaymasterConfig({
+            operatorRoleIndex: type(uint256).max,
+            autoWhitelistContracts: false,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            maxCallGas: 0,
+            maxVerificationGas: 0,
+            maxPreVerificationGas: 0,
+            defaultBudgetCapPerEpoch: 0,
+            defaultBudgetEpochLen: 0
+        });
+
         return params;
     }
 

--- a/src/OrgDeployer.sol
+++ b/src/OrgDeployer.sol
@@ -41,7 +41,25 @@ interface IExecutorAdmin {
 }
 
 interface IPaymasterHub {
+    struct DeployConfig {
+        uint256 operatorHatId;
+        uint256 maxFeePerGas;
+        uint256 maxPriorityFeePerGas;
+        uint32 maxCallGas;
+        uint32 maxVerificationGas;
+        uint32 maxPreVerificationGas;
+        address[] ruleTargets;
+        bytes4[] ruleSelectors;
+        bool[] ruleAllowed;
+        uint32[] ruleMaxCallGasHints;
+        bytes32[] budgetSubjectKeys;
+        uint128[] budgetCapsPerEpoch;
+        uint32[] budgetEpochLens;
+    }
+
     function registerOrg(bytes32 orgId, uint256 adminHatId, uint256 operatorHatId) external;
+    function registerAndConfigureOrg(bytes32 orgId, uint256 adminHatId, DeployConfig calldata config) external payable;
+    function depositForOrg(bytes32 orgId) external payable;
 }
 
 interface ITaskManagerBootstrap {
@@ -217,6 +235,19 @@ contract OrgDeployer is Initializable {
         ITaskManagerBootstrap.BootstrapTaskConfig[] tasks;
     }
 
+    struct PaymasterConfig {
+        uint256 operatorRoleIndex; // Role index for paymaster operator hat; type(uint256).max = skip (topHat-only)
+        bool autoWhitelistContracts; // If true, auto-whitelist deployed org contracts
+        uint256 maxFeePerGas;
+        uint256 maxPriorityFeePerGas;
+        uint32 maxCallGas;
+        uint32 maxVerificationGas;
+        uint32 maxPreVerificationGas;
+        // Budget config (all zeros = skip)
+        uint128 defaultBudgetCapPerEpoch; // Default spending cap per epoch for each role hat (0 = no budget)
+        uint32 defaultBudgetEpochLen; // Default epoch length in seconds for each role hat (0 = no budget)
+    }
+
     struct DeploymentParams {
         bytes32 orgId;
         string orgName;
@@ -238,6 +269,7 @@ contract OrgDeployer is Initializable {
         bool passkeyEnabled; // Whether passkey support is enabled (uses universal factory)
         ModulesFactory.EducationHubConfig educationHubConfig; // EducationHub deployment configuration
         BootstrapConfig bootstrap; // Optional: initial projects and tasks to create
+        PaymasterConfig paymasterConfig; // Optional: paymaster configuration (funding via msg.value)
     }
 
     /*════════════════  VALIDATION  ════════════════*/
@@ -291,7 +323,7 @@ contract OrgDeployer is Initializable {
 
     /*════════════════  MAIN DEPLOYMENT FUNCTION  ════════════════*/
 
-    function deployFullOrg(DeploymentParams calldata params) external returns (DeploymentResult memory result) {
+    function deployFullOrg(DeploymentParams calldata params) external payable returns (DeploymentResult memory result) {
         // Manual reentrancy guard
         Layout storage l = _layout();
         if (l._status == 2) revert Reentrant();
@@ -346,10 +378,7 @@ contract OrgDeployer is Initializable {
             l.orgRegistry.setOrgMetadataAdminHat(params.orgId, gov.roleHatIds[params.metadataAdminRoleIndex]);
         }
 
-        /* 5. Register org with shared PaymasterHub */
-        IPaymasterHub(l.paymasterHub).registerOrg(params.orgId, gov.topHatId, 0);
-
-        /* 6. Deploy Access Infrastructure (QuickJoin, Token) */
+        /* 5. Deploy Access Infrastructure (QuickJoin, Token) */
         AccessFactory.AccessResult memory access;
         {
             AccessFactory.RoleAssignments memory accessRoles = AccessFactory.RoleAssignments({
@@ -417,6 +446,9 @@ contract OrgDeployer is Initializable {
         /* 7. Deploy Voting Mechanisms (HybridVoting, DirectDemocracyVoting) */
         (result.hybridVoting, result.directDemocracyVoting) =
             _deployVotingMechanisms(params, result.executor, result.participationToken, gov.roleHatIds);
+
+        /* 7b. Register and configure org with PaymasterHub (after all modules deployed) */
+        _configurePaymaster(l, params, result, gov.topHatId, gov.roleHatIds);
 
         /* 8. Wire up cross-module connections */
         IParticipationToken(result.participationToken).setTaskManager(result.taskManager);
@@ -745,5 +777,227 @@ contract OrgDeployer is Initializable {
             hatIds[i] = roleHatIds[roleIndices[i]];
         }
         return hatIds;
+    }
+
+    /*══════════════  PAYMASTER CONFIGURATION  ═════════════=*/
+
+    /**
+     * @notice Register and optionally configure the org's PaymasterHub entry
+     * @dev Moved after all modules deployed so we know contract addresses for auto-whitelisting
+     */
+    function _configurePaymaster(
+        Layout storage l,
+        DeploymentParams calldata params,
+        DeploymentResult memory result,
+        uint256 topHatId,
+        uint256[] memory roleHatIds
+    ) internal {
+        PaymasterConfig calldata pmCfg = params.paymasterConfig;
+
+        // Resolve operator hat from role index (type(uint256).max = skip → operatorHatId stays 0)
+        uint256 operatorHatId = 0;
+        if (pmCfg.operatorRoleIndex < params.roles.length) {
+            operatorHatId = roleHatIds[pmCfg.operatorRoleIndex];
+        }
+
+        bool hasFeeCaps = pmCfg.maxFeePerGas != 0 || pmCfg.maxPriorityFeePerGas != 0 || pmCfg.maxCallGas != 0
+            || pmCfg.maxVerificationGas != 0 || pmCfg.maxPreVerificationGas != 0;
+        bool hasBudgets = pmCfg.defaultBudgetCapPerEpoch != 0 && pmCfg.defaultBudgetEpochLen != 0;
+        bool hasConfig = hasFeeCaps || pmCfg.autoWhitelistContracts || hasBudgets || msg.value > 0;
+
+        if (hasConfig) {
+            // Build rules for auto-whitelisting deployed contracts
+            (address[] memory targets, bytes4[] memory selectors, bool[] memory allowed, uint32[] memory gasHints) = pmCfg.autoWhitelistContracts
+                ? _buildDefaultPaymasterRules(result, params.educationHubConfig.enabled)
+                : (new address[](0), new bytes4[](0), new bool[](0), new uint32[](0));
+
+            // Build per-role-hat budgets if configured
+            (bytes32[] memory budgetKeys, uint128[] memory budgetCaps, uint32[] memory budgetEpochLens) = hasBudgets
+                ? _buildDefaultBudgets(roleHatIds, pmCfg.defaultBudgetCapPerEpoch, pmCfg.defaultBudgetEpochLen)
+                : (new bytes32[](0), new uint128[](0), new uint32[](0));
+
+            IPaymasterHub.DeployConfig memory config = IPaymasterHub.DeployConfig({
+                operatorHatId: operatorHatId,
+                maxFeePerGas: pmCfg.maxFeePerGas,
+                maxPriorityFeePerGas: pmCfg.maxPriorityFeePerGas,
+                maxCallGas: pmCfg.maxCallGas,
+                maxVerificationGas: pmCfg.maxVerificationGas,
+                maxPreVerificationGas: pmCfg.maxPreVerificationGas,
+                ruleTargets: targets,
+                ruleSelectors: selectors,
+                ruleAllowed: allowed,
+                ruleMaxCallGasHints: gasHints,
+                budgetSubjectKeys: budgetKeys,
+                budgetCapsPerEpoch: budgetCaps,
+                budgetEpochLens: budgetEpochLens
+            });
+
+            IPaymasterHub(l.paymasterHub).registerAndConfigureOrg{value: msg.value}(params.orgId, topHatId, config);
+        } else {
+            // Simple registration only (backwards compatible)
+            IPaymasterHub(l.paymasterHub).registerOrg(params.orgId, topHatId, operatorHatId);
+        }
+    }
+
+    /**
+     * @notice Build default paymaster whitelist rules for deployed org contracts
+     * @dev Whitelists common user-facing functions on QuickJoin, TaskManager, Voting, etc.
+     */
+    function _buildDefaultPaymasterRules(DeploymentResult memory result, bool educationEnabled)
+        internal
+        pure
+        returns (address[] memory targets, bytes4[] memory selectors, bool[] memory allowed, uint32[] memory gasHints)
+    {
+        // Count: QuickJoin(5) + TaskManager(9) + HybridVoting(3) + DDVoting(3) + PaymentManager(3) + EducationHub(0 or 1)
+        uint256 count = 23;
+        if (educationEnabled) count += 1;
+
+        targets = new address[](count);
+        selectors = new bytes4[](count);
+        allowed = new bool[](count);
+        gasHints = new uint32[](count);
+
+        uint256 i = 0;
+
+        // ── QuickJoin ──
+        targets[i] = result.quickJoin;
+        selectors[i] = bytes4(keccak256("quickJoinNoUser()"));
+        i++;
+
+        targets[i] = result.quickJoin;
+        selectors[i] = bytes4(keccak256("quickJoinWithUser()"));
+        i++;
+
+        targets[i] = result.quickJoin;
+        selectors[i] = bytes4(keccak256("quickJoinWithPasskey((bytes32,bytes32,bytes32,uint256))"));
+        i++;
+
+        targets[i] = result.quickJoin;
+        selectors[i] = bytes4(keccak256("registerAndQuickJoin(address,string,uint256,uint256,bytes)"));
+        i++;
+
+        targets[i] = result.quickJoin;
+        selectors[i] = bytes4(
+            keccak256(
+                "registerAndQuickJoinWithPasskey((bytes32,bytes32,bytes32,uint256),string,uint256,uint256,(bytes,bytes,uint256,uint256,bytes32,bytes32))"
+            )
+        );
+        i++;
+
+        // ── TaskManager ──
+        targets[i] = result.taskManager;
+        selectors[i] = bytes4(keccak256("createTask(uint256,bytes,bytes32,bytes32,address,uint256,bool)"));
+        i++;
+
+        targets[i] = result.taskManager;
+        selectors[i] = bytes4(keccak256("claimTask(uint256)"));
+        i++;
+
+        targets[i] = result.taskManager;
+        selectors[i] = bytes4(keccak256("submitTask(uint256,bytes32)"));
+        i++;
+
+        targets[i] = result.taskManager;
+        selectors[i] = bytes4(keccak256("completeTask(uint256)"));
+        i++;
+
+        targets[i] = result.taskManager;
+        selectors[i] = bytes4(keccak256("applyForTask(uint256,bytes32)"));
+        i++;
+
+        targets[i] = result.taskManager;
+        selectors[i] = bytes4(keccak256("approveApplication(uint256,address)"));
+        i++;
+
+        targets[i] = result.taskManager;
+        selectors[i] = bytes4(keccak256("assignTask(uint256,address)"));
+        i++;
+
+        targets[i] = result.taskManager;
+        selectors[i] = bytes4(keccak256("rejectTask(uint256,bytes32)"));
+        i++;
+
+        targets[i] = result.taskManager;
+        selectors[i] = bytes4(keccak256("cancelTask(uint256)"));
+        i++;
+
+        // ── HybridVoting ──
+        targets[i] = result.hybridVoting;
+        selectors[i] = bytes4(keccak256("vote(uint256,uint8[],uint8[])"));
+        i++;
+
+        targets[i] = result.hybridVoting;
+        selectors[i] = bytes4(keccak256("announceWinner(uint256)"));
+        i++;
+
+        targets[i] = result.hybridVoting;
+        selectors[i] =
+            bytes4(keccak256("createProposal(bytes,bytes32,uint32,uint8,(address,uint256,bytes)[][],uint256[])"));
+        i++;
+
+        // ── DirectDemocracyVoting ──
+        targets[i] = result.directDemocracyVoting;
+        selectors[i] = bytes4(keccak256("vote(uint256,uint8[],uint8[])"));
+        i++;
+
+        targets[i] = result.directDemocracyVoting;
+        selectors[i] = bytes4(keccak256("announceWinner(uint256)"));
+        i++;
+
+        targets[i] = result.directDemocracyVoting;
+        selectors[i] =
+            bytes4(keccak256("createProposal(bytes,bytes32,uint32,uint8,(address,uint256,bytes)[][],uint256[])"));
+        i++;
+
+        // ── PaymentManager ──
+        targets[i] = result.paymentManager;
+        selectors[i] = bytes4(keccak256("claimDistribution(uint256,uint256,bytes32[])"));
+        i++;
+
+        targets[i] = result.paymentManager;
+        selectors[i] = bytes4(keccak256("claimMultiple(uint256[],uint256[],bytes32[][])"));
+        i++;
+
+        targets[i] = result.paymentManager;
+        selectors[i] = bytes4(keccak256("optOut(bool)"));
+        i++;
+
+        // ── EducationHub (conditional) ──
+        if (educationEnabled) {
+            targets[i] = result.educationHub;
+            selectors[i] = bytes4(keccak256("completeModule(uint256,uint8)"));
+            i++;
+        }
+
+        // Set all rules to allowed with 0 gas hint (use default)
+        for (uint256 j = 0; j < count; j++) {
+            allowed[j] = true;
+            // gasHints[j] already 0
+        }
+    }
+
+    /**
+     * @notice Build default per-role-hat budget entries
+     * @dev Creates a budget for each role hat using SUBJECT_TYPE_HAT (0x01)
+     * @param roleHatIds Array of hat IDs for each role
+     * @param capPerEpoch Default spending cap per epoch for each hat
+     * @param epochLen Default epoch length in seconds
+     */
+    function _buildDefaultBudgets(uint256[] memory roleHatIds, uint128 capPerEpoch, uint32 epochLen)
+        internal
+        pure
+        returns (bytes32[] memory subjectKeys, uint128[] memory caps, uint32[] memory epochLens)
+    {
+        uint256 count = roleHatIds.length;
+        subjectKeys = new bytes32[](count);
+        caps = new uint128[](count);
+        epochLens = new uint32[](count);
+
+        for (uint256 i = 0; i < count; i++) {
+            // SUBJECT_TYPE_HAT = 0x01, subjectId = bytes20(uint160(hatId))
+            subjectKeys[i] = keccak256(abi.encodePacked(uint8(0x01), bytes20(uint160(roleHatIds[i]))));
+            caps[i] = capPerEpoch;
+            epochLens[i] = epochLen;
+        }
     }
 }

--- a/src/PaymasterHub.sol
+++ b/src/PaymasterHub.sol
@@ -290,6 +290,31 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
         emit PaymasterInitialized(_entryPoint, _hats, _poaManager);
     }
 
+    // ============ Deploy Config Struct ============
+
+    /**
+     * @notice Configuration passed by OrgDeployer during org creation
+     * @dev Allows initial paymaster setup in the same transaction as org deployment
+     */
+    struct DeployConfig {
+        uint256 operatorHatId;
+        // Fee caps (all zeros = skip)
+        uint256 maxFeePerGas;
+        uint256 maxPriorityFeePerGas;
+        uint32 maxCallGas;
+        uint32 maxVerificationGas;
+        uint32 maxPreVerificationGas;
+        // Rules batch (empty arrays = skip)
+        address[] ruleTargets;
+        bytes4[] ruleSelectors;
+        bool[] ruleAllowed;
+        uint32[] ruleMaxCallGasHints;
+        // Budgets batch (empty arrays = skip)
+        bytes32[] budgetSubjectKeys;
+        uint128[] budgetCapsPerEpoch;
+        uint32[] budgetEpochLens;
+    }
+
     // ============ Org Registration ============
 
     /**
@@ -300,8 +325,117 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
      * @param operatorHatId Optional hat ID for operators (0 if none)
      */
     function registerOrg(bytes32 orgId, uint256 adminHatId, uint256 operatorHatId) external {
+        _onlyRegistrar();
+        _registerOrg(orgId, adminHatId, operatorHatId);
+    }
+
+    /**
+     * @notice Register and configure an org with paymaster in one call
+     * @dev Called by OrgDeployer to register, configure rules/fee caps, and optionally deposit ETH
+     * @param orgId Unique organization identifier
+     * @param adminHatId Hat ID for org admin (topHat)
+     * @param config Initial paymaster configuration (operator hat, fee caps, rules)
+     */
+    function registerAndConfigureOrg(bytes32 orgId, uint256 adminHatId, DeployConfig calldata config) external payable {
+        _onlyRegistrar();
+        _registerOrg(orgId, adminHatId, config.operatorHatId);
+
+        // Set fee caps if any non-zero
+        if (
+            config.maxFeePerGas != 0 || config.maxPriorityFeePerGas != 0 || config.maxCallGas != 0
+                || config.maxVerificationGas != 0 || config.maxPreVerificationGas != 0
+        ) {
+            FeeCaps storage feeCaps = _getFeeCapsStorage()[orgId];
+            feeCaps.maxFeePerGas = config.maxFeePerGas;
+            feeCaps.maxPriorityFeePerGas = config.maxPriorityFeePerGas;
+            feeCaps.maxCallGas = config.maxCallGas;
+            feeCaps.maxVerificationGas = config.maxVerificationGas;
+            feeCaps.maxPreVerificationGas = config.maxPreVerificationGas;
+
+            emit FeeCapsSet(
+                orgId,
+                config.maxFeePerGas,
+                config.maxPriorityFeePerGas,
+                config.maxCallGas,
+                config.maxVerificationGas,
+                config.maxPreVerificationGas
+            );
+        }
+
+        // Set rules if arrays provided
+        if (config.ruleTargets.length > 0) {
+            uint256 length = config.ruleTargets.length;
+            if (
+                length != config.ruleSelectors.length || length != config.ruleAllowed.length
+                    || length != config.ruleMaxCallGasHints.length
+            ) {
+                revert ArrayLengthMismatch();
+            }
+
+            mapping(address => mapping(bytes4 => Rule)) storage rules = _getRulesStorage()[orgId];
+
+            for (uint256 i; i < length;) {
+                if (config.ruleTargets[i] == address(0)) revert ZeroAddress();
+
+                rules[config.ruleTargets[i]][config.ruleSelectors[i]] =
+                    Rule({allowed: config.ruleAllowed[i], maxCallGasHint: config.ruleMaxCallGasHints[i]});
+
+                emit RuleSet(
+                    orgId,
+                    config.ruleTargets[i],
+                    config.ruleSelectors[i],
+                    config.ruleAllowed[i],
+                    config.ruleMaxCallGasHints[i]
+                );
+
+                unchecked {
+                    ++i;
+                }
+            }
+        }
+
+        // Set budgets if arrays provided
+        if (config.budgetSubjectKeys.length > 0) {
+            uint256 budgetLen = config.budgetSubjectKeys.length;
+            if (budgetLen != config.budgetCapsPerEpoch.length || budgetLen != config.budgetEpochLens.length) {
+                revert ArrayLengthMismatch();
+            }
+
+            mapping(bytes32 => Budget) storage budgets = _getBudgetsStorage()[orgId];
+
+            for (uint256 j; j < budgetLen;) {
+                uint32 epochLen = config.budgetEpochLens[j];
+                if (epochLen < MIN_EPOCH_LENGTH || epochLen > MAX_EPOCH_LENGTH) {
+                    revert InvalidEpochLength();
+                }
+
+                Budget storage budget = budgets[config.budgetSubjectKeys[j]];
+                budget.capPerEpoch = config.budgetCapsPerEpoch[j];
+                budget.epochLen = epochLen;
+                budget.epochStart = uint32(block.timestamp);
+
+                emit BudgetSet(
+                    orgId, config.budgetSubjectKeys[j], config.budgetCapsPerEpoch[j], epochLen, uint32(block.timestamp)
+                );
+
+                unchecked {
+                    ++j;
+                }
+            }
+        }
+
+        // Deposit ETH if sent
+        if (msg.value > 0) {
+            _depositForOrg(orgId, msg.value);
+        }
+    }
+
+    function _onlyRegistrar() internal view {
         MainStorage storage main = _getMainStorage();
         if (msg.sender != main.poaManager && msg.sender != main.orgRegistrar) revert NotPoaManager();
+    }
+
+    function _registerOrg(bytes32 orgId, uint256 adminHatId, uint256 operatorHatId) internal {
         if (orgId == bytes32(0)) revert InvalidOrgId();
         if (adminHatId == 0) revert ZeroAddress();
 
@@ -442,12 +576,20 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
     function depositForOrg(bytes32 orgId) external payable {
         if (msg.value == 0) revert ZeroAddress();
 
-        mapping(bytes32 => OrgConfig) storage orgs = _getOrgsStorage();
+        // Verify org exists
+        if (_getOrgsStorage()[orgId].adminHatId == 0) revert OrgNotRegistered();
+
+        _depositForOrg(orgId, msg.value);
+    }
+
+    /**
+     * @dev Internal deposit logic shared by depositForOrg and registerAndConfigureOrg
+     * @param orgId The organization to deposit for
+     * @param amount Amount of ETH to deposit (must equal msg.value available)
+     */
+    function _depositForOrg(bytes32 orgId, uint256 amount) internal {
         mapping(bytes32 => OrgFinancials) storage financials = _getFinancialsStorage();
         GracePeriodConfig storage grace = _getGracePeriodStorage();
-
-        // Verify org exists
-        if (orgs[orgId].adminHatId == 0) revert OrgNotRegistered();
 
         OrgFinancials storage org = financials[orgId];
 
@@ -461,7 +603,7 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
 
         // Trigger 2: Crossing minimum threshold
         bool wasBelowMinimum = org.deposited < grace.minDepositRequired;
-        bool willBeAboveMinimum = org.deposited + msg.value >= grace.minDepositRequired;
+        bool willBeAboveMinimum = org.deposited + amount >= grace.minDepositRequired;
         if (wasBelowMinimum && willBeAboveMinimum) {
             shouldResetPeriod = true;
         }
@@ -470,11 +612,11 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
         bool wasUnfunded = org.deposited == 0;
 
         // Safe cast check
-        if (msg.value > type(uint128).max) revert Overflow();
+        if (amount > type(uint128).max) revert Overflow();
 
         // Update org financials
-        org.deposited += uint128(msg.value);
-        org.totalDeposited += uint128(msg.value);
+        org.deposited += uint128(amount);
+        org.totalDeposited += uint128(amount);
 
         // Reset period when triggered
         if (shouldResetPeriod) {
@@ -486,15 +628,15 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
         }
 
         // Update active org count if this is first deposit
-        if (wasUnfunded && msg.value > 0) {
+        if (wasUnfunded && amount > 0) {
             SolidarityFund storage solidarity = _getSolidarityStorage();
             solidarity.numActiveOrgs++;
         }
 
         // Deposit to EntryPoint
-        IEntryPoint(_getMainStorage().entryPoint).depositTo{value: msg.value}(address(this));
+        IEntryPoint(_getMainStorage().entryPoint).depositTo{value: amount}(address(this));
 
-        emit OrgDepositReceived(orgId, msg.sender, msg.value);
+        emit OrgDepositReceived(orgId, msg.sender, amount);
     }
 
     /**

--- a/test/DeployerTest.t.sol
+++ b/test/DeployerTest.t.sol
@@ -177,7 +177,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg(params);
@@ -256,6 +257,20 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
     }
 
     /// @dev Helper to build empty bootstrap config
+    function _defaultPaymasterConfig() internal pure returns (OrgDeployer.PaymasterConfig memory) {
+        return OrgDeployer.PaymasterConfig({
+            operatorRoleIndex: type(uint256).max,
+            autoWhitelistContracts: false,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            maxCallGas: 0,
+            maxVerificationGas: 0,
+            maxPreVerificationGas: 0,
+            defaultBudgetCapPerEpoch: 0,
+            defaultBudgetEpochLen: 0
+        });
+    }
+
     function _emptyBootstrap() internal pure returns (OrgDeployer.BootstrapConfig memory) {
         ITaskManagerBootstrap.BootstrapProjectConfig[] memory projects =
             new ITaskManagerBootstrap.BootstrapProjectConfig[](0);
@@ -418,7 +433,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg(params);
@@ -478,7 +494,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg(params);
@@ -815,7 +832,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg(params);
@@ -947,7 +965,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _buildBootstrapWithTasks()
+            bootstrap: _buildBootstrapWithTasks(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg(params);
@@ -1033,7 +1052,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         deployer.deployFullOrg(params);
@@ -1076,7 +1096,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg(params);
@@ -1162,7 +1183,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg(params);
@@ -1435,7 +1457,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg(params);
@@ -1652,7 +1675,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg(params);
@@ -1817,7 +1841,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg(params);
@@ -1956,7 +1981,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         vm.expectRevert(OrgDeployer.InvalidRoleConfiguration.selector);
@@ -2234,7 +2260,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg(params);
@@ -2342,7 +2369,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg(params);
@@ -2511,7 +2539,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg(params);
@@ -3497,7 +3526,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         // Record logs to verify HatCreatedWithEligibility events were emitted
@@ -3600,7 +3630,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: false}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg(params);
@@ -3664,7 +3695,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: false}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg(params);
@@ -3730,7 +3762,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: false}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg(params);
@@ -4165,7 +4198,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         vm.prank(deployerSigner);
@@ -4210,7 +4244,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         vm.prank(orgOwner);
@@ -4266,7 +4301,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max,
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         vm.prank(deployerSigner);
@@ -4318,7 +4354,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: 0, // Explicitly set role 0
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         deployer.deployFullOrg(params);
@@ -4368,7 +4405,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: 1, // Explicitly set role 1
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         deployer.deployFullOrg(params);
@@ -4422,7 +4460,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: type(uint256).max, // Skip
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         deployer.deployFullOrg(params);
@@ -4470,7 +4509,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             metadataAdminRoleIndex: 999, // Out of bounds but not max
             passkeyEnabled: false,
             educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
-            bootstrap: _emptyBootstrap()
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
         });
 
         deployer.deployFullOrg(params); // Should NOT revert
@@ -4479,5 +4519,1078 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         // Same behavior as skip — no metadata admin hat set
         uint256 metaAdminHat = orgRegistry.getOrgMetadataAdminHat(orgId);
         assertEq(metaAdminHat, 0, "Metadata admin hat should be zero for out-of-bounds index");
+    }
+
+    /*════════════════  PAYMASTER FUNDING & CONFIG TESTS  ════════════════*/
+
+    function testDeployFullOrgWithPaymasterFunding() public {
+        bytes32 orgId = keccak256("PAYMASTER-FUNDED-ORG");
+
+        string[] memory names = new string[](2);
+        names[0] = "DEFAULT";
+        names[1] = "EXECUTIVE";
+        string[] memory images = new string[](2);
+        images[0] = "";
+        images[1] = "";
+        bool[] memory voting = new bool[](2);
+        voting[0] = true;
+        voting[1] = true;
+
+        IHybridVotingInit.ClassConfig[] memory classes = _buildLegacyClasses(50, 50, false, 4 ether);
+        OrgDeployer.RoleAssignments memory roleAssignments = _buildDefaultRoleAssignments();
+        address[] memory ddTargets = new address[](0);
+
+        OrgDeployer.DeploymentParams memory params = OrgDeployer.DeploymentParams({
+            orgId: orgId,
+            orgName: "Funded DAO",
+            metadataHash: bytes32(0),
+            registryAddr: accountRegProxy,
+            deployerAddress: orgOwner,
+            deployerUsername: "",
+            regDeadline: 0,
+            regNonce: 0,
+            regSignature: "",
+            autoUpgrade: true,
+            hybridQuorumPct: 50,
+            ddQuorumPct: 50,
+            hybridClasses: classes,
+            ddInitialTargets: ddTargets,
+            roles: _buildSimpleRoleConfigs(names, images, voting),
+            roleAssignments: roleAssignments,
+            metadataAdminRoleIndex: type(uint256).max,
+            passkeyEnabled: false,
+            educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
+        });
+
+        vm.deal(orgOwner, 1 ether);
+        vm.prank(orgOwner);
+        deployer.deployFullOrg{value: 0.1 ether}(params);
+
+        // Verify org was registered with PaymasterHub
+        PaymasterHub.OrgConfig memory orgConfig = paymasterHub.getOrgConfig(orgId);
+        assertTrue(orgConfig.adminHatId != 0, "Org should be registered with PaymasterHub");
+
+        // Verify deposit was credited
+        PaymasterHub.OrgFinancials memory financials = paymasterHub.getOrgFinancials(orgId);
+        assertEq(financials.deposited, 0.1 ether, "Org should have 0.1 ETH deposited");
+        assertEq(financials.totalDeposited, 0.1 ether, "Total deposited should be 0.1 ETH");
+    }
+
+    function testDeployFullOrgWithPaymasterAutoWhitelist() public {
+        bytes32 orgId = keccak256("WHITELIST-ORG");
+
+        string[] memory names = new string[](2);
+        names[0] = "DEFAULT";
+        names[1] = "EXECUTIVE";
+        string[] memory images = new string[](2);
+        images[0] = "";
+        images[1] = "";
+        bool[] memory voting = new bool[](2);
+        voting[0] = true;
+        voting[1] = true;
+
+        IHybridVotingInit.ClassConfig[] memory classes = _buildLegacyClasses(50, 50, false, 4 ether);
+        OrgDeployer.RoleAssignments memory roleAssignments = _buildDefaultRoleAssignments();
+        address[] memory ddTargets = new address[](0);
+
+        OrgDeployer.PaymasterConfig memory pmConfig = OrgDeployer.PaymasterConfig({
+            operatorRoleIndex: 1, // EXECUTIVE role
+            autoWhitelistContracts: true,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            maxCallGas: 0,
+            maxVerificationGas: 0,
+            maxPreVerificationGas: 0,
+            defaultBudgetCapPerEpoch: 0,
+            defaultBudgetEpochLen: 0
+        });
+
+        OrgDeployer.DeploymentParams memory params = OrgDeployer.DeploymentParams({
+            orgId: orgId,
+            orgName: "Whitelist DAO",
+            metadataHash: bytes32(0),
+            registryAddr: accountRegProxy,
+            deployerAddress: orgOwner,
+            deployerUsername: "",
+            regDeadline: 0,
+            regNonce: 0,
+            regSignature: "",
+            autoUpgrade: true,
+            hybridQuorumPct: 50,
+            ddQuorumPct: 50,
+            hybridClasses: classes,
+            ddInitialTargets: ddTargets,
+            roles: _buildSimpleRoleConfigs(names, images, voting),
+            roleAssignments: roleAssignments,
+            metadataAdminRoleIndex: type(uint256).max,
+            passkeyEnabled: false,
+            educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: pmConfig
+        });
+
+        vm.deal(orgOwner, 1 ether);
+        vm.prank(orgOwner);
+        OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg{value: 0.05 ether}(params);
+
+        // Verify operator hat was set (role 1 = EXECUTIVE)
+        PaymasterHub.OrgConfig memory orgConfig = paymasterHub.getOrgConfig(orgId);
+        assertTrue(orgConfig.operatorHatId != 0, "Operator hat should be set");
+
+        // Verify auto-whitelisted rules exist for deployed contracts
+        PaymasterHub.Rule memory rule;
+
+        // Check QuickJoin quickJoinNoUser() is whitelisted
+        rule = paymasterHub.getRule(orgId, result.quickJoin, bytes4(keccak256("quickJoinNoUser()")));
+        assertTrue(rule.allowed, "QuickJoin quickJoinNoUser should be whitelisted");
+
+        // Check TaskManager claimTask(uint256) is whitelisted
+        rule = paymasterHub.getRule(orgId, result.taskManager, bytes4(keccak256("claimTask(uint256)")));
+        assertTrue(rule.allowed, "TaskManager claimTask should be whitelisted");
+
+        // Check HybridVoting vote is whitelisted
+        bytes4 voteSel = bytes4(keccak256("vote(uint256,uint8[],uint8[])"));
+        rule = paymasterHub.getRule(orgId, result.hybridVoting, voteSel);
+        assertTrue(rule.allowed, "HybridVoting vote should be whitelisted");
+
+        // Check DDVoting vote is whitelisted
+        rule = paymasterHub.getRule(orgId, result.directDemocracyVoting, voteSel);
+        assertTrue(rule.allowed, "DDVoting vote should be whitelisted");
+
+        // Check PaymentManager optOut is whitelisted
+        rule = paymasterHub.getRule(orgId, result.paymentManager, bytes4(keccak256("optOut(bool)")));
+        assertTrue(rule.allowed, "PaymentManager optOut should be whitelisted");
+
+        // Check EducationHub completeModule is whitelisted
+        rule = paymasterHub.getRule(orgId, result.educationHub, bytes4(keccak256("completeModule(uint256,uint8)")));
+        assertTrue(rule.allowed, "EducationHub completeModule should be whitelisted");
+
+        // Verify deposit was also credited
+        PaymasterHub.OrgFinancials memory financials = paymasterHub.getOrgFinancials(orgId);
+        assertEq(financials.deposited, 0.05 ether, "Org should have 0.05 ETH deposited");
+    }
+
+    function testDeployFullOrgWithPaymasterFeeCaps() public {
+        bytes32 orgId = keccak256("FEECAPS-ORG");
+
+        string[] memory names = new string[](2);
+        names[0] = "DEFAULT";
+        names[1] = "EXECUTIVE";
+        string[] memory images = new string[](2);
+        images[0] = "";
+        images[1] = "";
+        bool[] memory voting = new bool[](2);
+        voting[0] = true;
+        voting[1] = true;
+
+        IHybridVotingInit.ClassConfig[] memory classes = _buildLegacyClasses(50, 50, false, 4 ether);
+        OrgDeployer.RoleAssignments memory roleAssignments = _buildDefaultRoleAssignments();
+        address[] memory ddTargets = new address[](0);
+
+        OrgDeployer.PaymasterConfig memory pmConfig = OrgDeployer.PaymasterConfig({
+            operatorRoleIndex: type(uint256).max, // skip, topHat only
+            autoWhitelistContracts: false,
+            maxFeePerGas: 100 gwei,
+            maxPriorityFeePerGas: 2 gwei,
+            maxCallGas: 500_000,
+            maxVerificationGas: 200_000,
+            maxPreVerificationGas: 100_000,
+            defaultBudgetCapPerEpoch: 0,
+            defaultBudgetEpochLen: 0
+        });
+
+        OrgDeployer.DeploymentParams memory params = OrgDeployer.DeploymentParams({
+            orgId: orgId,
+            orgName: "FeeCaps DAO",
+            metadataHash: bytes32(0),
+            registryAddr: accountRegProxy,
+            deployerAddress: orgOwner,
+            deployerUsername: "",
+            regDeadline: 0,
+            regNonce: 0,
+            regSignature: "",
+            autoUpgrade: true,
+            hybridQuorumPct: 50,
+            ddQuorumPct: 50,
+            hybridClasses: classes,
+            ddInitialTargets: ddTargets,
+            roles: _buildSimpleRoleConfigs(names, images, voting),
+            roleAssignments: roleAssignments,
+            metadataAdminRoleIndex: type(uint256).max,
+            passkeyEnabled: false,
+            educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: pmConfig
+        });
+
+        vm.prank(orgOwner);
+        deployer.deployFullOrg(params);
+
+        // Verify fee caps were set
+        PaymasterHub.FeeCaps memory feeCaps = paymasterHub.getFeeCaps(orgId);
+        assertEq(feeCaps.maxFeePerGas, 100 gwei, "maxFeePerGas should be 100 gwei");
+        assertEq(feeCaps.maxPriorityFeePerGas, 2 gwei, "maxPriorityFeePerGas should be 2 gwei");
+        assertEq(feeCaps.maxCallGas, 500_000, "maxCallGas should be 500k");
+        assertEq(feeCaps.maxVerificationGas, 200_000, "maxVerificationGas should be 200k");
+        assertEq(feeCaps.maxPreVerificationGas, 100_000, "maxPreVerificationGas should be 100k");
+    }
+
+    function testDeployFullOrgPaymasterBackwardsCompat() public {
+        // Default config (all zeros) with no msg.value should work identically to before
+        bytes32 orgId = keccak256("COMPAT-ORG");
+
+        string[] memory names = new string[](2);
+        names[0] = "DEFAULT";
+        names[1] = "EXECUTIVE";
+        string[] memory images = new string[](2);
+        images[0] = "";
+        images[1] = "";
+        bool[] memory voting = new bool[](2);
+        voting[0] = true;
+        voting[1] = true;
+
+        IHybridVotingInit.ClassConfig[] memory classes = _buildLegacyClasses(50, 50, false, 4 ether);
+        OrgDeployer.RoleAssignments memory roleAssignments = _buildDefaultRoleAssignments();
+        address[] memory ddTargets = new address[](0);
+
+        OrgDeployer.DeploymentParams memory params = OrgDeployer.DeploymentParams({
+            orgId: orgId,
+            orgName: "Compat DAO",
+            metadataHash: bytes32(0),
+            registryAddr: accountRegProxy,
+            deployerAddress: orgOwner,
+            deployerUsername: "",
+            regDeadline: 0,
+            regNonce: 0,
+            regSignature: "",
+            autoUpgrade: true,
+            hybridQuorumPct: 50,
+            ddQuorumPct: 50,
+            hybridClasses: classes,
+            ddInitialTargets: ddTargets,
+            roles: _buildSimpleRoleConfigs(names, images, voting),
+            roleAssignments: roleAssignments,
+            metadataAdminRoleIndex: type(uint256).max,
+            passkeyEnabled: false,
+            educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
+        });
+
+        vm.prank(orgOwner);
+        deployer.deployFullOrg(params); // No msg.value, should use simple registerOrg path
+
+        // Verify org is registered
+        PaymasterHub.OrgConfig memory orgConfig = paymasterHub.getOrgConfig(orgId);
+        assertTrue(orgConfig.adminHatId != 0, "Org should be registered with PaymasterHub");
+
+        // Verify no deposits
+        PaymasterHub.OrgFinancials memory financials = paymasterHub.getOrgFinancials(orgId);
+        assertEq(financials.deposited, 0, "No deposit should be recorded");
+
+        // Verify operator hat is 0 (skipped)
+        assertEq(orgConfig.operatorHatId, 0, "Operator hat should be 0 when skipped");
+    }
+
+    function testDeployFullOrgPaymasterOperatorOnly() public {
+        // Setting operator role without other config should use simple registerOrg path
+        bytes32 orgId = keccak256("OPERATOR-ONLY-ORG");
+
+        string[] memory names = new string[](2);
+        names[0] = "DEFAULT";
+        names[1] = "EXECUTIVE";
+        string[] memory images = new string[](2);
+        images[0] = "";
+        images[1] = "";
+        bool[] memory voting = new bool[](2);
+        voting[0] = true;
+        voting[1] = true;
+
+        IHybridVotingInit.ClassConfig[] memory classes = _buildLegacyClasses(50, 50, false, 4 ether);
+        OrgDeployer.RoleAssignments memory roleAssignments = _buildDefaultRoleAssignments();
+        address[] memory ddTargets = new address[](0);
+
+        // Only set operator role, nothing else
+        OrgDeployer.PaymasterConfig memory pmConfig = OrgDeployer.PaymasterConfig({
+            operatorRoleIndex: 1, // EXECUTIVE
+            autoWhitelistContracts: false,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            maxCallGas: 0,
+            maxVerificationGas: 0,
+            maxPreVerificationGas: 0,
+            defaultBudgetCapPerEpoch: 0,
+            defaultBudgetEpochLen: 0
+        });
+
+        OrgDeployer.DeploymentParams memory params = OrgDeployer.DeploymentParams({
+            orgId: orgId,
+            orgName: "Operator Only DAO",
+            metadataHash: bytes32(0),
+            registryAddr: accountRegProxy,
+            deployerAddress: orgOwner,
+            deployerUsername: "",
+            regDeadline: 0,
+            regNonce: 0,
+            regSignature: "",
+            autoUpgrade: true,
+            hybridQuorumPct: 50,
+            ddQuorumPct: 50,
+            hybridClasses: classes,
+            ddInitialTargets: ddTargets,
+            roles: _buildSimpleRoleConfigs(names, images, voting),
+            roleAssignments: roleAssignments,
+            metadataAdminRoleIndex: type(uint256).max,
+            passkeyEnabled: false,
+            educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: pmConfig
+        });
+
+        vm.prank(orgOwner);
+        deployer.deployFullOrg(params); // No ETH, no fee caps, no whitelist → registerOrg path
+
+        // Verify operator hat is set via the simple registerOrg path
+        PaymasterHub.OrgConfig memory orgConfig = paymasterHub.getOrgConfig(orgId);
+        assertTrue(orgConfig.adminHatId != 0, "Org should be registered");
+        assertTrue(orgConfig.operatorHatId != 0, "Operator hat should be set even via registerOrg path");
+
+        // Verify no fee caps (should be default zeros)
+        PaymasterHub.FeeCaps memory feeCaps = paymasterHub.getFeeCaps(orgId);
+        assertEq(feeCaps.maxFeePerGas, 0, "No fee caps should be set");
+    }
+
+    function testDeployFullOrgAutoWhitelistNoEducation() public {
+        // Auto-whitelist with education disabled should produce 23 rules (not 24)
+        bytes32 orgId = keccak256("NO-EDU-WHITELIST-ORG");
+
+        string[] memory names = new string[](2);
+        names[0] = "DEFAULT";
+        names[1] = "EXECUTIVE";
+        string[] memory images = new string[](2);
+        images[0] = "";
+        images[1] = "";
+        bool[] memory voting = new bool[](2);
+        voting[0] = true;
+        voting[1] = true;
+
+        IHybridVotingInit.ClassConfig[] memory classes = _buildLegacyClasses(50, 50, false, 4 ether);
+        OrgDeployer.RoleAssignments memory roleAssignments = _buildDefaultRoleAssignments();
+        address[] memory ddTargets = new address[](0);
+
+        OrgDeployer.PaymasterConfig memory pmConfig = OrgDeployer.PaymasterConfig({
+            operatorRoleIndex: type(uint256).max,
+            autoWhitelistContracts: true,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            maxCallGas: 0,
+            maxVerificationGas: 0,
+            maxPreVerificationGas: 0,
+            defaultBudgetCapPerEpoch: 0,
+            defaultBudgetEpochLen: 0
+        });
+
+        OrgDeployer.DeploymentParams memory params = OrgDeployer.DeploymentParams({
+            orgId: orgId,
+            orgName: "No Edu Whitelist DAO",
+            metadataHash: bytes32(0),
+            registryAddr: accountRegProxy,
+            deployerAddress: orgOwner,
+            deployerUsername: "",
+            regDeadline: 0,
+            regNonce: 0,
+            regSignature: "",
+            autoUpgrade: true,
+            hybridQuorumPct: 50,
+            ddQuorumPct: 50,
+            hybridClasses: classes,
+            ddInitialTargets: ddTargets,
+            roles: _buildSimpleRoleConfigs(names, images, voting),
+            roleAssignments: roleAssignments,
+            metadataAdminRoleIndex: type(uint256).max,
+            passkeyEnabled: false,
+            educationHubConfig: ModulesFactory.EducationHubConfig({enabled: false}),
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: pmConfig
+        });
+
+        vm.prank(orgOwner);
+        OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg(params);
+
+        // Core contract rules should still be set
+        PaymasterHub.Rule memory rule;
+
+        rule = paymasterHub.getRule(orgId, result.quickJoin, bytes4(keccak256("quickJoinNoUser()")));
+        assertTrue(rule.allowed, "QuickJoin should be whitelisted");
+
+        rule = paymasterHub.getRule(orgId, result.taskManager, bytes4(keccak256("claimTask(uint256)")));
+        assertTrue(rule.allowed, "TaskManager should be whitelisted");
+
+        rule = paymasterHub.getRule(orgId, result.hybridVoting, bytes4(keccak256("vote(uint256,uint8[],uint8[])")));
+        assertTrue(rule.allowed, "HybridVoting should be whitelisted");
+
+        // EducationHub should NOT be whitelisted (disabled)
+        // educationHub address is zero when disabled, so checking rule on address(0) is meaningless
+        // Instead, verify the org was registered successfully
+        PaymasterHub.OrgConfig memory orgConfig = paymasterHub.getOrgConfig(orgId);
+        assertTrue(orgConfig.adminHatId != 0, "Org should be registered");
+    }
+
+    function testDeployFullOrgPaymasterFullConfig() public {
+        // All paymaster options together: funding + fee caps + auto-whitelist + operator hat
+        bytes32 orgId = keccak256("FULL-CONFIG-ORG");
+
+        string[] memory names = new string[](2);
+        names[0] = "DEFAULT";
+        names[1] = "EXECUTIVE";
+        string[] memory images = new string[](2);
+        images[0] = "";
+        images[1] = "";
+        bool[] memory voting = new bool[](2);
+        voting[0] = true;
+        voting[1] = true;
+
+        IHybridVotingInit.ClassConfig[] memory classes = _buildLegacyClasses(50, 50, false, 4 ether);
+        OrgDeployer.RoleAssignments memory roleAssignments = _buildDefaultRoleAssignments();
+        address[] memory ddTargets = new address[](0);
+
+        OrgDeployer.PaymasterConfig memory pmConfig = OrgDeployer.PaymasterConfig({
+            operatorRoleIndex: 1, // EXECUTIVE
+            autoWhitelistContracts: true,
+            maxFeePerGas: 50 gwei,
+            maxPriorityFeePerGas: 1 gwei,
+            maxCallGas: 300_000,
+            maxVerificationGas: 150_000,
+            maxPreVerificationGas: 50_000,
+            defaultBudgetCapPerEpoch: 0,
+            defaultBudgetEpochLen: 0
+        });
+
+        OrgDeployer.DeploymentParams memory params = OrgDeployer.DeploymentParams({
+            orgId: orgId,
+            orgName: "Full Config DAO",
+            metadataHash: bytes32(0),
+            registryAddr: accountRegProxy,
+            deployerAddress: orgOwner,
+            deployerUsername: "",
+            regDeadline: 0,
+            regNonce: 0,
+            regSignature: "",
+            autoUpgrade: true,
+            hybridQuorumPct: 50,
+            ddQuorumPct: 50,
+            hybridClasses: classes,
+            ddInitialTargets: ddTargets,
+            roles: _buildSimpleRoleConfigs(names, images, voting),
+            roleAssignments: roleAssignments,
+            metadataAdminRoleIndex: type(uint256).max,
+            passkeyEnabled: false,
+            educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: pmConfig
+        });
+
+        vm.deal(orgOwner, 1 ether);
+        vm.prank(orgOwner);
+        OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg{value: 0.2 ether}(params);
+
+        // 1. Verify operator hat
+        PaymasterHub.OrgConfig memory orgConfig = paymasterHub.getOrgConfig(orgId);
+        assertTrue(orgConfig.operatorHatId != 0, "Operator hat should be set");
+
+        // 2. Verify fee caps
+        PaymasterHub.FeeCaps memory feeCaps = paymasterHub.getFeeCaps(orgId);
+        assertEq(feeCaps.maxFeePerGas, 50 gwei);
+        assertEq(feeCaps.maxPriorityFeePerGas, 1 gwei);
+        assertEq(feeCaps.maxCallGas, 300_000);
+
+        // 3. Verify auto-whitelist (spot check)
+        PaymasterHub.Rule memory rule =
+            paymasterHub.getRule(orgId, result.quickJoin, bytes4(keccak256("quickJoinNoUser()")));
+        assertTrue(rule.allowed, "QuickJoin should be whitelisted");
+
+        rule = paymasterHub.getRule(orgId, result.taskManager, bytes4(keccak256("submitTask(uint256,bytes32)")));
+        assertTrue(rule.allowed, "TaskManager submitTask should be whitelisted");
+
+        // 4. Verify deposit
+        PaymasterHub.OrgFinancials memory financials = paymasterHub.getOrgFinancials(orgId);
+        assertEq(financials.deposited, 0.2 ether, "Deposit should be 0.2 ETH");
+    }
+
+    function testPaymasterSelectorAccuracy() public {
+        // Verify ALL computed selectors match actual contract function selectors
+        // This catches selector string typos in _buildDefaultPaymasterRules
+
+        // ── QuickJoin (5) ──
+        assertEq(
+            bytes4(keccak256("quickJoinNoUser()")),
+            QuickJoin.quickJoinNoUser.selector,
+            "quickJoinNoUser selector mismatch"
+        );
+        assertEq(
+            bytes4(keccak256("quickJoinWithUser()")),
+            QuickJoin.quickJoinWithUser.selector,
+            "quickJoinWithUser selector mismatch"
+        );
+        assertEq(
+            bytes4(keccak256("quickJoinWithPasskey((bytes32,bytes32,bytes32,uint256))")),
+            QuickJoin.quickJoinWithPasskey.selector,
+            "quickJoinWithPasskey selector mismatch"
+        );
+        assertEq(
+            bytes4(keccak256("registerAndQuickJoin(address,string,uint256,uint256,bytes)")),
+            QuickJoin.registerAndQuickJoin.selector,
+            "registerAndQuickJoin selector mismatch"
+        );
+        assertEq(
+            bytes4(
+                keccak256(
+                    "registerAndQuickJoinWithPasskey((bytes32,bytes32,bytes32,uint256),string,uint256,uint256,(bytes,bytes,uint256,uint256,bytes32,bytes32))"
+                )
+            ),
+            QuickJoin.registerAndQuickJoinWithPasskey.selector,
+            "registerAndQuickJoinWithPasskey selector mismatch"
+        );
+
+        // ── TaskManager (9) ──
+        assertEq(
+            bytes4(keccak256("createTask(uint256,bytes,bytes32,bytes32,address,uint256,bool)")),
+            TaskManager.createTask.selector,
+            "createTask selector mismatch"
+        );
+        assertEq(bytes4(keccak256("claimTask(uint256)")), TaskManager.claimTask.selector, "claimTask selector mismatch");
+        assertEq(
+            bytes4(keccak256("submitTask(uint256,bytes32)")),
+            TaskManager.submitTask.selector,
+            "submitTask selector mismatch"
+        );
+        assertEq(
+            bytes4(keccak256("completeTask(uint256)")),
+            TaskManager.completeTask.selector,
+            "completeTask selector mismatch"
+        );
+        assertEq(
+            bytes4(keccak256("applyForTask(uint256,bytes32)")),
+            TaskManager.applyForTask.selector,
+            "applyForTask selector mismatch"
+        );
+        assertEq(
+            bytes4(keccak256("approveApplication(uint256,address)")),
+            TaskManager.approveApplication.selector,
+            "approveApplication selector mismatch"
+        );
+        assertEq(
+            bytes4(keccak256("assignTask(uint256,address)")),
+            TaskManager.assignTask.selector,
+            "assignTask selector mismatch"
+        );
+        assertEq(
+            bytes4(keccak256("rejectTask(uint256,bytes32)")),
+            TaskManager.rejectTask.selector,
+            "rejectTask selector mismatch"
+        );
+        assertEq(
+            bytes4(keccak256("cancelTask(uint256)")), TaskManager.cancelTask.selector, "cancelTask selector mismatch"
+        );
+
+        // ── HybridVoting (3) ──
+        assertEq(
+            bytes4(keccak256("vote(uint256,uint8[],uint8[])")),
+            HybridVoting.vote.selector,
+            "HybridVoting vote selector mismatch"
+        );
+        assertEq(
+            bytes4(keccak256("announceWinner(uint256)")),
+            HybridVoting.announceWinner.selector,
+            "HybridVoting announceWinner selector mismatch"
+        );
+        assertEq(
+            bytes4(keccak256("createProposal(bytes,bytes32,uint32,uint8,(address,uint256,bytes)[][],uint256[])")),
+            HybridVoting.createProposal.selector,
+            "HybridVoting createProposal selector mismatch"
+        );
+
+        // ── DirectDemocracyVoting (3) ──
+        assertEq(
+            bytes4(keccak256("vote(uint256,uint8[],uint8[])")),
+            DirectDemocracyVoting.vote.selector,
+            "DDVoting vote selector mismatch"
+        );
+        assertEq(
+            bytes4(keccak256("announceWinner(uint256)")),
+            DirectDemocracyVoting.announceWinner.selector,
+            "DDVoting announceWinner selector mismatch"
+        );
+        assertEq(
+            bytes4(keccak256("createProposal(bytes,bytes32,uint32,uint8,(address,uint256,bytes)[][],uint256[])")),
+            DirectDemocracyVoting.createProposal.selector,
+            "DDVoting createProposal selector mismatch"
+        );
+
+        // ── PaymentManager (3) ──
+        assertEq(
+            bytes4(keccak256("claimDistribution(uint256,uint256,bytes32[])")),
+            PaymentManager.claimDistribution.selector,
+            "claimDistribution selector mismatch"
+        );
+        assertEq(
+            bytes4(keccak256("claimMultiple(uint256[],uint256[],bytes32[][])")),
+            PaymentManager.claimMultiple.selector,
+            "claimMultiple selector mismatch"
+        );
+        assertEq(bytes4(keccak256("optOut(bool)")), PaymentManager.optOut.selector, "optOut selector mismatch");
+
+        // ── EducationHub (1) ──
+        assertEq(
+            bytes4(keccak256("completeModule(uint256,uint8)")),
+            EducationHub.completeModule.selector,
+            "completeModule selector mismatch"
+        );
+    }
+
+    function testDeployFullOrgWithBudgets() public {
+        bytes32 orgId = keccak256("BUDGET-ORG");
+
+        string[] memory names = new string[](2);
+        names[0] = "DEFAULT";
+        names[1] = "EXECUTIVE";
+        string[] memory images = new string[](2);
+        images[0] = "";
+        images[1] = "";
+        bool[] memory voting = new bool[](2);
+        voting[0] = true;
+        voting[1] = true;
+
+        IHybridVotingInit.ClassConfig[] memory classes = _buildLegacyClasses(50, 50, false, 4 ether);
+        OrgDeployer.RoleAssignments memory roleAssignments = _buildDefaultRoleAssignments();
+        address[] memory ddTargets = new address[](0);
+
+        OrgDeployer.PaymasterConfig memory pmConfig = OrgDeployer.PaymasterConfig({
+            operatorRoleIndex: 1,
+            autoWhitelistContracts: false,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            maxCallGas: 0,
+            maxVerificationGas: 0,
+            maxPreVerificationGas: 0,
+            defaultBudgetCapPerEpoch: 0.1 ether,
+            defaultBudgetEpochLen: 1 days
+        });
+
+        OrgDeployer.DeploymentParams memory params = OrgDeployer.DeploymentParams({
+            orgId: orgId,
+            orgName: "Budget DAO",
+            metadataHash: bytes32(0),
+            registryAddr: accountRegProxy,
+            deployerAddress: orgOwner,
+            deployerUsername: "",
+            regDeadline: 0,
+            regNonce: 0,
+            regSignature: "",
+            autoUpgrade: true,
+            hybridQuorumPct: 50,
+            ddQuorumPct: 50,
+            hybridClasses: classes,
+            ddInitialTargets: ddTargets,
+            roles: _buildSimpleRoleConfigs(names, images, voting),
+            roleAssignments: roleAssignments,
+            metadataAdminRoleIndex: type(uint256).max,
+            passkeyEnabled: false,
+            educationHubConfig: ModulesFactory.EducationHubConfig({enabled: false}),
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: pmConfig
+        });
+
+        vm.deal(orgOwner, 1 ether);
+        vm.prank(orgOwner);
+        deployer.deployFullOrg{value: 0.05 ether}(params);
+
+        // Verify budget set for each role hat (2 roles)
+        for (uint256 i = 0; i < 2; i++) {
+            uint256 hatId = orgRegistry.getRoleHat(orgId, i);
+            bytes32 subjectKey = keccak256(abi.encodePacked(uint8(0x01), bytes20(uint160(hatId))));
+            PaymasterHub.Budget memory budget = paymasterHub.getBudget(orgId, subjectKey);
+            assertEq(budget.capPerEpoch, 0.1 ether, "Budget cap should match");
+            assertEq(budget.epochLen, 1 days, "Epoch length should match");
+            assertTrue(budget.epochStart > 0, "Epoch start should be initialized");
+        }
+
+        // Verify deposit was also credited
+        PaymasterHub.OrgFinancials memory financials = paymasterHub.getOrgFinancials(orgId);
+        assertEq(financials.deposited, 0.05 ether, "Org should have 0.05 ETH deposited");
+    }
+
+    function testDeployFullOrgBudgetsWithFullConfig() public {
+        bytes32 orgId = keccak256("BUDGET-FULL-ORG");
+
+        string[] memory names = new string[](3);
+        names[0] = "MEMBER";
+        names[1] = "MODERATOR";
+        names[2] = "ADMIN";
+        string[] memory images = new string[](3);
+        images[0] = "";
+        images[1] = "";
+        images[2] = "";
+        bool[] memory voting = new bool[](3);
+        voting[0] = true;
+        voting[1] = true;
+        voting[2] = true;
+
+        IHybridVotingInit.ClassConfig[] memory classes = _buildLegacyClasses(50, 50, false, 4 ether);
+        OrgDeployer.RoleAssignments memory roleAssignments = _buildDefaultRoleAssignments();
+        address[] memory ddTargets = new address[](0);
+
+        OrgDeployer.PaymasterConfig memory pmConfig = OrgDeployer.PaymasterConfig({
+            operatorRoleIndex: 2, // ADMIN role
+            autoWhitelistContracts: true,
+            maxFeePerGas: 100 gwei,
+            maxPriorityFeePerGas: 2 gwei,
+            maxCallGas: 500_000,
+            maxVerificationGas: 200_000,
+            maxPreVerificationGas: 100_000,
+            defaultBudgetCapPerEpoch: 0.5 ether,
+            defaultBudgetEpochLen: 7 days
+        });
+
+        OrgDeployer.DeploymentParams memory params = OrgDeployer.DeploymentParams({
+            orgId: orgId,
+            orgName: "Budget Full DAO",
+            metadataHash: bytes32(0),
+            registryAddr: accountRegProxy,
+            deployerAddress: orgOwner,
+            deployerUsername: "",
+            regDeadline: 0,
+            regNonce: 0,
+            regSignature: "",
+            autoUpgrade: true,
+            hybridQuorumPct: 50,
+            ddQuorumPct: 50,
+            hybridClasses: classes,
+            ddInitialTargets: ddTargets,
+            roles: _buildSimpleRoleConfigs(names, images, voting),
+            roleAssignments: roleAssignments,
+            metadataAdminRoleIndex: type(uint256).max,
+            passkeyEnabled: false,
+            educationHubConfig: ModulesFactory.EducationHubConfig({enabled: true}),
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: pmConfig
+        });
+
+        vm.deal(orgOwner, 1 ether);
+        vm.prank(orgOwner);
+        OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg{value: 0.1 ether}(params);
+
+        // Verify budgets for all 3 role hats
+        for (uint256 i = 0; i < 3; i++) {
+            uint256 hatId = orgRegistry.getRoleHat(orgId, i);
+            bytes32 subjectKey = keccak256(abi.encodePacked(uint8(0x01), bytes20(uint160(hatId))));
+            PaymasterHub.Budget memory budget = paymasterHub.getBudget(orgId, subjectKey);
+            assertEq(budget.capPerEpoch, 0.5 ether, "Budget cap should match for each role");
+            assertEq(budget.epochLen, 7 days, "Epoch length should be 7 days for each role");
+        }
+
+        // Verify fee caps also set
+        PaymasterHub.FeeCaps memory feeCaps = paymasterHub.getFeeCaps(orgId);
+        assertEq(feeCaps.maxFeePerGas, 100 gwei, "maxFeePerGas should be set");
+
+        // Verify whitelist rules also set
+        PaymasterHub.Rule memory rule =
+            paymasterHub.getRule(orgId, result.quickJoin, bytes4(keccak256("quickJoinNoUser()")));
+        assertTrue(rule.allowed, "QuickJoin should be whitelisted");
+
+        // Verify deposit
+        PaymasterHub.OrgFinancials memory financials = paymasterHub.getOrgFinancials(orgId);
+        assertEq(financials.deposited, 0.1 ether, "Should have 0.1 ETH deposited");
+    }
+
+    function testDeployFullOrgNoBudgetsBackwardsCompat() public {
+        // Ensure zero budget config doesn't create any budgets
+        bytes32 orgId = keccak256("NO-BUDGET-ORG");
+
+        string[] memory names = new string[](2);
+        names[0] = "DEFAULT";
+        names[1] = "EXECUTIVE";
+        string[] memory images = new string[](2);
+        images[0] = "";
+        images[1] = "";
+        bool[] memory voting = new bool[](2);
+        voting[0] = true;
+        voting[1] = true;
+
+        IHybridVotingInit.ClassConfig[] memory classes = _buildLegacyClasses(50, 50, false, 4 ether);
+        OrgDeployer.RoleAssignments memory roleAssignments = _buildDefaultRoleAssignments();
+        address[] memory ddTargets = new address[](0);
+
+        OrgDeployer.DeploymentParams memory params = OrgDeployer.DeploymentParams({
+            orgId: orgId,
+            orgName: "No Budget DAO",
+            metadataHash: bytes32(0),
+            registryAddr: accountRegProxy,
+            deployerAddress: orgOwner,
+            deployerUsername: "",
+            regDeadline: 0,
+            regNonce: 0,
+            regSignature: "",
+            autoUpgrade: true,
+            hybridQuorumPct: 50,
+            ddQuorumPct: 50,
+            hybridClasses: classes,
+            ddInitialTargets: ddTargets,
+            roles: _buildSimpleRoleConfigs(names, images, voting),
+            roleAssignments: roleAssignments,
+            metadataAdminRoleIndex: type(uint256).max,
+            passkeyEnabled: false,
+            educationHubConfig: ModulesFactory.EducationHubConfig({enabled: false}),
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: _defaultPaymasterConfig()
+        });
+
+        vm.prank(orgOwner);
+        deployer.deployFullOrg(params);
+
+        // Verify no budgets set (2 roles)
+        for (uint256 i = 0; i < 2; i++) {
+            uint256 hatId = orgRegistry.getRoleHat(orgId, i);
+            bytes32 subjectKey = keccak256(abi.encodePacked(uint8(0x01), bytes20(uint160(hatId))));
+            PaymasterHub.Budget memory budget = paymasterHub.getBudget(orgId, subjectKey);
+            assertEq(budget.capPerEpoch, 0, "Budget cap should be 0");
+            assertEq(budget.epochLen, 0, "Epoch length should be 0");
+        }
+    }
+
+    function testDeployFullOrgBudgetOnlyConfig() public {
+        // Budget is the ONLY config — no fee caps, no whitelist, no ETH
+        // This tests the hasBudgets-alone path triggering registerAndConfigureOrg
+        bytes32 orgId = keccak256("BUDGET-ONLY-ORG");
+
+        string[] memory names = new string[](2);
+        names[0] = "DEFAULT";
+        names[1] = "EXECUTIVE";
+        string[] memory images = new string[](2);
+        images[0] = "";
+        images[1] = "";
+        bool[] memory voting = new bool[](2);
+        voting[0] = true;
+        voting[1] = true;
+
+        IHybridVotingInit.ClassConfig[] memory classes = _buildLegacyClasses(50, 50, false, 4 ether);
+        OrgDeployer.RoleAssignments memory roleAssignments = _buildDefaultRoleAssignments();
+        address[] memory ddTargets = new address[](0);
+
+        OrgDeployer.PaymasterConfig memory pmConfig = OrgDeployer.PaymasterConfig({
+            operatorRoleIndex: type(uint256).max,
+            autoWhitelistContracts: false,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            maxCallGas: 0,
+            maxVerificationGas: 0,
+            maxPreVerificationGas: 0,
+            defaultBudgetCapPerEpoch: 0.05 ether,
+            defaultBudgetEpochLen: 12 hours
+        });
+
+        OrgDeployer.DeploymentParams memory params = OrgDeployer.DeploymentParams({
+            orgId: orgId,
+            orgName: "Budget Only DAO",
+            metadataHash: bytes32(0),
+            registryAddr: accountRegProxy,
+            deployerAddress: orgOwner,
+            deployerUsername: "",
+            regDeadline: 0,
+            regNonce: 0,
+            regSignature: "",
+            autoUpgrade: true,
+            hybridQuorumPct: 50,
+            ddQuorumPct: 50,
+            hybridClasses: classes,
+            ddInitialTargets: ddTargets,
+            roles: _buildSimpleRoleConfigs(names, images, voting),
+            roleAssignments: roleAssignments,
+            metadataAdminRoleIndex: type(uint256).max,
+            passkeyEnabled: false,
+            educationHubConfig: ModulesFactory.EducationHubConfig({enabled: false}),
+            bootstrap: _emptyBootstrap(),
+            paymasterConfig: pmConfig
+        });
+
+        // No ETH sent — budgets are the only config
+        vm.prank(orgOwner);
+        deployer.deployFullOrg(params);
+
+        // Verify budgets set for each role hat
+        for (uint256 i = 0; i < 2; i++) {
+            uint256 hatId = orgRegistry.getRoleHat(orgId, i);
+            bytes32 subjectKey = keccak256(abi.encodePacked(uint8(0x01), bytes20(uint160(hatId))));
+            PaymasterHub.Budget memory budget = paymasterHub.getBudget(orgId, subjectKey);
+            assertEq(budget.capPerEpoch, 0.05 ether, "Budget cap should match");
+            assertEq(budget.epochLen, 12 hours, "Epoch length should be 12 hours");
+            assertTrue(budget.epochStart > 0, "Epoch start should be initialized");
+        }
+
+        // Verify no deposit
+        PaymasterHub.OrgFinancials memory financials = paymasterHub.getOrgFinancials(orgId);
+        assertEq(financials.deposited, 0, "Should have no deposit");
+
+        // Verify no whitelist rules
+        PaymasterHub.Rule memory rule = paymasterHub.getRule(orgId, address(1), bytes4(keccak256("quickJoinNoUser()")));
+        assertFalse(rule.allowed, "No rules should be set");
+    }
+
+    function testRegisterAndConfigureOrgBudgetEpochTooLong() public {
+        // Epoch > MAX_EPOCH_LENGTH (365 days) should revert
+        bytes32 orgId = keccak256("BUDGET-LONG-EPOCH-ORG");
+
+        bytes32[] memory keys = new bytes32[](1);
+        keys[0] = keccak256(abi.encodePacked(uint8(0x01), bytes20(uint160(123))));
+        uint128[] memory caps = new uint128[](1);
+        caps[0] = 0.1 ether;
+        uint32[] memory epochLens = new uint32[](1);
+        epochLens[0] = 366 days; // Above MAX_EPOCH_LENGTH (365 days)
+
+        PaymasterHub.DeployConfig memory config = PaymasterHub.DeployConfig({
+            operatorHatId: 0,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            maxCallGas: 0,
+            maxVerificationGas: 0,
+            maxPreVerificationGas: 0,
+            ruleTargets: new address[](0),
+            ruleSelectors: new bytes4[](0),
+            ruleAllowed: new bool[](0),
+            ruleMaxCallGasHints: new uint32[](0),
+            budgetSubjectKeys: keys,
+            budgetCapsPerEpoch: caps,
+            budgetEpochLens: epochLens
+        });
+
+        vm.prank(address(poaManager));
+        vm.expectRevert(abi.encodeWithSignature("InvalidEpochLength()"));
+        paymasterHub.registerAndConfigureOrg(orgId, 1, config);
+    }
+
+    function testRegisterAndConfigureOrgBudgetArrayMismatch() public {
+        // Mismatched budget array lengths should revert
+        bytes32 orgId = keccak256("BUDGET-MISMATCH-ORG");
+
+        bytes32[] memory keys = new bytes32[](2);
+        keys[0] = keccak256(abi.encodePacked(uint8(0x01), bytes20(uint160(123))));
+        keys[1] = keccak256(abi.encodePacked(uint8(0x01), bytes20(uint160(456))));
+        uint128[] memory caps = new uint128[](1); // Length mismatch!
+        caps[0] = 0.1 ether;
+        uint32[] memory epochLens = new uint32[](2);
+        epochLens[0] = 1 days;
+        epochLens[1] = 1 days;
+
+        PaymasterHub.DeployConfig memory config = PaymasterHub.DeployConfig({
+            operatorHatId: 0,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            maxCallGas: 0,
+            maxVerificationGas: 0,
+            maxPreVerificationGas: 0,
+            ruleTargets: new address[](0),
+            ruleSelectors: new bytes4[](0),
+            ruleAllowed: new bool[](0),
+            ruleMaxCallGasHints: new uint32[](0),
+            budgetSubjectKeys: keys,
+            budgetCapsPerEpoch: caps,
+            budgetEpochLens: epochLens
+        });
+
+        vm.prank(address(poaManager));
+        vm.expectRevert(abi.encodeWithSignature("ArrayLengthMismatch()"));
+        paymasterHub.registerAndConfigureOrg(orgId, 1, config);
+    }
+
+    function testRegisterAndConfigureOrgBudgetInvalidEpoch() public {
+        // Invalid epoch length should revert
+        bytes32 orgId = keccak256("BUDGET-EPOCH-ORG");
+
+        bytes32[] memory keys = new bytes32[](1);
+        keys[0] = keccak256(abi.encodePacked(uint8(0x01), bytes20(uint160(123))));
+        uint128[] memory caps = new uint128[](1);
+        caps[0] = 0.1 ether;
+        uint32[] memory epochLens = new uint32[](1);
+        epochLens[0] = 30 minutes; // Below MIN_EPOCH_LENGTH (1 hour)
+
+        PaymasterHub.DeployConfig memory config = PaymasterHub.DeployConfig({
+            operatorHatId: 0,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            maxCallGas: 0,
+            maxVerificationGas: 0,
+            maxPreVerificationGas: 0,
+            ruleTargets: new address[](0),
+            ruleSelectors: new bytes4[](0),
+            ruleAllowed: new bool[](0),
+            ruleMaxCallGasHints: new uint32[](0),
+            budgetSubjectKeys: keys,
+            budgetCapsPerEpoch: caps,
+            budgetEpochLens: epochLens
+        });
+
+        vm.prank(address(poaManager));
+        vm.expectRevert(abi.encodeWithSignature("InvalidEpochLength()"));
+        paymasterHub.registerAndConfigureOrg(orgId, 1, config);
+    }
+
+    function testRegisterAndConfigureOrgUnauthorized() public {
+        // Non-registrar cannot call registerAndConfigureOrg directly
+        bytes32 orgId = keccak256("UNAUTH-ORG");
+
+        PaymasterHub.DeployConfig memory config = PaymasterHub.DeployConfig({
+            operatorHatId: 0,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            maxCallGas: 0,
+            maxVerificationGas: 0,
+            maxPreVerificationGas: 0,
+            ruleTargets: new address[](0),
+            ruleSelectors: new bytes4[](0),
+            ruleAllowed: new bool[](0),
+            ruleMaxCallGasHints: new uint32[](0),
+            budgetSubjectKeys: new bytes32[](0),
+            budgetCapsPerEpoch: new uint128[](0),
+            budgetEpochLens: new uint32[](0)
+        });
+
+        // Random address should be rejected
+        vm.prank(address(0xBEEF));
+        vm.expectRevert(abi.encodeWithSignature("NotPoaManager()"));
+        paymasterHub.registerAndConfigureOrg(orgId, 1, config);
+    }
+
+    function testRegisterAndConfigureOrgRuleArrayMismatch() public {
+        // Mismatched rule array lengths should revert
+        bytes32 orgId = keccak256("MISMATCH-ORG");
+
+        address[] memory targets = new address[](2);
+        targets[0] = address(1);
+        targets[1] = address(2);
+        bytes4[] memory sels = new bytes4[](1); // Length mismatch!
+        sels[0] = bytes4(0x12345678);
+
+        PaymasterHub.DeployConfig memory config = PaymasterHub.DeployConfig({
+            operatorHatId: 0,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            maxCallGas: 0,
+            maxVerificationGas: 0,
+            maxPreVerificationGas: 0,
+            ruleTargets: targets,
+            ruleSelectors: sels,
+            ruleAllowed: new bool[](2),
+            ruleMaxCallGasHints: new uint32[](2),
+            budgetSubjectKeys: new bytes32[](0),
+            budgetCapsPerEpoch: new uint128[](0),
+            budgetEpochLens: new uint32[](0)
+        });
+
+        // Call as poaManager (authorized)
+        vm.prank(address(poaManager));
+        vm.expectRevert(abi.encodeWithSignature("ArrayLengthMismatch()"));
+        paymasterHub.registerAndConfigureOrg(orgId, 1, config);
     }
 }


### PR DESCRIPTION
## Summary

Enable orgs to deploy fully operational with a configured paymaster in a single atomic transaction. Users can now set funding, operator hat, fee caps, budget limits, and auto-whitelist contracts all via `deployFullOrg`. Fixed three selector bugs in auto-whitelist rules.

## Changes

- **PaymasterHub**: Add `DeployConfig` struct with budget arrays; implement `registerAndConfigureOrg` for deploy-time setup with validation
- **OrgDeployer**: Add `PaymasterConfig` with funding, operator, fee caps, and per-role-hat budget config; build budgets using `SUBJECT_TYPE_HAT` subject keys
- **Auto-whitelist**: 24 user-facing functions across QuickJoin, TaskManager, HybridVoting, DirectDemocracyVoting, PaymentManager, EducationHub
- **Bug fixes**: Correct selectors for `registerAndQuickJoinWithPasskey` (WebAuthnAuth struct), `createProposal` on both voting contracts (IExecutor.Call value field)
- **Tests**: Add 7 budget tests + edge cases; expand `testPaymasterSelectorAccuracy` to verify all 24 selectors against actual `.selector` values
- **Backwards compatible**: Zero config uses simple `registerOrg` path; zero budget fields skip budget creation

## Test Coverage

All 75 deployer tests pass (no new failures). New tests:
- `testDeployFullOrgWithBudgets` — per-role-hat budgets
- `testDeployFullOrgBudgetsWithFullConfig` — budgets + whitelist + fee caps
- `testDeployFullOrgNoBudgetsBackwardsCompat` — zero config compatibility
- `testDeployFullOrgBudgetOnlyConfig` — budgets as sole config trigger
- `testRegisterAndConfigureOrgBudgetArrayMismatch` — array length validation
- `testRegisterAndConfigureOrgBudgetInvalidEpoch` — epoch range validation (min/max)
- `testRegisterAndConfigureOrgBudgetEpochTooLong` — epoch > 365 days rejection
- `testPaymasterSelectorAccuracy` — comprehensive selector verification (24 functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)