### PR TITLE
feat: expand subjectId from bytes20 to bytes32

### DIFF
--- a/src/OrgDeployer.sol
+++ b/src/OrgDeployer.sol
@@ -1014,8 +1014,8 @@ contract OrgDeployer is Initializable {
         epochLens = new uint32[](count);
 
         for (uint256 i = 0; i < count; i++) {
-            // SUBJECT_TYPE_HAT = 0x01, subjectId = bytes20(uint160(hatId))
-            subjectKeys[i] = keccak256(abi.encodePacked(uint8(0x01), bytes20(uint160(roleHatIds[i]))));
+            // SUBJECT_TYPE_HAT = 0x01, subjectId = bytes32(hatId)
+            subjectKeys[i] = keccak256(abi.encodePacked(uint8(0x01), bytes32(roleHatIds[i])));
             caps[i] = capPerEpoch;
             epochLens[i] = epochLen;
         }

--- a/src/PaymasterHub.sol
+++ b/src/PaymasterHub.sol
@@ -674,7 +674,7 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
         returns (bytes memory context, uint256 validationData)
     {
         // Decode and validate paymasterAndData
-        (uint8 version, bytes32 orgId, uint8 subjectType, bytes20 subjectId, uint32 ruleId, uint64 mailboxCommit8) =
+        (uint8 version, bytes32 orgId, uint8 subjectType, bytes32 subjectId, uint32 ruleId, uint64 mailboxCommit8) =
             _decodePaymasterData(userOp.paymasterAndData);
 
         if (version != PAYMASTER_DATA_VERSION) revert InvalidVersion();
@@ -688,7 +688,7 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
         // Handle POA onboarding separately (no org required)
         if (isOnboarding) {
             // Global-only onboarding path: never org-scoped billing.
-            if (orgId != bytes32(0) || subjectId != bytes20(0) || ruleId != RULE_ID_GENERIC) {
+            if (orgId != bytes32(0) || subjectId != bytes32(0) || ruleId != RULE_ID_GENERIC) {
                 revert InvalidOnboardingRequest();
             }
 
@@ -1548,43 +1548,43 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
             uint8 version,
             bytes32 orgId,
             uint8 subjectType,
-            bytes20 subjectId,
+            bytes32 subjectId,
             uint32 ruleId,
             uint64 mailboxCommit8
         )
     {
         // ERC-4337 v0.7 packed format:
-        // [paymaster(20) | verificationGasLimit(16) | postOpGasLimit(16) | version(1) | orgId(32) | subjectType(1) | subjectId(20) | ruleId(4) | mailboxCommit(8)]
-        // = 118 bytes total. Custom data starts at offset 52.
-        if (paymasterAndData.length < 118) revert InvalidPaymasterData();
+        // [paymaster(20) | verificationGasLimit(16) | postOpGasLimit(16) | version(1) | orgId(32) | subjectType(1) | subjectId(32) | ruleId(4) | mailboxCommit(8)]
+        // = 130 bytes total. Custom data starts at offset 52.
+        if (paymasterAndData.length < 130) revert InvalidPaymasterData();
 
         // Skip first 52 bytes (paymaster address + v0.7 gas limits) and decode the rest
         version = uint8(paymasterAndData[52]);
         orgId = bytes32(paymasterAndData[53:85]);
         subjectType = uint8(paymasterAndData[85]);
 
-        // Extract bytes20 subjectId from bytes 86-105
+        // Extract bytes32 subjectId from bytes 86-117
         assembly {
             subjectId := calldataload(add(paymasterAndData.offset, 86))
         }
 
-        // Extract ruleId from bytes 106-109
-        ruleId = uint32(bytes4(paymasterAndData[106:110]));
+        // Extract ruleId from bytes 118-121
+        ruleId = uint32(bytes4(paymasterAndData[118:122]));
 
-        // Extract mailboxCommit8 from bytes 110-117
-        mailboxCommit8 = uint64(bytes8(paymasterAndData[110:118]));
+        // Extract mailboxCommit8 from bytes 122-129
+        mailboxCommit8 = uint64(bytes8(paymasterAndData[122:130]));
     }
 
-    function _validateSubjectEligibility(address sender, uint8 subjectType, bytes20 subjectId)
+    function _validateSubjectEligibility(address sender, uint8 subjectType, bytes32 subjectId)
         private
         view
         returns (bytes32 subjectKey)
     {
         if (subjectType == SUBJECT_TYPE_ACCOUNT) {
-            if (address(subjectId) != sender) revert Ineligible();
+            if (address(uint160(uint256(subjectId))) != sender) revert Ineligible();
             subjectKey = keccak256(abi.encodePacked(subjectType, subjectId));
         } else if (subjectType == SUBJECT_TYPE_HAT) {
-            uint256 hatId = uint256(uint160(subjectId));
+            uint256 hatId = uint256(subjectId);
             IHats hatsContract = IHats(_getMainStorage().hats);
             if (!hatsContract.isEligible(sender, hatId)) {
                 revert Ineligible();

--- a/src/PaymasterHubLens.sol
+++ b/src/PaymasterHubLens.sol
@@ -160,7 +160,7 @@ contract PaymasterHubLens {
         if (cfg.paused) return (false, "Paused");
 
         // Decode paymasterAndData
-        (uint8 version, uint8 subjectType, bytes20 subjectId, uint32 ruleId,) =
+        (uint8 version, uint8 subjectType, bytes32 subjectId, uint32 ruleId,) =
             _decodePaymasterData(userOp.paymasterAndData);
 
         if (version != PAYMASTER_DATA_VERSION) return (false, "InvalidVersion");
@@ -168,10 +168,10 @@ contract PaymasterHubLens {
         // Check subject eligibility
         bytes32 subjectKey;
         if (subjectType == SUBJECT_TYPE_ACCOUNT) {
-            if (address(subjectId) != userOp.sender) return (false, "Ineligible");
+            if (address(uint160(uint256(subjectId))) != userOp.sender) return (false, "Ineligible");
             subjectKey = keccak256(abi.encodePacked(subjectType, subjectId));
         } else if (subjectType == SUBJECT_TYPE_HAT) {
-            uint256 hatId = uint256(bytes32(subjectId));
+            uint256 hatId = uint256(subjectId);
             if (!IHats(cfg.hats).isWearerOfHat(userOp.sender, hatId)) {
                 return (false, "Ineligible");
             }
@@ -209,28 +209,28 @@ contract PaymasterHubLens {
     function _decodePaymasterData(bytes calldata paymasterAndData)
         private
         pure
-        returns (uint8 version, uint8 subjectType, bytes20 subjectId, uint32 ruleId, uint64 mailboxCommit8)
+        returns (uint8 version, uint8 subjectType, bytes32 subjectId, uint32 ruleId, uint64 mailboxCommit8)
     {
         // ERC-4337 v0.7 packed format (must match PaymasterHub._decodePaymasterData):
-        // [paymaster(20) | verificationGasLimit(16) | postOpGasLimit(16) | version(1) | orgId(32) | subjectType(1) | subjectId(20) | ruleId(4) | mailboxCommit(8)]
-        // = 118 bytes total. Custom data starts at offset 52.
-        if (paymasterAndData.length < 118) revert InvalidPaymasterData();
+        // [paymaster(20) | verificationGasLimit(16) | postOpGasLimit(16) | version(1) | orgId(32) | subjectType(1) | subjectId(32) | ruleId(4) | mailboxCommit(8)]
+        // = 130 bytes total. Custom data starts at offset 52.
+        if (paymasterAndData.length < 130) revert InvalidPaymasterData();
 
         // Skip first 52 bytes (paymaster address + v0.7 gas limits) and decode the rest
         // orgId at [53:85] is skipped (not needed by Lens)
         version = uint8(paymasterAndData[52]);
         subjectType = uint8(paymasterAndData[85]);
 
-        // Extract bytes20 subjectId from bytes 86-105
+        // Extract bytes32 subjectId from bytes 86-117
         assembly {
             subjectId := calldataload(add(paymasterAndData.offset, 86))
         }
 
-        // Extract ruleId from bytes 106-109
-        ruleId = uint32(bytes4(paymasterAndData[106:110]));
+        // Extract ruleId from bytes 118-121
+        ruleId = uint32(bytes4(paymasterAndData[118:122]));
 
-        // Extract mailboxCommit8 from bytes 110-117
-        mailboxCommit8 = uint64(bytes8(paymasterAndData[110:118]));
+        // Extract mailboxCommit8 from bytes 122-129
+        mailboxCommit8 = uint64(bytes8(paymasterAndData[122:130]));
     }
 
     function _extractTargetSelector(PackedUserOperation calldata userOp, uint32 ruleId)

--- a/test/DeployerTest.t.sol
+++ b/test/DeployerTest.t.sol
@@ -5200,7 +5200,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         // Verify budget set for each role hat (2 roles)
         for (uint256 i = 0; i < 2; i++) {
             uint256 hatId = orgRegistry.getRoleHat(orgId, i);
-            bytes32 subjectKey = keccak256(abi.encodePacked(uint8(0x01), bytes20(uint160(hatId))));
+            bytes32 subjectKey = keccak256(abi.encodePacked(uint8(0x01), bytes32(hatId)));
             PaymasterHub.Budget memory budget = paymasterHub.getBudget(orgId, subjectKey);
             assertEq(budget.capPerEpoch, 0.1 ether, "Budget cap should match");
             assertEq(budget.epochLen, 1 days, "Epoch length should match");
@@ -5275,7 +5275,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         // Verify budgets for all 3 role hats
         for (uint256 i = 0; i < 3; i++) {
             uint256 hatId = orgRegistry.getRoleHat(orgId, i);
-            bytes32 subjectKey = keccak256(abi.encodePacked(uint8(0x01), bytes20(uint160(hatId))));
+            bytes32 subjectKey = keccak256(abi.encodePacked(uint8(0x01), bytes32(hatId)));
             PaymasterHub.Budget memory budget = paymasterHub.getBudget(orgId, subjectKey);
             assertEq(budget.capPerEpoch, 0.5 ether, "Budget cap should match for each role");
             assertEq(budget.epochLen, 7 days, "Epoch length should be 7 days for each role");
@@ -5343,7 +5343,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         // Verify no budgets set (2 roles)
         for (uint256 i = 0; i < 2; i++) {
             uint256 hatId = orgRegistry.getRoleHat(orgId, i);
-            bytes32 subjectKey = keccak256(abi.encodePacked(uint8(0x01), bytes20(uint160(hatId))));
+            bytes32 subjectKey = keccak256(abi.encodePacked(uint8(0x01), bytes32(hatId)));
             PaymasterHub.Budget memory budget = paymasterHub.getBudget(orgId, subjectKey);
             assertEq(budget.capPerEpoch, 0, "Budget cap should be 0");
             assertEq(budget.epochLen, 0, "Epoch length should be 0");
@@ -5412,7 +5412,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         // Verify budgets set for each role hat
         for (uint256 i = 0; i < 2; i++) {
             uint256 hatId = orgRegistry.getRoleHat(orgId, i);
-            bytes32 subjectKey = keccak256(abi.encodePacked(uint8(0x01), bytes20(uint160(hatId))));
+            bytes32 subjectKey = keccak256(abi.encodePacked(uint8(0x01), bytes32(hatId)));
             PaymasterHub.Budget memory budget = paymasterHub.getBudget(orgId, subjectKey);
             assertEq(budget.capPerEpoch, 0.05 ether, "Budget cap should match");
             assertEq(budget.epochLen, 12 hours, "Epoch length should be 12 hours");
@@ -5434,7 +5434,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         bytes32 orgId = keccak256("BUDGET-LONG-EPOCH-ORG");
 
         bytes32[] memory keys = new bytes32[](1);
-        keys[0] = keccak256(abi.encodePacked(uint8(0x01), bytes20(uint160(123))));
+        keys[0] = keccak256(abi.encodePacked(uint8(0x01), bytes32(uint256(123))));
         uint128[] memory caps = new uint128[](1);
         caps[0] = 0.1 ether;
         uint32[] memory epochLens = new uint32[](1);
@@ -5466,8 +5466,8 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         bytes32 orgId = keccak256("BUDGET-MISMATCH-ORG");
 
         bytes32[] memory keys = new bytes32[](2);
-        keys[0] = keccak256(abi.encodePacked(uint8(0x01), bytes20(uint160(123))));
-        keys[1] = keccak256(abi.encodePacked(uint8(0x01), bytes20(uint160(456))));
+        keys[0] = keccak256(abi.encodePacked(uint8(0x01), bytes32(uint256(123))));
+        keys[1] = keccak256(abi.encodePacked(uint8(0x01), bytes32(uint256(456))));
         uint128[] memory caps = new uint128[](1); // Length mismatch!
         caps[0] = 0.1 ether;
         uint32[] memory epochLens = new uint32[](2);
@@ -5500,7 +5500,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         bytes32 orgId = keccak256("BUDGET-EPOCH-ORG");
 
         bytes32[] memory keys = new bytes32[](1);
-        keys[0] = keccak256(abi.encodePacked(uint8(0x01), bytes20(uint160(123))));
+        keys[0] = keccak256(abi.encodePacked(uint8(0x01), bytes32(uint256(123))));
         uint128[] memory caps = new uint128[](1);
         caps[0] = 0.1 ether;
         uint32[] memory epochLens = new uint32[](1);

--- a/test/PasskeyPaymasterIntegration.t.sol
+++ b/test/PasskeyPaymasterIntegration.t.sol
@@ -185,7 +185,7 @@ contract PasskeyPaymasterIntegrationTest is Test {
 
     function _setupDefaultBudget(address account) internal {
         // Set a generous default budget for the account
-        bytes32 subjectKey = keccak256(abi.encodePacked(uint8(0), bytes20(account)));
+        bytes32 subjectKey = keccak256(abi.encodePacked(uint8(0), bytes32(uint256(uint160(account)))));
         vm.prank(orgAdmin);
         hub.setBudget(ORG_ID, subjectKey, 1 ether, 1 days);
     }
@@ -193,11 +193,11 @@ contract PasskeyPaymasterIntegrationTest is Test {
     function _buildPaymasterData(
         bytes32 orgId,
         uint8 subjectType,
-        bytes20 subjectId,
+        bytes32 subjectId,
         uint32 ruleId,
         uint64 mailboxCommit8
     ) internal view returns (bytes memory) {
-        // ERC-4337 v0.7 format: paymaster(20) | verificationGasLimit(16) | postOpGasLimit(16) | version(1) | orgId(32) | subjectType(1) | subjectId(20) | ruleId(4) | mailboxCommit(8) = 118 bytes
+        // ERC-4337 v0.7 format: paymaster(20) | verificationGasLimit(16) | postOpGasLimit(16) | version(1) | orgId(32) | subjectType(1) | subjectId(32) | ruleId(4) | mailboxCommit(8) = 130 bytes
         return abi.encodePacked(
             address(hub), // 20 bytes
             uint128(200_000), // paymasterVerificationGasLimit - 16 bytes
@@ -205,7 +205,7 @@ contract PasskeyPaymasterIntegrationTest is Test {
             PAYMASTER_DATA_VERSION, // 1 byte
             orgId, // 32 bytes
             subjectType, // 1 byte
-            subjectId, // 20 bytes
+            subjectId, // 32 bytes
             ruleId, // 4 bytes
             mailboxCommit8 // 8 bytes
         );
@@ -260,8 +260,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         // Build UserOperation with execute() calling mockTarget.doSomething()
         bytes memory innerCall = abi.encodeWithSelector(MockTarget.doSomething.selector);
         bytes memory callData = _buildExecuteCalldata(address(mockTarget), 0, innerCall);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -282,8 +283,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         // Build UserOperation
         bytes memory innerCall = abi.encodeWithSelector(MockTarget.doSomething.selector);
         bytes memory callData = _buildExecuteCalldata(address(mockTarget), 0, innerCall);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -312,8 +314,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         // Build UserOp calling target1 - should succeed
         bytes memory innerCall1 = abi.encodeWithSelector(MockTarget.doSomething.selector);
         bytes memory callData1 = _buildExecuteCalldata(address(target1), 0, innerCall1);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp1 = _createUserOp(address(account), callData1, paymasterAndData, "");
 
@@ -363,8 +366,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[1] = abi.encodeWithSelector(MockTarget.doSomethingElse.selector);
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -390,8 +394,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[0] = abi.encodeWithSelector(MockTarget.doSomething.selector);
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -426,8 +431,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[1] = abi.encodeWithSelector(MockTarget.doSomethingElse.selector);
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -466,8 +472,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[1] = abi.encodeWithSelector(MockTarget.doSomething.selector); // Wrong selector for target2
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -488,8 +495,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         bytes[] memory datas = new bytes[](0);
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -519,8 +527,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[0] = abi.encodeWithSelector(MockTarget.doSomething.selector);
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -564,8 +573,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[2] = abi.encodeWithSelector(MockEligibility.claimVouchedHat.selector, uint256(42));
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -603,8 +613,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[2] = abi.encodeWithSelector(MockEligibility.claimVouchedHat.selector, uint256(42));
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -643,8 +654,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[2] = abi.encodeWithSelector(MockTarget.doWithValue.selector);
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -675,8 +687,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[1] = abi.encodeWithSelector(MockTarget.doSomethingElse.selector);
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -705,8 +718,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[0] = abi.encodeWithSelector(MockTarget.doSomething.selector);
 
         bytes memory callData = abi.encodeWithSelector(SIMPLE_EXECUTE_BATCH_SELECTOR, targets, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -729,8 +743,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[0] = abi.encodeWithSelector(MockTarget.doSomething.selector);
 
         bytes memory callData = abi.encodeWithSelector(SIMPLE_EXECUTE_BATCH_SELECTOR, targets, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -756,8 +771,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[0] = ""; // Empty calldata — raw transfer / fallback
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -780,8 +796,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[0] = hex"aabb"; // Only 2 bytes
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -806,8 +823,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[0] = ""; // Empty calldata
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -843,8 +861,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[0] = nestedBatchCalldata; // executeBatch as inner call
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -876,8 +895,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[0] = innerExecuteCalldata;
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -904,8 +924,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
         // Use COARSE mode — needs (account, executeBatch) rule, not inner rules
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_COARSE, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_COARSE, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -932,8 +953,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[0] = abi.encodeWithSelector(MockTarget.doSomething.selector);
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         // UserOp has callGasLimit=500000 (from _createUserOp), which exceeds the 50k hint
         // In single execute() path this would revert with GasTooHigh, but batch ignores gas hints
@@ -963,8 +985,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[0] = abi.encodeWithSelector(MockTarget.doSomething.selector);
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_COARSE, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_COARSE, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -991,8 +1014,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[0] = abi.encodeWithSelector(MockTarget.doSomething.selector);
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_EXECUTOR, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_EXECUTOR, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -1030,8 +1054,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         datas[2] = abi.encodeWithSelector(MockTaskManager.claimTask.selector, uint256(7));
 
         bytes memory callData = _buildExecuteBatchCalldata(targets, values, datas);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -1056,8 +1081,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
 
         bytes memory innerCall = abi.encodeWithSelector(MockTarget.doSomething.selector);
         bytes memory callData = _buildExecuteCalldata(address(mockTarget), 0, innerCall);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -1079,8 +1105,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
         // Inner call is to an unauthorized target, but COARSE mode ignores it
         bytes memory innerCall = abi.encodeWithSelector(MockTarget.doSomething.selector);
         bytes memory callData = _buildExecuteCalldata(address(mockTarget), 0, innerCall);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_COARSE, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_COARSE, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -1117,8 +1144,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
 
         bytes memory innerCall = abi.encodeWithSelector(MockTarget.doSomething.selector);
         bytes memory callData = _buildExecuteCalldata(address(mockTarget), 0, innerCall);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         // UserOp with gas limits within caps
         PackedUserOperation memory userOp = PackedUserOperation({
@@ -1152,8 +1180,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
 
         bytes memory innerCall = abi.encodeWithSelector(MockTarget.doSomething.selector);
         bytes memory callData = _buildExecuteCalldata(address(mockTarget), 0, innerCall);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         // UserOp with verification gas exceeding cap (400k > 300k)
         PackedUserOperation memory userOp = PackedUserOperation({
@@ -1181,7 +1210,7 @@ contract PasskeyPaymasterIntegrationTest is Test {
         PasskeyAccount account = _createPasskeyAccount();
 
         // Set budget for this specific account
-        bytes32 subjectKey = keccak256(abi.encodePacked(uint8(0), bytes20(address(account))));
+        bytes32 subjectKey = keccak256(abi.encodePacked(uint8(0), bytes32(uint256(uint160(address(account))))));
         vm.prank(orgAdmin);
         hub.setBudget(ORG_ID, subjectKey, 0.01 ether, 1 days);
 
@@ -1191,8 +1220,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
 
         bytes memory innerCall = abi.encodeWithSelector(MockTarget.doSomething.selector);
         bytes memory callData = _buildExecuteCalldata(address(mockTarget), 0, innerCall);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -1207,7 +1237,7 @@ contract PasskeyPaymasterIntegrationTest is Test {
         PasskeyAccount account = _createPasskeyAccount();
 
         // Set small budget
-        bytes32 subjectKey = keccak256(abi.encodePacked(uint8(0), bytes20(address(account))));
+        bytes32 subjectKey = keccak256(abi.encodePacked(uint8(0), bytes32(uint256(uint160(address(account))))));
         vm.prank(orgAdmin);
         hub.setBudget(ORG_ID, subjectKey, 0.001 ether, 1 days);
 
@@ -1216,8 +1246,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
 
         bytes memory innerCall = abi.encodeWithSelector(MockTarget.doSomething.selector);
         bytes memory callData = _buildExecuteCalldata(address(mockTarget), 0, innerCall);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -1241,8 +1272,9 @@ contract PasskeyPaymasterIntegrationTest is Test {
 
         bytes memory innerCall = abi.encodeWithSelector(MockTarget.doSomething.selector);
         bytes memory callData = _buildExecuteCalldata(address(mockTarget), 0, innerCall);
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
         PackedUserOperation memory userOp = _createUserOp(address(account), callData, paymasterAndData, "");
 
@@ -1267,11 +1299,12 @@ contract PasskeyPaymasterIntegrationTest is Test {
     function testPaymasterAndData_CorrectFormat() public {
         PasskeyAccount account = _createPasskeyAccount();
 
-        bytes memory paymasterAndData =
-            _buildPaymasterData(ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes20(address(account)), RULE_ID_GENERIC, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(
+            ORG_ID, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(address(account)))), RULE_ID_GENERIC, 0
+        );
 
-        // Should be exactly 118 bytes (86 + 32 for v0.7 gas limits)
-        assertEq(paymasterAndData.length, 118, "paymasterAndData should be 118 bytes");
+        // Should be exactly 130 bytes (86 + 32 subjectId + 12 ruleId/mailbox for v0.7 gas limits)
+        assertEq(paymasterAndData.length, 130, "paymasterAndData should be 130 bytes");
 
         // Verify structure using assembly to extract values from memory
         address paymaster;
@@ -1321,7 +1354,7 @@ contract PasskeyPaymasterIntegrationTest is Test {
         MockHatsIntegration(address(hats)).setEligible(eligibleUser, USER_HAT, true);
 
         // Setup budget for hat-based subject
-        bytes32 hatSubjectKey = keccak256(abi.encodePacked(SUBJECT_TYPE_HAT, bytes20(uint160(USER_HAT))));
+        bytes32 hatSubjectKey = keccak256(abi.encodePacked(SUBJECT_TYPE_HAT, bytes32(USER_HAT)));
         vm.prank(orgAdmin);
         hub.setBudget(ORG_ID, hatSubjectKey, 1 ether, 1 days);
 
@@ -1332,7 +1365,7 @@ contract PasskeyPaymasterIntegrationTest is Test {
         // Build UserOp with SUBJECT_TYPE_HAT
         bytes memory innerCall = abi.encodeWithSelector(MockTarget.doSomething.selector);
         bytes memory callData = _buildExecuteCalldata(address(mockTarget), 0, innerCall);
-        bytes memory paymasterAndData = _buildPaymasterData(ORG_ID, SUBJECT_TYPE_HAT, bytes20(uint160(USER_HAT)), 0, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(ORG_ID, SUBJECT_TYPE_HAT, bytes32(USER_HAT), 0, 0);
 
         PackedUserOperation memory userOp = _createUserOp(eligibleUser, callData, paymasterAndData, "");
 
@@ -1351,7 +1384,7 @@ contract PasskeyPaymasterIntegrationTest is Test {
 
         // Do NOT set eligible — user is neither wearing nor eligible
 
-        bytes32 hatSubjectKey = keccak256(abi.encodePacked(SUBJECT_TYPE_HAT, bytes20(uint160(USER_HAT))));
+        bytes32 hatSubjectKey = keccak256(abi.encodePacked(SUBJECT_TYPE_HAT, bytes32(USER_HAT)));
         vm.prank(orgAdmin);
         hub.setBudget(ORG_ID, hatSubjectKey, 1 ether, 1 days);
 
@@ -1360,7 +1393,7 @@ contract PasskeyPaymasterIntegrationTest is Test {
 
         bytes memory innerCall = abi.encodeWithSelector(MockTarget.doSomething.selector);
         bytes memory callData = _buildExecuteCalldata(address(mockTarget), 0, innerCall);
-        bytes memory paymasterAndData = _buildPaymasterData(ORG_ID, SUBJECT_TYPE_HAT, bytes20(uint160(USER_HAT)), 0, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(ORG_ID, SUBJECT_TYPE_HAT, bytes32(USER_HAT), 0, 0);
 
         PackedUserOperation memory userOp = _createUserOp(ineligibleUser, callData, paymasterAndData, "");
 
@@ -1372,7 +1405,7 @@ contract PasskeyPaymasterIntegrationTest is Test {
     /// @notice Test that an existing hat wearer still passes SUBJECT_TYPE_HAT validation
     function testHat_ExistingWearer_Succeeds() public {
         // `user` already wears USER_HAT from setUp (mintHat sets both wearer and active)
-        bytes32 hatSubjectKey = keccak256(abi.encodePacked(SUBJECT_TYPE_HAT, bytes20(uint160(USER_HAT))));
+        bytes32 hatSubjectKey = keccak256(abi.encodePacked(SUBJECT_TYPE_HAT, bytes32(USER_HAT)));
         vm.prank(orgAdmin);
         hub.setBudget(ORG_ID, hatSubjectKey, 1 ether, 1 days);
 
@@ -1381,7 +1414,7 @@ contract PasskeyPaymasterIntegrationTest is Test {
 
         bytes memory innerCall = abi.encodeWithSelector(MockTarget.doSomething.selector);
         bytes memory callData = _buildExecuteCalldata(address(mockTarget), 0, innerCall);
-        bytes memory paymasterAndData = _buildPaymasterData(ORG_ID, SUBJECT_TYPE_HAT, bytes20(uint160(USER_HAT)), 0, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(ORG_ID, SUBJECT_TYPE_HAT, bytes32(USER_HAT), 0, 0);
 
         PackedUserOperation memory userOp = _createUserOp(user, callData, paymasterAndData, "");
 
@@ -1403,7 +1436,7 @@ contract PasskeyPaymasterIntegrationTest is Test {
         // Deactivate the hat
         MockHatsIntegration(address(hats)).setActive(USER_HAT, false);
 
-        bytes32 hatSubjectKey = keccak256(abi.encodePacked(SUBJECT_TYPE_HAT, bytes20(uint160(USER_HAT))));
+        bytes32 hatSubjectKey = keccak256(abi.encodePacked(SUBJECT_TYPE_HAT, bytes32(USER_HAT)));
         vm.prank(orgAdmin);
         hub.setBudget(ORG_ID, hatSubjectKey, 1 ether, 1 days);
 
@@ -1412,7 +1445,7 @@ contract PasskeyPaymasterIntegrationTest is Test {
 
         bytes memory innerCall = abi.encodeWithSelector(MockTarget.doSomething.selector);
         bytes memory callData = _buildExecuteCalldata(address(mockTarget), 0, innerCall);
-        bytes memory paymasterAndData = _buildPaymasterData(ORG_ID, SUBJECT_TYPE_HAT, bytes20(uint160(USER_HAT)), 0, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(ORG_ID, SUBJECT_TYPE_HAT, bytes32(USER_HAT), 0, 0);
 
         PackedUserOperation memory userOp = _createUserOp(eligibleUser, callData, paymasterAndData, "");
 
@@ -1427,7 +1460,7 @@ contract PasskeyPaymasterIntegrationTest is Test {
         // Deactivate the hat
         MockHatsIntegration(address(hats)).setActive(USER_HAT, false);
 
-        bytes32 hatSubjectKey = keccak256(abi.encodePacked(SUBJECT_TYPE_HAT, bytes20(uint160(USER_HAT))));
+        bytes32 hatSubjectKey = keccak256(abi.encodePacked(SUBJECT_TYPE_HAT, bytes32(USER_HAT)));
         vm.prank(orgAdmin);
         hub.setBudget(ORG_ID, hatSubjectKey, 1 ether, 1 days);
 
@@ -1436,7 +1469,7 @@ contract PasskeyPaymasterIntegrationTest is Test {
 
         bytes memory innerCall = abi.encodeWithSelector(MockTarget.doSomething.selector);
         bytes memory callData = _buildExecuteCalldata(address(mockTarget), 0, innerCall);
-        bytes memory paymasterAndData = _buildPaymasterData(ORG_ID, SUBJECT_TYPE_HAT, bytes20(uint160(USER_HAT)), 0, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(ORG_ID, SUBJECT_TYPE_HAT, bytes32(USER_HAT), 0, 0);
 
         PackedUserOperation memory userOp = _createUserOp(user, callData, paymasterAndData, "");
 
@@ -1454,7 +1487,7 @@ contract PasskeyPaymasterIntegrationTest is Test {
         MockHatsIntegration(address(hats)).setActive(USER_HAT, false);
         MockHatsIntegration(address(hats)).setActive(USER_HAT, true);
 
-        bytes32 hatSubjectKey = keccak256(abi.encodePacked(SUBJECT_TYPE_HAT, bytes20(uint160(USER_HAT))));
+        bytes32 hatSubjectKey = keccak256(abi.encodePacked(SUBJECT_TYPE_HAT, bytes32(USER_HAT)));
         vm.prank(orgAdmin);
         hub.setBudget(ORG_ID, hatSubjectKey, 1 ether, 1 days);
 
@@ -1463,7 +1496,7 @@ contract PasskeyPaymasterIntegrationTest is Test {
 
         bytes memory innerCall = abi.encodeWithSelector(MockTarget.doSomething.selector);
         bytes memory callData = _buildExecuteCalldata(address(mockTarget), 0, innerCall);
-        bytes memory paymasterAndData = _buildPaymasterData(ORG_ID, SUBJECT_TYPE_HAT, bytes20(uint160(USER_HAT)), 0, 0);
+        bytes memory paymasterAndData = _buildPaymasterData(ORG_ID, SUBJECT_TYPE_HAT, bytes32(USER_HAT), 0, 0);
 
         PackedUserOperation memory userOp = _createUserOp(eligibleUser, callData, paymasterAndData, "");
 

--- a/test/PaymasterHubSolidarity.t.sol
+++ b/test/PaymasterHubSolidarity.t.sol
@@ -1321,11 +1321,11 @@ contract PaymasterHubSolidarityTest is Test {
     function _buildPaymasterData(
         bytes32 orgId,
         uint8 subjectType,
-        bytes20 subjectId,
+        bytes32 subjectId,
         uint32 ruleId,
         uint64 mailboxCommit8
     ) internal view returns (bytes memory) {
-        // ERC-4337 v0.7 format: paymaster(20) | verificationGasLimit(16) | postOpGasLimit(16) | version(1) | orgId(32) | subjectType(1) | subjectId(20) | ruleId(4) | mailboxCommit(8) = 118 bytes
+        // ERC-4337 v0.7 format: paymaster(20) | verificationGasLimit(16) | postOpGasLimit(16) | version(1) | orgId(32) | subjectType(1) | subjectId(32) | ruleId(4) | mailboxCommit(8) = 130 bytes
         return abi.encodePacked(
             address(hub),
             uint128(200_000),
@@ -1363,7 +1363,7 @@ contract PaymasterHubSolidarityTest is Test {
         vm.prank(poaManager);
         hub.setOnboardingConfig(uint128(MAX_COST), 10, true, address(0));
         bytes memory pmData =
-            _buildPaymasterData(ORG_ALPHA, SUBJECT_TYPE_POA_ONBOARDING, bytes20(0), RULE_ID_GENERIC, uint64(0));
+            _buildPaymasterData(ORG_ALPHA, SUBJECT_TYPE_POA_ONBOARDING, bytes32(0), RULE_ID_GENERIC, uint64(0));
         PackedUserOperation memory userOp = _buildUserOp(address(0xdead), "", pmData);
         userOp.initCode = hex"01";
         vm.prank(address(entryPoint));
@@ -1384,7 +1384,7 @@ contract PaymasterHubSolidarityTest is Test {
         hub.setOnboardingConfig(uint128(MAX_COST), 10, true, address(0));
         address deployed = address(new DummySender());
         bytes memory pmData =
-            _buildPaymasterData(bytes32(0), SUBJECT_TYPE_POA_ONBOARDING, bytes20(0), RULE_ID_GENERIC, uint64(0));
+            _buildPaymasterData(bytes32(0), SUBJECT_TYPE_POA_ONBOARDING, bytes32(0), RULE_ID_GENERIC, uint64(0));
         PackedUserOperation memory userOp = _buildUserOp(deployed, "", pmData);
         userOp.initCode = hex"01";
         vm.prank(address(entryPoint));
@@ -1401,7 +1401,7 @@ contract PaymasterHubSolidarityTest is Test {
         hub.setOnboardingConfig(uint128(MAX_COST), 10, true, address(0));
         address newAccount = address(0xbeef);
         bytes memory pmData =
-            _buildPaymasterData(bytes32(0), SUBJECT_TYPE_POA_ONBOARDING, bytes20(0), RULE_ID_GENERIC, uint64(0));
+            _buildPaymasterData(bytes32(0), SUBJECT_TYPE_POA_ONBOARDING, bytes32(0), RULE_ID_GENERIC, uint64(0));
         PackedUserOperation memory userOp = _buildUserOp(newAccount, "", pmData);
         userOp.initCode = hex"01";
         vm.prank(address(entryPoint));
@@ -1427,7 +1427,7 @@ contract PaymasterHubSolidarityTest is Test {
         hub.setOnboardingConfig(uint128(MAX_COST), 1, true, address(0));
         address account1 = address(0xaa01);
         bytes memory pmData1 =
-            _buildPaymasterData(bytes32(0), SUBJECT_TYPE_POA_ONBOARDING, bytes20(0), RULE_ID_GENERIC, uint64(0));
+            _buildPaymasterData(bytes32(0), SUBJECT_TYPE_POA_ONBOARDING, bytes32(0), RULE_ID_GENERIC, uint64(0));
         PackedUserOperation memory userOp1 = _buildUserOp(account1, "", pmData1);
         userOp1.initCode = hex"01";
         vm.prank(address(entryPoint));
@@ -1438,7 +1438,7 @@ contract PaymasterHubSolidarityTest is Test {
         // Second onboarding should succeed because the failed op's slot was refunded
         address account2 = address(0xaa02);
         bytes memory pmData2 =
-            _buildPaymasterData(bytes32(0), SUBJECT_TYPE_POA_ONBOARDING, bytes20(0), RULE_ID_GENERIC, uint64(0));
+            _buildPaymasterData(bytes32(0), SUBJECT_TYPE_POA_ONBOARDING, bytes32(0), RULE_ID_GENERIC, uint64(0));
         PackedUserOperation memory userOp2 = _buildUserOp(account2, "", pmData2);
         userOp2.initCode = hex"01";
         vm.prank(address(entryPoint));
@@ -1449,7 +1449,7 @@ contract PaymasterHubSolidarityTest is Test {
         // Third onboarding should now be blocked (limit of 1 reached)
         address account3 = address(0xaa03);
         bytes memory pmData3 =
-            _buildPaymasterData(bytes32(0), SUBJECT_TYPE_POA_ONBOARDING, bytes20(0), RULE_ID_GENERIC, uint64(0));
+            _buildPaymasterData(bytes32(0), SUBJECT_TYPE_POA_ONBOARDING, bytes32(0), RULE_ID_GENERIC, uint64(0));
         PackedUserOperation memory userOp3 = _buildUserOp(account3, "", pmData3);
         userOp3.initCode = hex"01";
         vm.prank(address(entryPoint));
@@ -1467,7 +1467,7 @@ contract PaymasterHubSolidarityTest is Test {
         hub.setOnboardingConfig(uint128(MAX_COST), 10, true, registry);
         address deployed = address(new DummySender());
         bytes memory pmData =
-            _buildPaymasterData(bytes32(0), SUBJECT_TYPE_POA_ONBOARDING, bytes20(0), RULE_ID_GENERIC, uint64(0));
+            _buildPaymasterData(bytes32(0), SUBJECT_TYPE_POA_ONBOARDING, bytes32(0), RULE_ID_GENERIC, uint64(0));
         // Build execute(registryAddress, 0, registerAccount("alice"))
         bytes memory innerData = abi.encodeWithSelector(bytes4(0xbff6de20), "alice");
         bytes memory execCallData = abi.encodeWithSelector(bytes4(0xb61d27f6), registry, uint256(0), innerData);
@@ -1488,7 +1488,7 @@ contract PaymasterHubSolidarityTest is Test {
         hub.setOnboardingConfig(uint128(MAX_COST), 10, true, registry);
         address deployed = address(new DummySender());
         bytes memory pmData =
-            _buildPaymasterData(bytes32(0), SUBJECT_TYPE_POA_ONBOARDING, bytes20(0), RULE_ID_GENERIC, uint64(0));
+            _buildPaymasterData(bytes32(0), SUBJECT_TYPE_POA_ONBOARDING, bytes32(0), RULE_ID_GENERIC, uint64(0));
         // Build execute(wrongTarget, 0, registerAccount("alice"))
         bytes memory innerData = abi.encodeWithSelector(bytes4(0xbff6de20), "alice");
         bytes memory execCallData = abi.encodeWithSelector(bytes4(0xb61d27f6), address(0xBAD), uint256(0), innerData);
@@ -1509,7 +1509,7 @@ contract PaymasterHubSolidarityTest is Test {
         hub.setOnboardingConfig(uint128(MAX_COST), 10, true, registry);
         address deployed = address(new DummySender());
         bytes memory pmData =
-            _buildPaymasterData(bytes32(0), SUBJECT_TYPE_POA_ONBOARDING, bytes20(0), RULE_ID_GENERIC, uint64(0));
+            _buildPaymasterData(bytes32(0), SUBJECT_TYPE_POA_ONBOARDING, bytes32(0), RULE_ID_GENERIC, uint64(0));
         // Build execute(registry, 0, someOtherFunction("data"))
         bytes memory innerData = abi.encodeWithSelector(bytes4(0xdeadbeef), "alice");
         bytes memory execCallData = abi.encodeWithSelector(bytes4(0xb61d27f6), registry, uint256(0), innerData);
@@ -1530,7 +1530,7 @@ contract PaymasterHubSolidarityTest is Test {
         hub.setOnboardingConfig(uint128(MAX_COST), 10, true, registry);
         address deployed = address(new DummySender());
         bytes memory pmData =
-            _buildPaymasterData(bytes32(0), SUBJECT_TYPE_POA_ONBOARDING, bytes20(0), RULE_ID_GENERIC, uint64(0));
+            _buildPaymasterData(bytes32(0), SUBJECT_TYPE_POA_ONBOARDING, bytes32(0), RULE_ID_GENERIC, uint64(0));
         // Build arbitrary callData (not execute())
         bytes memory badCallData = abi.encodeWithSelector(bytes4(0x12345678), address(0), uint256(0));
         PackedUserOperation memory userOp = _buildUserOp(deployed, badCallData, pmData);
@@ -1552,7 +1552,7 @@ contract PaymasterHubSolidarityTest is Test {
         vm.prank(poaManager);
         hub.setGracePeriodConfig(90, 100 ether, 0.003 ether);
         hub.donateToSolidarity{value: 0.001 ether}();
-        bytes32 accountKey = keccak256(abi.encodePacked(SUBJECT_TYPE_ACCOUNT, bytes20(user1)));
+        bytes32 accountKey = keccak256(abi.encodePacked(SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(user1)))));
         vm.startPrank(orgAdmin);
         hub.setBudget(ORG_ALPHA, accountKey, 10 ether, 1 days);
         hub.setRule(ORG_ALPHA, address(0x9999), bytes4(0xdeadbeef), true, 0);
@@ -1560,8 +1560,9 @@ contract PaymasterHubSolidarityTest is Test {
         bytes memory innerCall = abi.encodeWithSelector(
             bytes4(0xb61d27f6), address(0x9999), uint256(0), abi.encodeWithSelector(bytes4(0xdeadbeef))
         );
-        bytes memory pmData =
-            _buildPaymasterData(ORG_ALPHA, SUBJECT_TYPE_ACCOUNT, bytes20(user1), RULE_ID_GENERIC, uint64(0));
+        bytes memory pmData = _buildPaymasterData(
+            ORG_ALPHA, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(user1))), RULE_ID_GENERIC, uint64(0)
+        );
         PackedUserOperation memory userOp = _buildUserOp(user1, innerCall, pmData);
         vm.prank(address(entryPoint));
         vm.expectRevert(PaymasterHub.InsufficientFunds.selector);


### PR DESCRIPTION
## Summary
Expand the `subjectId` field in paymaster data from 20 bytes to 32 bytes to support larger hat ID values. This updates the wire format, payload offsets, and extraction logic across PaymasterHub, PaymasterHubLens, OrgDeployer, and all test files.

## Changes
- Widen `subjectId` type from `bytes20` to `bytes32` in decoding and validation functions
- Update minimum payload length from 118 to 130 bytes
- Shift byte offsets for `ruleId` (106→118) and `mailboxCommit8` (110→122) to account for the 12-byte expansion
- Update address extraction to `address(uint160(uint256(subjectId)))` and hat ID extraction to `uint256(subjectId)`
- Update all test helpers and assertions consistently

## Test Coverage
All tests pass; test files updated for the new format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)