### PR TITLE
feat(TaskManager): createTasksBatch + v2 upgrade script

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -42,7 +42,10 @@ base-llama = "https://base.llamarpc.com"
 base-public = "https://mainnet.base.org"
 arbitrum = "https://arb1.arbitrum.io/rpc"
 polygon = "https://polygon.drpc.org"
-gnosis = "https://gnosis.drpc.org"
+gnosis = "https://rpc.gnosischain.com"
+gnosis-drpc = "https://gnosis.drpc.org"
+gnosis-ankr = "https://rpc.ankr.com/gnosis"
+gnosis-gateway = "https://rpc.gnosis.gateway.fm"
 
 # Local development
 local = "http://localhost:8545"

--- a/script/upgrades/UpgradeTaskManagerCreateTasksBatch.s.sol
+++ b/script/upgrades/UpgradeTaskManagerCreateTasksBatch.s.sol
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import {TaskManager} from "../../src/TaskManager.sol";
+import {PoaManagerHub} from "../../src/crosschain/PoaManagerHub.sol";
+import {PoaManager} from "../../src/PoaManager.sol";
+import {DeterministicDeployer} from "../../src/crosschain/DeterministicDeployer.sol";
+
+/*
+ * ============================================================================
+ * TaskManager Upgrade — createTasksBatch (v2)
+ * ============================================================================
+ *
+ * Adds `createTasksBatch(bytes32 pid, CreateTaskInput[] calldata tasks)` so a
+ * project lead can create N tasks in a single transaction. The batch hoists the
+ * permission check (one Hats `balanceOfBatch` call instead of N) and is
+ * all-or-nothing: any per-task failure reverts the whole call. Internally
+ * `_createTask` was refactored to return the new task id so the batch can
+ * surface ids back to the caller without recomputing from `nextTaskId - 1`.
+ * No new state, no Layout changes, no event signature changes — drop-in safe
+ * for upgrade and for existing subgraph indexers.
+ *
+ * Three-step cross-chain upgrade pattern:
+ *   1. Deploy impl on Gnosis via DeterministicDeployer
+ *   2. Deploy on Arbitrum + upgradeBeaconCrossChain
+ *   3. Verify on Gnosis
+ *
+ * Usage:
+ *   source .env && FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeTaskManagerCreateTasksBatch.s.sol:<StepContract> \
+ *     --rpc-url <chain> --broadcast --slow
+ * ============================================================================
+ */
+
+address constant DD = 0x4aC8B5ebEb9D8C3dE3180ddF381D552d59e8835a;
+address constant HUB = 0xB72840B343654eAfb2CFf7acC4Fc6b59E6c3CC71;
+address constant GNOSIS_POA_MANAGER = 0x794fD39e75140ee1545B1B022E5486B7c863789b;
+uint256 constant HYPERLANE_FEE = 0.005 ether;
+// Current live TaskManager impl was registered at "v1" (see
+// script/deploy/DeploySatelliteInfrastructure.s.sol). Bump to "v2" for a fresh
+// deterministic address with createTasksBatch.
+string constant VERSION = "v2";
+
+/**
+ * @title Step1_DeployImplOnGnosis
+ * @notice Deploy TaskManager v2 implementation on Gnosis via DD.
+ *
+ * Usage:
+ *   source .env && FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeTaskManagerCreateTasksBatch.s.sol:Step1_DeployImplOnGnosis \
+ *     --rpc-url gnosis --broadcast --slow
+ */
+contract Step1_DeployImplOnGnosis is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+
+        bytes32 salt = dd.computeSalt("TaskManager", VERSION);
+        address predicted = dd.computeAddress(salt);
+        console.log("\n=== Step 1: Deploy TaskManager v2 impl on Gnosis ===");
+        console.log("Predicted:", predicted);
+
+        if (predicted.code.length > 0) {
+            console.log("Already deployed. Skipping.");
+            return;
+        }
+
+        vm.startBroadcast(deployerKey);
+        address deployed = dd.deploy(salt, type(TaskManager).creationCode);
+        vm.stopBroadcast();
+
+        require(deployed == predicted, "Address mismatch");
+        console.log("Deployed:", deployed);
+        console.log("\nNext: Run Step2_UpgradeFromArbitrum on Arbitrum");
+    }
+}
+
+/**
+ * @title Step2_UpgradeFromArbitrum
+ * @notice Deploy impl on Arbitrum via DD, upgrade beacon cross-chain.
+ *
+ * Usage:
+ *   source .env && FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeTaskManagerCreateTasksBatch.s.sol:Step2_UpgradeFromArbitrum \
+ *     --rpc-url arbitrum --broadcast --slow
+ */
+contract Step2_UpgradeFromArbitrum is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        address deployer = vm.addr(deployerKey);
+
+        PoaManagerHub hub = PoaManagerHub(payable(HUB));
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+
+        require(hub.owner() == deployer, "Deployer must own Hub");
+        require(!hub.paused(), "Hub is paused");
+
+        bytes32 salt = dd.computeSalt("TaskManager", VERSION);
+        address predicted = dd.computeAddress(salt);
+        console.log("\n=== Step 2: Upgrade TaskManager from Arbitrum ===");
+        console.log("DD impl address:", predicted);
+
+        vm.startBroadcast(deployerKey);
+
+        if (predicted.code.length == 0) {
+            dd.deploy(salt, type(TaskManager).creationCode);
+            console.log("Deployed on Arbitrum");
+        } else {
+            console.log("Already deployed on Arbitrum");
+        }
+
+        hub.upgradeBeaconCrossChain{value: HYPERLANE_FEE}("TaskManager", predicted, VERSION);
+        console.log("Beacon upgraded cross-chain");
+
+        vm.stopBroadcast();
+        console.log("\nWait ~5 min for Hyperlane relay, then run Step3 on Gnosis.");
+    }
+}
+
+/**
+ * @title Step3_VerifyGnosis
+ * @notice Verify the Gnosis beacon upgrade landed.
+ *
+ * Usage:
+ *   forge script script/upgrades/UpgradeTaskManagerCreateTasksBatch.s.sol:Step3_VerifyGnosis \
+ *     --rpc-url gnosis
+ */
+contract Step3_VerifyGnosis is Script {
+    function run() public view {
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+        bytes32 salt = dd.computeSalt("TaskManager", VERSION);
+        address expectedImpl = dd.computeAddress(salt);
+
+        address currentImpl = PoaManager(GNOSIS_POA_MANAGER).getCurrentImplementationById(keccak256("TaskManager"));
+
+        console.log("\n=== Step 3: Verify Gnosis TaskManager Upgrade ===");
+        console.log("Expected impl:", expectedImpl);
+        console.log("Current impl: ", currentImpl);
+
+        if (currentImpl == expectedImpl) {
+            console.log("PASS: TaskManager upgraded to v2 on Gnosis");
+            console.log("\nNew capability: createTasksBatch(bytes32 pid, CreateTaskInput[] calldata tasks)");
+            console.log("  - Bulk task creation under one project, atomic revert-all");
+            console.log("  - Single permission check; one balanceOfBatch instead of N");
+        } else {
+            console.log("WAITING: Hyperlane message not yet relayed.");
+        }
+    }
+}
+
+interface IOrgRegistry {
+    function orgIds(uint256 index) external view returns (bytes32);
+    function proxyOf(bytes32 orgId, bytes32 typeId) external view returns (address);
+}
+
+/**
+ * @title DryRun_GnosisUpgrade
+ * @notice Pre-flight test on a Gnosis fork. Deploys impl via DD, upgrades the
+ *         beacon, and exercises createTasksBatch against a live, autoUpgrade-
+ *         tracking TaskManager proxy. Does not broadcast.
+ *
+ *         Asserts:
+ *           1. DD-predicted address matches deployed address.
+ *           2. PoaManager beacon updates to the new impl.
+ *           3. New `createTasksBatch` selector exists in impl runtime bytecode.
+ *           4. A live TaskManager proxy on Gnosis (org #0 from OrgRegistry):
+ *              a. Pre-existing storage is preserved (executor address survives
+ *                 the impl swap — proves Layout struct is compatible).
+ *              b. The new selector is callable through the proxy.
+ *              c. Empty batch reverts with EmptyBatch.
+ *              d. A 3-task batch on a freshly-created project succeeds, returns
+ *                 sequential ids, and each task is readable with the right
+ *                 projectId via the lens path.
+ *              e. Batch is atomic: a batch ending in a zero-payout task reverts
+ *                 with InvalidPayout and leaves nextTaskId unchanged.
+ *
+ * Usage:
+ *   FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeTaskManagerCreateTasksBatch.s.sol:DryRun_GnosisUpgrade \
+ *     --rpc-url gnosis
+ */
+contract DryRun_GnosisUpgrade is Script {
+    // OrgRegistry is deployed at the same CREATE2 address on every chain.
+    address constant ORG_REGISTRY = 0x3744b372abc41589226313F2bB1dB3aCAa22A854;
+
+    function run() public {
+        console.log("\n=== DRY RUN: TaskManager v2 upgrade on Gnosis fork ===\n");
+
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+        PoaManager pm = PoaManager(GNOSIS_POA_MANAGER);
+
+        // 1. Pre-state snapshot.
+        address implBefore = pm.getCurrentImplementationById(keccak256("TaskManager"));
+        console.log("Impl before:", implBefore);
+
+        // 2. Step1 simulation: deploy v2 impl via DD.
+        bytes32 salt = dd.computeSalt("TaskManager", VERSION);
+        address predicted = dd.computeAddress(salt);
+        console.log("DD predicted impl:", predicted);
+
+        address deployed;
+        if (predicted.code.length == 0) {
+            // DD's deploy is onlyOwner — prank as the DD owner EOA.
+            vm.prank(DeterministicDeployer(DD).owner());
+            deployed = dd.deploy(salt, type(TaskManager).creationCode);
+        } else {
+            console.log("Already deployed at predicted (skipping deploy)");
+            deployed = predicted;
+        }
+        require(deployed == predicted, "DryRun: DD address mismatch");
+        require(deployed.code.length > 0, "DryRun: impl code missing");
+        console.log("Deployed impl:", deployed);
+
+        // 3. Step2 simulation: upgrade beacon as PoaManager owner.
+        address pmOwner = pm.owner();
+        vm.prank(pmOwner);
+        pm.upgradeBeacon("TaskManager", deployed, VERSION);
+        address implAfter = pm.getCurrentImplementationById(keccak256("TaskManager"));
+        require(implAfter == deployed, "DryRun: beacon upgrade did not stick");
+        console.log("Impl after :", implAfter);
+
+        // 4. Selector presence in impl bytecode (cheap source-vs-deployed check).
+        bytes4 sel = TaskManager.createTasksBatch.selector;
+        bytes memory code = deployed.code;
+        bool found = false;
+        for (uint256 i; i + 4 <= code.length; ++i) {
+            if (code[i] == sel[0] && code[i + 1] == sel[1] && code[i + 2] == sel[2] && code[i + 3] == sel[3]) {
+                found = true;
+                break;
+            }
+        }
+        require(found, "DryRun: createTasksBatch selector missing from impl bytecode");
+        console.log("createTasksBatch selector present in impl bytecode");
+
+        // 5. Live-proxy exercise: pull a real TaskManager proxy from OrgRegistry
+        //    and prove the new function works against production state.
+        _exerciseLiveProxy();
+
+        console.log("\n=== ALL DRY-RUN CHECKS PASSED ===");
+        console.log("Safe to broadcast Step1/Step2/Step3 against mainnet.");
+    }
+
+    function _exerciseLiveProxy() internal {
+        IOrgRegistry reg = IOrgRegistry(ORG_REGISTRY);
+        bytes32 orgId = reg.orgIds(0);
+        address proxy = reg.proxyOf(orgId, keccak256("TaskManager"));
+        require(proxy != address(0), "DryRun: no TaskManager proxy for org 0");
+        TaskManager tm = TaskManager(proxy);
+
+        console.log("\n--- Live-proxy exercise ---");
+        console.log("orgId:", vm.toString(orgId));
+        console.log("TaskManager proxy:", proxy);
+
+        // 5a. Storage preservation: read executor through the upgraded impl.
+        //     If Layout drifted, this would either revert or return junk.
+        bytes memory execData = tm.getLensData(4, "");
+        address executor = abi.decode(execData, (address));
+        require(executor != address(0), "DryRun: executor unset post-upgrade (storage drift?)");
+        console.log("Executor (preserved):", executor);
+
+        // 5b. Empty batch reverts.
+        TaskManager.CreateTaskInput[] memory empty = new TaskManager.CreateTaskInput[](0);
+        vm.prank(executor);
+        (bool okEmpty, bytes memory emptyRet) =
+            proxy.call(abi.encodeCall(TaskManager.createTasksBatch, (bytes32(uint256(1)), empty)));
+        require(!okEmpty, "DryRun: empty batch must revert");
+        require(bytes4(emptyRet) == TaskManager.EmptyBatch.selector, "DryRun: empty batch wrong error");
+        console.log("EmptyBatch revert path OK");
+
+        // 5c. Create a fresh test project (executor bypasses _requireCreator).
+        TaskManager.BootstrapProjectConfig memory cfg = TaskManager.BootstrapProjectConfig({
+            title: bytes("dryrun-batch-test"),
+            metadataHash: bytes32(0),
+            cap: 0, // unlimited PT
+            managers: new address[](0),
+            createHats: new uint256[](0),
+            claimHats: new uint256[](0),
+            reviewHats: new uint256[](0),
+            assignHats: new uint256[](0),
+            bountyTokens: new address[](0),
+            bountyCaps: new uint256[](0)
+        });
+        vm.prank(executor);
+        bytes32 pid = tm.createProject(cfg);
+        console.log("Test project pid:", vm.toString(pid));
+
+        // 5d. Successful 3-task batch.
+        TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](3);
+        inputs[0] = TaskManager.CreateTaskInput({
+            payout: 1 ether,
+            title: bytes("batch-task-a"),
+            metadataHash: bytes32(0),
+            bountyToken: address(0),
+            bountyPayout: 0,
+            requiresApplication: false
+        });
+        inputs[1] = TaskManager.CreateTaskInput({
+            payout: 2 ether,
+            title: bytes("batch-task-b"),
+            metadataHash: bytes32(0),
+            bountyToken: address(0),
+            bountyPayout: 0,
+            requiresApplication: false
+        });
+        inputs[2] = TaskManager.CreateTaskInput({
+            payout: 3 ether,
+            title: bytes("batch-task-c"),
+            metadataHash: bytes32(0),
+            bountyToken: address(0),
+            bountyPayout: 0,
+            requiresApplication: false
+        });
+
+        vm.prank(executor);
+        uint256[] memory ids = tm.createTasksBatch(pid, inputs);
+        require(ids.length == 3, "DryRun: batch returned wrong length");
+        require(ids[1] == ids[0] + 1 && ids[2] == ids[1] + 1, "DryRun: ids not sequential");
+        console.log("createTasksBatch returned ids:", ids[0], ids[1], ids[2]);
+
+        // 5e. Verify each task has the right projectId via the lens path.
+        for (uint256 i; i < 3; ++i) {
+            bytes memory taskBytes = tm.getLensData(1, abi.encode(ids[i]));
+            (bytes32 taskPid,,,,,,) =
+                abi.decode(taskBytes, (bytes32, uint96, address, uint96, bool, TaskManager.Status, address));
+            require(taskPid == pid, "DryRun: task projectId mismatch");
+        }
+        console.log("All 3 tasks have correct projectId");
+
+        // 5f. Atomicity: batch with a bad final task must leave nextTaskId stable.
+        //     Capture pre-state by trying to read id == ids[2] + 1 (should revert).
+        uint256 expectedNextId = ids[2] + 1;
+        bytes memory probeBefore =
+            abi.encodeWithSelector(TaskManager.getLensData.selector, uint8(1), abi.encode(expectedNextId));
+        (bool existsBefore,) = proxy.staticcall(probeBefore);
+        require(!existsBefore, "DryRun: pre-revert next id already exists");
+
+        TaskManager.CreateTaskInput[] memory bad = new TaskManager.CreateTaskInput[](3);
+        bad[0] = inputs[0];
+        bad[1] = inputs[1];
+        bad[2] = TaskManager.CreateTaskInput({
+            payout: 0, // invalid: triggers InvalidPayout
+            title: bytes("zero-payout"),
+            metadataHash: bytes32(0),
+            bountyToken: address(0),
+            bountyPayout: 0,
+            requiresApplication: false
+        });
+
+        vm.prank(executor);
+        (bool okBad,) = proxy.call(abi.encodeCall(TaskManager.createTasksBatch, (pid, bad)));
+        require(!okBad, "DryRun: bad batch must revert");
+
+        // After revert, the same probe must still fail — counter did not advance.
+        (bool existsAfter,) = proxy.staticcall(probeBefore);
+        require(!existsAfter, "DryRun: nextTaskId advanced despite atomic revert");
+        console.log("Atomic revert preserved nextTaskId");
+    }
+}

--- a/src/TaskManager.sol
+++ b/src/TaskManager.sol
@@ -43,6 +43,7 @@ contract TaskManager is Initializable, ContextUpgradeable {
     error InvalidIndex();
     error SelfReviewNotAllowed();
     error ArrayLengthMismatch();
+    error EmptyBatch();
 
     /*──────── Constants ─────*/
     bytes4 public constant MODULE_ID = 0x54534b32; // "TSK2"
@@ -106,6 +107,15 @@ contract TaskManager is Initializable, ContextUpgradeable {
 
     struct BootstrapTaskConfig {
         uint8 projectIndex; // References project in same batch (0 for first project)
+        uint256 payout;
+        bytes title;
+        bytes32 metadataHash;
+        address bountyToken;
+        uint256 bountyPayout;
+        bool requiresApplication;
+    }
+
+    struct CreateTaskInput {
         uint256 payout;
         bytes title;
         bytes32 metadataHash;
@@ -434,6 +444,36 @@ contract TaskManager is Initializable, ContextUpgradeable {
         _createTask(payout, title, metadataHash, pid, requiresApplication, bountyToken, bountyPayout);
     }
 
+    /**
+     * @notice Create multiple tasks in a single project in one transaction.
+     * @dev Permission is checked once for the whole batch; project existence and
+     *      per-task validation still run inside `_createTask`. All-or-nothing:
+     *      any failure reverts the entire call.
+     * @param pid    Project ID all tasks will be created under.
+     * @param tasks  Array of task configurations, in the order they should be created.
+     * @return taskIds IDs of the newly-created tasks, in the same order as `tasks`.
+     */
+    function createTasksBatch(bytes32 pid, CreateTaskInput[] calldata tasks)
+        external
+        returns (uint256[] memory taskIds)
+    {
+        if (tasks.length == 0) revert EmptyBatch();
+        _requireCanCreate(pid);
+
+        uint256 len = tasks.length;
+        taskIds = new uint256[](len);
+
+        for (uint256 i; i < len;) {
+            CreateTaskInput calldata t = tasks[i];
+            taskIds[i] = _createTask(
+                t.payout, t.title, t.metadataHash, pid, t.requiresApplication, t.bountyToken, t.bountyPayout
+            );
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
     function _createTask(
         uint256 payout,
         bytes calldata title,
@@ -442,7 +482,7 @@ contract TaskManager is Initializable, ContextUpgradeable {
         bool requiresApplication,
         address bountyToken,
         uint256 bountyPayout
-    ) internal {
+    ) internal returns (uint48 id) {
         Layout storage l = _layout();
         ValidationLib.requireValidTitle(title);
         ValidationLib.requireValidPayout96(payout);
@@ -463,7 +503,7 @@ contract TaskManager is Initializable, ContextUpgradeable {
             bb.addSpent(bountyPayout);
         }
 
-        uint48 id = l.nextTaskId++;
+        id = l.nextTaskId++;
         l._tasks[id] = Task(
             pid, uint96(payout), address(0), uint96(bountyPayout), requiresApplication, Status.UNCLAIMED, bountyToken
         );

--- a/test/TaskManager.t.sol
+++ b/test/TaskManager.t.sol
@@ -6761,3 +6761,404 @@ contract MockToken is Test, IERC20 {
                 assertEq(spent, 0, "Bootstrap spent should be zero");
             }
         }
+
+        contract TaskManagerCreateTasksBatchTest is TaskManagerTestBase {
+            bytes32 PID;
+            bytes32 BOUNTY_PID;
+            MockERC20 bountyToken;
+
+            function setUp() public {
+                setUpBase();
+                bountyToken = new MockERC20();
+                bountyToken.mint(address(tm), 1000 ether);
+
+                PID = _createDefaultProject("BATCH", 0);
+
+                address[] memory tokens = new address[](1);
+                tokens[0] = address(bountyToken);
+                uint256[] memory caps = new uint256[](1);
+                caps[0] = 5 ether;
+                BOUNTY_PID = _createProjectWithBountyBudget("BATCH_BOUNTY", 10 ether, tokens, caps);
+            }
+
+            function _mkInput(uint256 payout, bytes memory title)
+                internal
+                pure
+                returns (TaskManager.CreateTaskInput memory)
+            {
+                return TaskManager.CreateTaskInput({
+                    payout: payout,
+                    title: title,
+                    metadataHash: bytes32(0),
+                    bountyToken: address(0),
+                    bountyPayout: 0,
+                    requiresApplication: false
+                });
+            }
+
+            function _projectSpent(bytes32 pid) internal view returns (uint128 spent) {
+                bytes memory result =
+                    lens.getStorage(address(tm), TaskManagerLens.StorageKey.PROJECT_INFO, abi.encode(pid));
+                (, uint128 s,) = abi.decode(result, (uint128, uint128, bool));
+                spent = s;
+            }
+
+            function _bountySpent(bytes32 pid, address tok) internal view returns (uint128 spent) {
+                bytes memory result =
+                    lens.getStorage(address(tm), TaskManagerLens.StorageKey.BOUNTY_BUDGET, abi.encode(pid, tok));
+                (, uint128 s) = abi.decode(result, (uint128, uint128));
+                spent = s;
+            }
+
+            function _taskProjectId(uint256 id) internal view returns (bytes32 projectId) {
+                bytes memory result = lens.getStorage(address(tm), TaskManagerLens.StorageKey.TASK_INFO, abi.encode(id));
+                (,,, bytes32 pid,) = abi.decode(result, (uint256, TaskManager.Status, address, bytes32, bool));
+                projectId = pid;
+            }
+
+            /*───────────────── HAPPY PATHS ─────────────────*/
+
+            function test_CreateTasksBatch_HappyPath_FiveTasks() public {
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](5);
+                inputs[0] = _mkInput(1 ether, bytes("a"));
+                inputs[1] = _mkInput(2 ether, bytes("b"));
+                inputs[2] = _mkInput(3 ether, bytes("c"));
+                inputs[3] = _mkInput(4 ether, bytes("d"));
+                inputs[4] = _mkInput(5 ether, bytes("e"));
+
+                vm.prank(creator1);
+                uint256[] memory ids = tm.createTasksBatch(PID, inputs);
+
+                assertEq(ids.length, 5, "should return five ids");
+                for (uint256 i; i < 5; ++i) {
+                    assertEq(ids[i], i, "ids should be sequential from 0");
+                    assertEq(_taskProjectId(ids[i]), PID, "task should belong to PID");
+                }
+                assertEq(_projectSpent(PID), 15 ether, "spent should equal sum of payouts");
+            }
+
+            function test_CreateTasksBatch_EmitsTaskCreatedPerTask() public {
+                // Bind expected ids to a prior task so any reordering bug surfaces
+                // (without the seed, ids and loop indices coincidentally match starting at 0).
+                vm.prank(creator1);
+                tm.createTask(1 ether, bytes("seed"), bytes32(0), PID, address(0), 0, false);
+
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](3);
+                inputs[0] = _mkInput(1 ether, bytes("title-a"));
+                inputs[1] = _mkInput(2 ether, bytes("title-b"));
+                inputs[2] = _mkInput(3 ether, bytes("title-c"));
+
+                for (uint256 i; i < 3; ++i) {
+                    vm.expectEmit(true, true, false, true, address(tm));
+                    emit TaskManager.TaskCreated(
+                        i + 1, PID, inputs[i].payout, address(0), 0, false, inputs[i].title, bytes32(0)
+                    );
+                }
+
+                vm.prank(creator1);
+                uint256[] memory ids = tm.createTasksBatch(PID, inputs);
+
+                for (uint256 i; i < 3; ++i) {
+                    assertEq(ids[i], i + 1, "returned id must match emitted event id");
+                }
+            }
+
+            function test_CreateTasksBatch_MixedRequiresApplicationFlag() public {
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](3);
+                inputs[0] = TaskManager.CreateTaskInput({
+                    payout: 1 ether,
+                    title: bytes("open"),
+                    metadataHash: bytes32(0),
+                    bountyToken: address(0),
+                    bountyPayout: 0,
+                    requiresApplication: true
+                });
+                inputs[1] = _mkInput(1 ether, bytes("claimable"));
+                inputs[2] = TaskManager.CreateTaskInput({
+                    payout: 1 ether,
+                    title: bytes("open-2"),
+                    metadataHash: bytes32(0),
+                    bountyToken: address(0),
+                    bountyPayout: 0,
+                    requiresApplication: true
+                });
+
+                vm.prank(creator1);
+                uint256[] memory ids = tm.createTasksBatch(PID, inputs);
+
+                bytes memory r0 = lens.getStorage(address(tm), TaskManagerLens.StorageKey.TASK_INFO, abi.encode(ids[0]));
+                bytes memory r1 = lens.getStorage(address(tm), TaskManagerLens.StorageKey.TASK_INFO, abi.encode(ids[1]));
+                bytes memory r2 = lens.getStorage(address(tm), TaskManagerLens.StorageKey.TASK_INFO, abi.encode(ids[2]));
+                (,,,, bool ra0) = abi.decode(r0, (uint256, TaskManager.Status, address, bytes32, bool));
+                (,,,, bool ra1) = abi.decode(r1, (uint256, TaskManager.Status, address, bytes32, bool));
+                (,,,, bool ra2) = abi.decode(r2, (uint256, TaskManager.Status, address, bytes32, bool));
+                assertTrue(ra0, "task 0 should require application");
+                assertFalse(ra1, "task 1 should be directly claimable");
+                assertTrue(ra2, "task 2 should require application");
+
+                // Sanity end-to-end: directly-claimable task can be claimed; application-required cannot.
+                vm.prank(member1);
+                tm.claimTask(ids[1]);
+                vm.prank(member1);
+                vm.expectRevert(TaskManager.RequiresApplication.selector);
+                tm.claimTask(ids[0]);
+            }
+
+            function test_CreateTasksBatch_WithBountyTokens() public {
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](2);
+                inputs[0] = TaskManager.CreateTaskInput({
+                    payout: 1 ether,
+                    title: bytes("bounty-a"),
+                    metadataHash: bytes32(0),
+                    bountyToken: address(bountyToken),
+                    bountyPayout: 1 ether,
+                    requiresApplication: false
+                });
+                inputs[1] = TaskManager.CreateTaskInput({
+                    payout: 1 ether,
+                    title: bytes("bounty-b"),
+                    metadataHash: bytes32(0),
+                    bountyToken: address(bountyToken),
+                    bountyPayout: 2 ether,
+                    requiresApplication: false
+                });
+
+                vm.prank(creator1);
+                tm.createTasksBatch(BOUNTY_PID, inputs);
+
+                assertEq(_projectSpent(BOUNTY_PID), 2 ether, "PT spent should accumulate");
+                assertEq(_bountySpent(BOUNTY_PID, address(bountyToken)), 3 ether, "bounty spent should accumulate");
+            }
+
+            function test_CreateTasksBatch_MixedBountyAndNonBounty() public {
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](3);
+                inputs[0] = TaskManager.CreateTaskInput({
+                    payout: 1 ether,
+                    title: bytes("with-bounty"),
+                    metadataHash: bytes32(0),
+                    bountyToken: address(bountyToken),
+                    bountyPayout: 2 ether,
+                    requiresApplication: false
+                });
+                inputs[1] = _mkInput(1 ether, bytes("plain"));
+                inputs[2] = TaskManager.CreateTaskInput({
+                    payout: 1 ether,
+                    title: bytes("with-bounty-2"),
+                    metadataHash: bytes32(0),
+                    bountyToken: address(bountyToken),
+                    bountyPayout: 1 ether,
+                    requiresApplication: false
+                });
+
+                vm.prank(creator1);
+                tm.createTasksBatch(BOUNTY_PID, inputs);
+
+                assertEq(_bountySpent(BOUNTY_PID, address(bountyToken)), 3 ether, "only bounty tasks count");
+            }
+
+            function test_CreateTasksBatch_IdsContinueAfterPriorCreate() public {
+                vm.prank(creator1);
+                tm.createTask(1 ether, bytes("first"), bytes32(0), PID, address(0), 0, false);
+
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](3);
+                inputs[0] = _mkInput(1 ether, bytes("a"));
+                inputs[1] = _mkInput(1 ether, bytes("b"));
+                inputs[2] = _mkInput(1 ether, bytes("c"));
+
+                vm.prank(creator1);
+                uint256[] memory ids = tm.createTasksBatch(PID, inputs);
+
+                assertEq(ids[0], 1, "should continue after prior id 0");
+                assertEq(ids[1], 2);
+                assertEq(ids[2], 3);
+            }
+
+            function test_CreateTasksBatch_ExecutorCanCall() public {
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](2);
+                inputs[0] = _mkInput(1 ether, bytes("a"));
+                inputs[1] = _mkInput(1 ether, bytes("b"));
+
+                vm.prank(executor);
+                uint256[] memory ids = tm.createTasksBatch(PID, inputs);
+
+                assertEq(ids.length, 2);
+            }
+
+            function test_CreateTasksBatch_ProjectManagerCanCall() public {
+                vm.prank(executor);
+                tm.setConfig(TaskManager.ConfigKey.PROJECT_MANAGER, abi.encode(PID, pm1, true));
+
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](2);
+                inputs[0] = _mkInput(1 ether, bytes("a"));
+                inputs[1] = _mkInput(1 ether, bytes("b"));
+
+                vm.prank(pm1);
+                uint256[] memory ids = tm.createTasksBatch(PID, inputs);
+
+                assertEq(ids.length, 2);
+            }
+
+            /*───────────────── REVERTS ─────────────────*/
+
+            function test_RevertWhen_CreateTasksBatch_Empty() public {
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](0);
+                vm.prank(creator1);
+                vm.expectRevert(TaskManager.EmptyBatch.selector);
+                tm.createTasksBatch(PID, inputs);
+            }
+
+            function test_RevertWhen_CreateTasksBatch_NoPermission() public {
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](1);
+                inputs[0] = _mkInput(1 ether, bytes("a"));
+
+                vm.prank(outsider);
+                vm.expectRevert(TaskManager.Unauthorized.selector);
+                tm.createTasksBatch(PID, inputs);
+            }
+
+            function test_RevertWhen_CreateTasksBatch_ProjectNotFound() public {
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](1);
+                inputs[0] = _mkInput(1 ether, bytes("a"));
+
+                // Executor bypasses permission via _isPM, then hits NotFound inside _createTask.
+                vm.prank(executor);
+                vm.expectRevert(TaskManager.NotFound.selector);
+                tm.createTasksBatch(bytes32("does-not-exist"), inputs);
+            }
+
+            function test_RevertWhen_CreateTasksBatch_ZeroPayout() public {
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](2);
+                inputs[0] = _mkInput(1 ether, bytes("a"));
+                inputs[1] = _mkInput(0, bytes("zero-payout"));
+
+                vm.prank(creator1);
+                vm.expectRevert(ValidationLib.InvalidPayout.selector);
+                tm.createTasksBatch(PID, inputs);
+            }
+
+            function test_RevertWhen_CreateTasksBatch_EmptyTitle() public {
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](1);
+                inputs[0] = _mkInput(1 ether, bytes(""));
+
+                vm.prank(creator1);
+                vm.expectRevert(ValidationLib.EmptyTitle.selector);
+                tm.createTasksBatch(PID, inputs);
+            }
+
+            function test_RevertWhen_CreateTasksBatch_TitleTooLong() public {
+                bytes memory longTitle = new bytes(257);
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](1);
+                inputs[0] = _mkInput(1 ether, longTitle);
+
+                vm.prank(creator1);
+                vm.expectRevert(ValidationLib.TitleTooLong.selector);
+                tm.createTasksBatch(PID, inputs);
+            }
+
+            function test_RevertWhen_CreateTasksBatch_PayoutOverflow() public {
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](1);
+                inputs[0] = _mkInput(1e24 + 1, bytes("too-big"));
+
+                vm.prank(creator1);
+                vm.expectRevert(ValidationLib.InvalidPayout.selector);
+                tm.createTasksBatch(PID, inputs);
+            }
+
+            function test_RevertWhen_CreateTasksBatch_ExceedsProjectCap() public {
+                bytes32 cappedPid = _createDefaultProject("CAPPED_BATCH", 2 ether);
+
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](3);
+                inputs[0] = _mkInput(1 ether, bytes("a"));
+                inputs[1] = _mkInput(1 ether, bytes("b"));
+                inputs[2] = _mkInput(1, bytes("over"));
+
+                vm.prank(creator1);
+                vm.expectRevert(BudgetLib.BudgetExceeded.selector);
+                tm.createTasksBatch(cappedPid, inputs);
+
+                // Atomicity: nothing should have been written.
+                assertEq(_projectSpent(cappedPid), 0, "spent must be unchanged after revert");
+            }
+
+            function test_RevertWhen_CreateTasksBatch_ExceedsBountyCap() public {
+                // BOUNTY_PID has bounty cap of 5 ether.
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](2);
+                inputs[0] = TaskManager.CreateTaskInput({
+                    payout: 1 ether,
+                    title: bytes("a"),
+                    metadataHash: bytes32(0),
+                    bountyToken: address(bountyToken),
+                    bountyPayout: 4 ether,
+                    requiresApplication: false
+                });
+                inputs[1] = TaskManager.CreateTaskInput({
+                    payout: 1 ether,
+                    title: bytes("b"),
+                    metadataHash: bytes32(0),
+                    bountyToken: address(bountyToken),
+                    bountyPayout: 2 ether,
+                    requiresApplication: false
+                });
+
+                vm.prank(creator1);
+                vm.expectRevert(BudgetLib.BudgetExceeded.selector);
+                tm.createTasksBatch(BOUNTY_PID, inputs);
+
+                assertEq(_bountySpent(BOUNTY_PID, address(bountyToken)), 0, "bounty spent must roll back");
+                assertEq(_projectSpent(BOUNTY_PID), 0, "PT spent must roll back");
+            }
+
+            function test_RevertWhen_CreateTasksBatch_BadBountyConfig_TokenZeroPayoutPositive() public {
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](1);
+                inputs[0] = TaskManager.CreateTaskInput({
+                    payout: 1 ether,
+                    title: bytes("bad"),
+                    metadataHash: bytes32(0),
+                    bountyToken: address(0),
+                    bountyPayout: 1 ether,
+                    requiresApplication: false
+                });
+
+                vm.prank(creator1);
+                vm.expectRevert(ValidationLib.ZeroAddress.selector);
+                tm.createTasksBatch(BOUNTY_PID, inputs);
+            }
+
+            function test_RevertWhen_CreateTasksBatch_BadBountyConfig_TokenSetPayoutZero() public {
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](1);
+                inputs[0] = TaskManager.CreateTaskInput({
+                    payout: 1 ether,
+                    title: bytes("bad"),
+                    metadataHash: bytes32(0),
+                    bountyToken: address(bountyToken),
+                    bountyPayout: 0,
+                    requiresApplication: false
+                });
+
+                vm.prank(creator1);
+                vm.expectRevert(ValidationLib.InvalidPayout.selector);
+                tm.createTasksBatch(BOUNTY_PID, inputs);
+            }
+
+            function test_RevertWhen_CreateTasksBatch_AtomicityOnLastFailure() public {
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](6);
+                for (uint256 i; i < 5; ++i) {
+                    inputs[i] = _mkInput(1 ether, bytes("ok"));
+                }
+                inputs[5] = _mkInput(0, bytes("bad")); // zero payout reverts
+
+                vm.prank(creator1);
+                vm.expectRevert(ValidationLib.InvalidPayout.selector);
+                tm.createTasksBatch(PID, inputs);
+
+                assertEq(_projectSpent(PID), 0, "spent must be unchanged after atomic revert");
+
+                // nextTaskId atomicity: a fresh task after the failed batch must get id 0,
+                // proving the counter never advanced inside the reverted loop.
+                vm.prank(creator1);
+                tm.createTask(1 ether, bytes("post-revert"), bytes32(0), PID, address(0), 0, false);
+                bytes memory result = lens.getStorage(address(tm), TaskManagerLens.StorageKey.TASK_INFO, abi.encode(0));
+                (,,, bytes32 projectId,) = abi.decode(result, (uint256, TaskManager.Status, address, bytes32, bool));
+                assertEq(projectId, PID, "id 0 must be the post-revert task: counter did not advance");
+            }
+        }


### PR DESCRIPTION
## Summary
- Adds `createTasksBatch(bytes32 pid, CreateTaskInput[])` to TaskManager: project leads can create N tasks in one tx with one hoisted permission check (one Hats `balanceOfBatch` instead of N), atomic revert-all on any failure. `_createTask` now returns the new id; no Layout / event-signature changes — drop-in safe for upgrades and the existing subgraph.
- 20 new tests covering happy paths, mixed bounty configs, executor/PM bypass, every revert path, and atomicity (asserts both `spent` and `nextTaskId` are unchanged after a failed batch). 1308/1308 repo tests pass.
- Adds `script/upgrades/UpgradeTaskManagerCreateTasksBatch.s.sol` with the standard 3-step cross-chain flow (Gnosis deploy → Arbitrum deploy + cross-chain beacon upgrade → verify) plus a DryRun that forks Gnosis, swaps the beacon, and exercises `createTasksBatch` end-to-end against a real org's live TaskManager proxy.
- Bumps the default `gnosis` RPC to `rpc.gnosischain.com` (with drpc/ankr/gateway aliases) since dRPC was returning intermittent 500s during fork testing.

## Test plan
- [x] \`forge test\` — 1308/1308 pass
- [x] \`forge fmt --check\` — clean across all touched files
- [x] \`forge script ...:DryRun_GnosisUpgrade --rpc-url gnosis\` — passes against forked live state (storage preserved, ids sequential, atomic revert verified on real proxy)
- [ ] Broadcast Step1 → Step2 → wait ~5min → Step3