### PR TITLE
fix: make claimVouchedHat idempotent for batch compatibility

### DIFF
--- a/src/EligibilityModule.sol
+++ b/src/EligibilityModule.sol
@@ -802,8 +802,8 @@ contract EligibilityModule is Initializable, IHatsEligibility {
         (bool eligible, bool standing) = this.getWearerStatus(msg.sender, hatId);
         require(eligible && standing, "Not eligible to claim hat");
 
-        // Check if already wearing the hat
-        require(!l.hats.isWearerOfHat(msg.sender, hatId), "Already wearing hat");
+        // Already wearing — no-op (idempotent for batch compatibility)
+        if (l.hats.isWearerOfHat(msg.sender, hatId)) return;
 
         // State change BEFORE external call (CEI pattern)
         delete l.roleApplications[hatId][msg.sender];

--- a/test/DeployerTest.t.sol
+++ b/test/DeployerTest.t.sol
@@ -5750,6 +5750,49 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         );
     }
 
+    /// @notice claimVouchedHat should be idempotent - no revert when already wearing hat
+    function testClaimVouchedHat_Idempotent() public {
+        TestOrgSetup memory setup = _createTestOrg("Idempotent Claim Test DAO");
+        address user = address(0xCAFE);
+
+        // defaultRoleHat has defaultEligible=true, so any user can claim it
+        // First claim should succeed
+        vm.prank(user);
+        EligibilityModule(setup.eligibilityModule).claimVouchedHat(setup.defaultRoleHat);
+        _assertWearingHat(user, setup.defaultRoleHat, true, "after first claim");
+
+        // Second claim should be a no-op (not revert)
+        vm.prank(user);
+        EligibilityModule(setup.eligibilityModule).claimVouchedHat(setup.defaultRoleHat);
+        _assertWearingHat(user, setup.defaultRoleHat, true, "after second claim");
+    }
+
+    /// @notice Simulates the frontend batch: QuickJoin mints hat, then claimVouchedHat for same hat
+    function testQuickJoinThenClaimVouchedHat_NoConflict() public {
+        TestOrgSetup memory setup = _createTestOrg("Batch Compatibility Test DAO");
+        address user = address(0xBEEF);
+
+        // Get the hats that QuickJoin mints to new members
+        uint256[] memory memberHats = QuickJoin(setup.qj).memberHatIds();
+        assertTrue(memberHats.length > 0, "QuickJoin should have member hats");
+
+        // Simulate what registerAndQuickJoinWithPasskey does internally:
+        // QuickJoin calls executor.mintHatsForUser(user, memberHatIds)
+        vm.prank(setup.qj);
+        Executor(payable(setup.exec)).mintHatsForUser(user, memberHats);
+
+        // Verify user got the hat from QuickJoin
+        _assertWearingHat(user, memberHats[0], true, "after QuickJoin mint");
+
+        // Now simulate the second call in the frontend's executeBatch:
+        // claimVouchedHat for the same hat - should be a no-op, not revert
+        vm.prank(user);
+        EligibilityModule(setup.eligibilityModule).claimVouchedHat(memberHats[0]);
+
+        // User should still wear the hat
+        _assertWearingHat(user, memberHats[0], true, "after claimVouchedHat no-op");
+    }
+
     /// @notice Paymaster validates batch UserOp with passkey onboarding + claimVouchedHat
     function testPasskeyOnboarding_PaymasterBatchValidation() public {
         (OrgDeployer.DeploymentResult memory result, bytes32 orgId) = _deployPasskeyOrg();


### PR DESCRIPTION
## Summary

Fixed batch UserOp compatibility issue where `registerAndQuickJoinWithPasskey` + `claimVouchedHat` for the same hat would revert on the second call.

**Changed behavior**: `claimVouchedHat` now returns early (no-op) if the user already wears the hat instead of reverting with "Already wearing hat".

**Tests**: Added two integration tests that verify the fix works end-to-end: `testClaimVouchedHat_Idempotent` and `testQuickJoinThenClaimVouchedHat_NoConflict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)