### PR TITLE
feat(paymaster): autowhitelist createTasksBatch + retroactive fix for KUBI/Poa/Test6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Any new forge script that mutates on-chain state (`Hub.adminCall`, `Hub.adminCal
 When you need to find an org's deployed contract addresses (TaskManager, Executor, QuickJoin, etc.), query the Poa subgraph rather than spelunking on-chain. It's the canonical source for `(orgId → contracts)` and is faster than fork-querying OrgRegistry.
 
 - **Gnosis** endpoint: `https://api.studio.thegraph.com/query/73367/poa-gnosis-v-1/version/latest`
-- **Arbitrum** endpoint: `https://api.studio.thegraph.com/query/73367/poa-arb-v-1/version/latest` *(note: chain prefix is `arb`, not `arbitrum`)*
+- **Arbitrum** endpoint: `https://api.studio.thegraph.com/query/73367/poa-arb-v-1/version/latest`
 - Schema: https://github.com/poa-box/subgraph-pop/blob/main/pop-subgraph/schema.graphql
 - Manifest (chain network names + start blocks): https://github.com/poa-box/subgraph-pop/blob/main/pop-subgraph/subgraph.yaml
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,43 @@
 - Slither runs in CI — fails on `high` severity; `arbitrary-send-eth` detector excluded (see `slither.config.json`)
 - Upgrade safety validated in CI against `upgrades/baseline` storage layouts
 
+## Forge scripts — simulate before declaring done
+
+Any new forge script that mutates on-chain state (`Hub.adminCall`, `Hub.adminCallCrossChain`, `Satellite.adminCall`, beacon upgrades, `setRulesBatch`, etc.) must be simulated against a real RPC fork before being called complete. `forge build` + a unit test selector check is **not** enough — transport/permission/struct-decoding bugs only show up against live state.
+
+**Required setup for every new mutating script:**
+
+1. Pair every `BroadcastX` contract with a `SimX` sibling that exercises the exact same call path under `vm.prank(<actual on-chain admin>)`.
+2. The admin EOA for Hub / Satellite / paymaster admin calls is **`0xA6F4D9f44Dd980b7168D829d5f74c2b00a46b2c9`** (Hudson). Owners of `PoaManagerHub` (Arbitrum) and `PoaManagerSatellite` (Gnosis) are this address — prank as it, don't read `Hub.owner()` and reuse the result, in case ownership ever changes mid-fork.
+3. Sims must call `getRule` / `getCurrentImplementationById` / etc. **before and after** the mutation and `require()` the expected change. Don't trust events alone — match the actual return type of the read function (e.g. PaymasterHub's `getRule` returns `Rule { uint32 maxCallGasHint; bool allowed }`, in that field order — decoding it as `(bool, uint32)` silently swaps the values).
+4. For cross-chain state (Hub on Arbitrum dispatching to Gnosis Satellite), prefer running on the destination chain via `Satellite.adminCall` over Hyperlane'd `adminCallCrossChain` — same destination effect, no 0.005 ETH fee, no 5-min relay wait. Cross-chain dispatch is also ~impossible to fully simulate locally.
+5. Run the sim end-to-end and confirm `PASS` output before writing any "ready to broadcast" message:
+   ```sh
+   forge script <path>:SimX --fork-url <chain> -vvv
+   ```
+6. Production profile (`FOUNDRY_PROFILE=production`) on this branch currently has a pre-existing `Stack too deep` issue independent of any single script — default profile is the one that has to compile cleanly for every change.
+
+## Subgraph (live deployment lookups)
+
+When you need to find an org's deployed contract addresses (TaskManager, Executor, QuickJoin, etc.), query the Poa subgraph rather than spelunking on-chain. It's the canonical source for `(orgId → contracts)` and is faster than fork-querying OrgRegistry.
+
+- **Gnosis** endpoint: `https://api.studio.thegraph.com/query/73367/poa-gnosis-v-1/version/latest`
+- **Arbitrum** endpoint: `https://api.studio.thegraph.com/query/73367/poa-arb-v-1/version/latest` *(note: chain prefix is `arb`, not `arbitrum`)*
+- Schema: https://github.com/poa-box/subgraph-pop/blob/main/pop-subgraph/schema.graphql
+- Manifest (chain network names + start blocks): https://github.com/poa-box/subgraph-pop/blob/main/pop-subgraph/subgraph.yaml
+
+Each chain runs its own subgraph — Poa governance lives on Arbitrum, KUBI/Test6/etc. on Gnosis. Query the chain where the org was deployed.
+
+Quick recipe — find an org's TaskManager + Executor + QuickJoin from its `orgId`:
+
+```bash
+curl -s -X POST 'https://api.studio.thegraph.com/query/73367/poa-arb-v-1/version/latest' \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"{ organization(id: \"0xa71879ef0e38b15fe7080196c0102f859e0ca8e7b8c0703ec8df03c66befd069\") { name taskManager { id } executorContract { id } quickJoin { id } } }"}'
+```
+
+Useful root entities: `Organization`, `TaskManager`, `Project`, `Task`, `User`, `RegisteredContract`, `GovernanceModule`. The `Organization` entity links to every per-org contract via fields like `executorContract`, `hybridVoting`, `directDemocracyVoting`, `quickJoin`, `participationToken`, `taskManager`, `educationHub`, `paymentManager`, `eligibilityModule`, `toggleModuleContract` — each is the proxy address.
+
 ## References
 
 - `docs/POP_OVERVIEW.md` — full protocol architecture and use cases

--- a/script/fixes/AddCreateTasksBatchSelectorRules.s.sol
+++ b/script/fixes/AddCreateTasksBatchSelectorRules.s.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+
+/*
+ * ============================================================================
+ * Add createTasksBatch selector to existing org paymaster whitelists
+ * ============================================================================
+ *
+ * Companion to UpgradeTaskManagerCreateTasksBatch.s.sol (PR #151), which
+ * upgraded the TaskManager beacon impl on Gnosis + Arbitrum. The new
+ * createTasksBatch selector (0xc18aa1c9) is now live on the impl, but the
+ * three existing orgs still need it added to their PaymasterHub rule sets so
+ * 4337/passkey users do not hit RuleDenied(TaskManager, 0xc18aa1c9).
+ *
+ * Each org is updated on the chain it lives on:
+ *   - Poa   (Arbitrum) — Hub.adminCall(ARB_PM, setRulesBatch)
+ *   - KUBI  (Gnosis)   — Satellite.adminCall(GNOSIS_PM, setRulesBatch)
+ *   - Test6 (Gnosis)   — Satellite.adminCall(GNOSIS_PM, setRulesBatch)
+ *
+ * The Hub on Arbitrum and the Satellite on Gnosis are both owned by the same
+ * deployer EOA, so all four rule writes use that single signer.
+ *
+ * Deployer / Hub.owner / Satellite.owner: 0xA6F4D9f44Dd980b7168D829d5f74c2b00a46b2c9
+ *
+ * TaskManager addresses resolved via subgraph (Organization.taskManager.id) —
+ * see CLAUDE.md "Subgraph (live deployment lookups)".
+ *
+ * Usage (sims — run these first):
+ *   forge script script/fixes/AddCreateTasksBatchSelectorRules.s.sol:SimAddBatchSelectorArbitrum --fork-url arbitrum -vvv
+ *   forge script script/fixes/AddCreateTasksBatchSelectorRules.s.sol:SimAddBatchSelectorGnosis  --fork-url gnosis  -vvv
+ *
+ * Usage (broadcast):
+ *   source .env && forge script script/fixes/AddCreateTasksBatchSelectorRules.s.sol:BroadcastAddBatchSelectorPoa     --rpc-url arbitrum --broadcast --slow
+ *   source .env && forge script script/fixes/AddCreateTasksBatchSelectorRules.s.sol:BroadcastAddBatchSelectorGnosis  --rpc-url gnosis  --broadcast --slow
+ * ============================================================================
+ */
+
+interface IHub {
+    function adminCall(address target, bytes calldata data) external returns (bytes memory);
+    function owner() external view returns (address);
+}
+
+interface IPoaManagerSatellite {
+    function adminCall(address target, bytes calldata data) external returns (bytes memory);
+    function owner() external view returns (address);
+    function poaManager() external view returns (address);
+}
+
+interface IPM {
+    struct Rule {
+        uint32 maxCallGasHint;
+        bool allowed;
+    }
+
+    function getRule(bytes32 orgId, address target, bytes4 sel) external view returns (Rule memory);
+}
+
+// ─── Shared infra addresses ──────────────────────────────────────────────────
+address constant DEPLOYER = 0xA6F4D9f44Dd980b7168D829d5f74c2b00a46b2c9;
+address constant HUB = 0xB72840B343654eAfb2CFf7acC4Fc6b59E6c3CC71; // PoaManagerHub on Arbitrum
+address constant ARB_PM = 0xD6659bCaFAdCB9CC2F57B7aE923c7F1Ca4438a11; // PaymasterHub on Arbitrum
+address constant GNOSIS_PM = 0xdEf1038C297493c0b5f82F0CDB49e929B53B4108; // PaymasterHub on Gnosis
+address constant GNOSIS_SATELLITE = 0x4Ad70029a9247D369a5bEA92f90840B9ee58eD06; // PoaManagerSatellite on Gnosis
+
+// ─── Org IDs ─────────────────────────────────────────────────────────────────
+bytes32 constant POA_ORG = 0xa71879ef0e38b15fe7080196c0102f859e0ca8e7b8c0703ec8df03c66befd069;
+bytes32 constant KUBI_ORG = 0xc0f2765d555e21bfad5c6b05accef86a5758e0dee3e9a5b4ee3c3f3069c2102e;
+bytes32 constant TEST6_ORG = 0x263b2b29f392647f0fb8ddbb26f099e812ab4ba2777e5e07b906277164181f6b;
+
+// ─── TaskManager proxy addresses (resolved via subgraph) ─────────────────────
+address constant POA_TM = 0x681f29751724D2bED331d3EB35e0C9B1C57aF9F0;
+address constant KUBI_TM = 0xF57024fC77915Fce8f2608afdd027941bCEE3336;
+address constant TEST6_TM = 0x3d93f0D090356D25E7a1614F0F8764b103ca99bc;
+
+// ─── New selector ────────────────────────────────────────────────────────────
+// keccak256("createTasksBatch(bytes32,(uint256,bytes,bytes32,address,uint256,bool)[])")[:4]
+bytes4 constant SEL_CREATE_TASKS_BATCH = 0xc18aa1c9;
+
+abstract contract Base is Script {
+    /// @dev Build the inner setRulesBatch calldata for a single (target, selector) row.
+    function _buildInner(bytes32 orgId, address taskManager) internal pure returns (bytes memory) {
+        address[] memory targets = new address[](1);
+        bytes4[] memory sels = new bytes4[](1);
+        bool[] memory allowed = new bool[](1);
+        uint32[] memory hints = new uint32[](1);
+        targets[0] = taskManager;
+        sels[0] = SEL_CREATE_TASKS_BATCH;
+        allowed[0] = true;
+        return abi.encodeWithSignature(
+            "setRulesBatch(bytes32,address[],bytes4[],bool[],uint32[])", orgId, targets, sels, allowed, hints
+        );
+    }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ *                         POA — Arbitrum (Hub.adminCall)
+ * ────────────────────────────────────────────────────────────────────────*/
+
+contract BroadcastAddBatchSelectorPoa is Base {
+    function run() public {
+        uint256 key = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        address deployer = vm.addr(key);
+        require(deployer == DEPLOYER, "Sender must be the Hub owner (Hudson)");
+        require(IHub(HUB).owner() == deployer, "Hub owner mismatch");
+
+        console.log("\n=== Add createTasksBatch -- Poa (Arbitrum) ===");
+        console.log("TaskManager:", POA_TM);
+
+        bytes memory inner = _buildInner(POA_ORG, POA_TM);
+
+        vm.startBroadcast(key);
+        IHub(HUB).adminCall(ARB_PM, inner);
+        vm.stopBroadcast();
+
+        require(IPM(ARB_PM).getRule(POA_ORG, POA_TM, SEL_CREATE_TASKS_BATCH).allowed, "Rule not set after broadcast");
+        console.log("Poa createTasksBatch rule set on Arbitrum.");
+    }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ *               KUBI + TEST6 — Gnosis (Satellite.adminCall)
+ * ────────────────────────────────────────────────────────────────────────*/
+
+contract BroadcastAddBatchSelectorGnosis is Base {
+    function run() public {
+        uint256 key = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        address deployer = vm.addr(key);
+        require(deployer == DEPLOYER, "Sender must own the Gnosis Satellite (Hudson)");
+        require(IPoaManagerSatellite(GNOSIS_SATELLITE).owner() == deployer, "Satellite owner mismatch");
+
+        console.log("\n=== Add createTasksBatch -- KUBI + Test6 (Gnosis) ===");
+        console.log("KUBI TaskManager: ", KUBI_TM);
+        console.log("Test6 TaskManager:", TEST6_TM);
+
+        vm.startBroadcast(key);
+        IPoaManagerSatellite(GNOSIS_SATELLITE).adminCall(GNOSIS_PM, _buildInner(KUBI_ORG, KUBI_TM));
+        IPoaManagerSatellite(GNOSIS_SATELLITE).adminCall(GNOSIS_PM, _buildInner(TEST6_ORG, TEST6_TM));
+        vm.stopBroadcast();
+
+        require(
+            IPM(GNOSIS_PM).getRule(KUBI_ORG, KUBI_TM, SEL_CREATE_TASKS_BATCH).allowed,
+            "KUBI rule not set after broadcast"
+        );
+        require(
+            IPM(GNOSIS_PM).getRule(TEST6_ORG, TEST6_TM, SEL_CREATE_TASKS_BATCH).allowed,
+            "Test6 rule not set after broadcast"
+        );
+        console.log("KUBI + Test6 createTasksBatch rules set on Gnosis.");
+    }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ *                              SIMULATIONS
+ * ────────────────────────────────────────────────────────────────────────*/
+
+contract SimAddBatchSelectorArbitrum is Base {
+    function run() public {
+        require(IHub(HUB).owner() == DEPLOYER, "Hub owner mismatch (sim assumes Hudson)");
+
+        console.log("\n=== SIM: createTasksBatch -- Poa (Arbitrum fork) ===");
+        console.log("Deployer (pranked):", DEPLOYER);
+        console.log("Poa TaskManager:    ", POA_TM);
+
+        bool before_ = IPM(ARB_PM).getRule(POA_ORG, POA_TM, SEL_CREATE_TASKS_BATCH).allowed;
+        console.log("Before (Poa):", before_);
+
+        bytes memory inner = _buildInner(POA_ORG, POA_TM);
+        vm.prank(DEPLOYER);
+        IHub(HUB).adminCall(ARB_PM, inner);
+
+        bool afterPoa = IPM(ARB_PM).getRule(POA_ORG, POA_TM, SEL_CREATE_TASKS_BATCH).allowed;
+        console.log("After  (Poa):", afterPoa);
+        require(afterPoa, "Poa rule did not stick");
+
+        console.log("PASS: Poa rule set on Arbitrum (sim).");
+    }
+}
+
+contract SimAddBatchSelectorGnosis is Base {
+    function run() public {
+        require(IPoaManagerSatellite(GNOSIS_SATELLITE).owner() == DEPLOYER, "Satellite owner is not Hudson");
+
+        console.log("\n=== SIM: createTasksBatch -- KUBI + Test6 (Gnosis fork) ===");
+        console.log("Deployer (pranked):", DEPLOYER);
+        console.log("KUBI TaskManager:   ", KUBI_TM);
+        console.log("Test6 TaskManager:  ", TEST6_TM);
+
+        bool kBefore = IPM(GNOSIS_PM).getRule(KUBI_ORG, KUBI_TM, SEL_CREATE_TASKS_BATCH).allowed;
+        bool tBefore = IPM(GNOSIS_PM).getRule(TEST6_ORG, TEST6_TM, SEL_CREATE_TASKS_BATCH).allowed;
+        console.log("Before (KUBI):", kBefore);
+        console.log("Before (Test6):", tBefore);
+
+        vm.prank(DEPLOYER);
+        IPoaManagerSatellite(GNOSIS_SATELLITE).adminCall(GNOSIS_PM, _buildInner(KUBI_ORG, KUBI_TM));
+
+        vm.prank(DEPLOYER);
+        IPoaManagerSatellite(GNOSIS_SATELLITE).adminCall(GNOSIS_PM, _buildInner(TEST6_ORG, TEST6_TM));
+
+        bool kAfter = IPM(GNOSIS_PM).getRule(KUBI_ORG, KUBI_TM, SEL_CREATE_TASKS_BATCH).allowed;
+        bool tAfter = IPM(GNOSIS_PM).getRule(TEST6_ORG, TEST6_TM, SEL_CREATE_TASKS_BATCH).allowed;
+        console.log("After  (KUBI):", kAfter);
+        console.log("After  (Test6):", tAfter);
+        require(kAfter && tAfter, "Gnosis rules did not stick");
+
+        console.log("PASS: KUBI + Test6 rules set on Gnosis (sim).");
+    }
+}

--- a/script/upgrades/UpgradeOrgDeployerCreateTasksBatch.s.sol
+++ b/script/upgrades/UpgradeOrgDeployerCreateTasksBatch.s.sol
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import {OrgDeployer} from "../../src/OrgDeployer.sol";
+import {PoaManagerHub} from "../../src/crosschain/PoaManagerHub.sol";
+import {PoaManager} from "../../src/PoaManager.sol";
+import {DeterministicDeployer} from "../../src/crosschain/DeterministicDeployer.sol";
+
+/*
+ * ============================================================================
+ * OrgDeployer v11 — createTasksBatch in default paymaster whitelist
+ * ============================================================================
+ *
+ * Upgrades OrgDeployer so the default paymaster ruleset emitted by deployFullOrg
+ * includes TaskManager.createTasksBatch (selector 0xc18aa1c9). Forward-only:
+ * existing orgs are unaffected (they need AddCreateTasksBatchSelectorRules.s.sol).
+ *
+ * Previous version was v10 (UpgradeOrgDeployerEduRules.s.sol).
+ *
+ * Deployment flow (mirrors UpgradeOrgDeployerEduRules):
+ *   1. Step1_DeployOnGnosis      — deploy impl on Gnosis via DD
+ *   2. Step2_UpgradeFromArbitrum — deploy on Arbitrum via DD + cross-chain beacon upgrade
+ *   3. Step3_Verify              — confirm Gnosis picked up the upgrade after Hyperlane relay
+ *
+ * Commands:
+ *   source .env && FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeOrgDeployerCreateTasksBatch.s.sol:Step1_DeployOnGnosis \
+ *     --rpc-url gnosis --broadcast --slow --private-key $DEPLOYER_PRIVATE_KEY
+ *
+ *   source .env && FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeOrgDeployerCreateTasksBatch.s.sol:Step2_UpgradeFromArbitrum \
+ *     --rpc-url arbitrum --broadcast --slow --private-key $DEPLOYER_PRIVATE_KEY
+ *
+ *   FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeOrgDeployerCreateTasksBatch.s.sol:Step3_Verify \
+ *     --rpc-url gnosis
+ * ============================================================================
+ */
+
+address constant DD = 0x4aC8B5ebEb9D8C3dE3180ddF381D552d59e8835a;
+address constant HUB = 0xB72840B343654eAfb2CFf7acC4Fc6b59E6c3CC71;
+address constant GNOSIS_POA_MANAGER = 0x794fD39e75140ee1545B1B022E5486B7c863789b;
+uint256 constant HYPERLANE_FEE = 0.005 ether;
+string constant VERSION = "v11";
+
+contract Step1_DeployOnGnosis is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        address deployer = vm.addr(deployerKey);
+
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+        bytes32 salt = dd.computeSalt("OrgDeployer", VERSION);
+        address predicted = dd.computeAddress(salt);
+
+        console.log("\n=== Step 1: Deploy OrgDeployer v11 on Gnosis ===");
+        console.log("Deployer: ", deployer);
+        console.log("Predicted:", predicted);
+
+        if (predicted.code.length > 0) {
+            console.log("Already deployed. Skipping.");
+            return;
+        }
+
+        vm.startBroadcast(deployerKey);
+        address deployed = dd.deploy(salt, type(OrgDeployer).creationCode);
+        vm.stopBroadcast();
+
+        require(deployed == predicted, "Address mismatch");
+        console.log("Deployed:", deployed);
+        console.log("\nNext: Run Step2_UpgradeFromArbitrum on Arbitrum");
+    }
+}
+
+contract Step2_UpgradeFromArbitrum is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        address deployer = vm.addr(deployerKey);
+
+        PoaManagerHub hub = PoaManagerHub(payable(HUB));
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+
+        console.log("\n=== Step 2: Upgrade OrgDeployer from Arbitrum ===");
+        require(hub.owner() == deployer, "Deployer must own Hub");
+        require(!hub.paused(), "Hub is paused");
+
+        bytes32 salt = dd.computeSalt("OrgDeployer", VERSION);
+        address impl = dd.computeAddress(salt);
+        console.log("OrgDeployer v11 impl:", impl);
+
+        vm.startBroadcast(deployerKey);
+
+        if (impl.code.length == 0) {
+            address deployed = dd.deploy(salt, type(OrgDeployer).creationCode);
+            require(deployed == impl, "Address mismatch on Arbitrum");
+            console.log("Deployed on Arbitrum");
+        } else {
+            console.log("Already deployed on Arbitrum");
+        }
+
+        hub.upgradeBeaconCrossChain{value: HYPERLANE_FEE}("OrgDeployer", impl, VERSION);
+        console.log("Beacon upgrade dispatched (Arbitrum local + Gnosis cross-chain)");
+
+        vm.stopBroadcast();
+
+        address pm = address(hub.poaManager());
+        address current = PoaManager(pm).getCurrentImplementationById(keccak256("OrgDeployer"));
+        require(current == impl, "Arbitrum impl not upgraded");
+        console.log("Arbitrum upgrade: PASS");
+        console.log("\nWait ~5 min for Hyperlane relay, then run Step3_Verify on Gnosis");
+    }
+}
+
+contract Step3_Verify is Script {
+    function run() public view {
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+        address expected = dd.computeAddress(dd.computeSalt("OrgDeployer", VERSION));
+        address current = PoaManager(GNOSIS_POA_MANAGER).getCurrentImplementationById(keccak256("OrgDeployer"));
+
+        console.log("\n=== Verify Gnosis OrgDeployer Upgrade ===");
+        console.log("Expected:", expected);
+        console.log("Current: ", current);
+        if (current == expected) {
+            console.log("PASS: OrgDeployer v11 live on Gnosis");
+            console.log("New orgs deployed from now on auto-whitelist createTasksBatch (0xc18aa1c9)");
+        } else {
+            console.log("WAITING: Hyperlane message not yet relayed.");
+        }
+    }
+}
+
+/**
+ * @title SimulateOrgDeployerUpgrade
+ * @notice Fork-simulates the upgrade end-to-end on Arbitrum: deploys v11 via DD,
+ *         calls upgradeBeaconCrossChain, verifies Arbitrum impl switched.
+ *         Does NOT verify Gnosis (that requires cross-chain relay).
+ *
+ * Usage:
+ *   FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeOrgDeployerCreateTasksBatch.s.sol:SimulateOrgDeployerUpgrade \
+ *     --rpc-url arbitrum
+ */
+contract SimulateOrgDeployerUpgrade is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        address deployer = vm.addr(deployerKey);
+
+        PoaManagerHub hub = PoaManagerHub(payable(HUB));
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+        address pm = address(hub.poaManager());
+
+        console.log("\n=== SIM: OrgDeployer v11 upgrade (Arbitrum fork) ===");
+        console.log("Deployer:", deployer);
+
+        address before = PoaManager(pm).getCurrentImplementationById(keccak256("OrgDeployer"));
+        console.log("Current impl:", before);
+
+        bytes32 salt = dd.computeSalt("OrgDeployer", VERSION);
+        address predicted = dd.computeAddress(salt);
+        console.log("Predicted v11:", predicted);
+
+        vm.deal(deployer, 1 ether);
+        vm.startPrank(deployer);
+
+        if (predicted.code.length == 0) {
+            address deployed = dd.deploy(salt, type(OrgDeployer).creationCode);
+            require(deployed == predicted, "Address mismatch");
+            console.log("v11 deployed at:", deployed);
+        }
+
+        hub.upgradeBeaconCrossChain{value: HYPERLANE_FEE}("OrgDeployer", predicted, VERSION);
+
+        vm.stopPrank();
+
+        address after_ = PoaManager(pm).getCurrentImplementationById(keccak256("OrgDeployer"));
+        console.log("New impl:", after_);
+        require(after_ == predicted, "Upgrade failed");
+        require(after_.code.length > 0, "Impl has no code");
+        console.log("New impl codesize:", after_.code.length, "bytes");
+        console.log("\nArbitrum upgrade simulation: PASS");
+    }
+}

--- a/src/OrgDeployer.sol
+++ b/src/OrgDeployer.sol
@@ -867,8 +867,8 @@ contract OrgDeployer is Initializable {
         pure
         returns (address[] memory targets, bytes4[] memory selectors, bool[] memory allowed, uint32[] memory gasHints)
     {
-        // Count: QuickJoin(6) + TaskManager(12) + HybridVoting(3) + DDVoting(3) + PaymentManager(5) + EligibilityModule(5) + ParticipationToken(3) + Registry(2) + EducationHub(0 or 4)
-        uint256 count = 39;
+        // Count: QuickJoin(6) + TaskManager(13) + HybridVoting(3) + DDVoting(3) + PaymentManager(5) + EligibilityModule(5) + ParticipationToken(3) + Registry(2) + EducationHub(0 or 4)
+        uint256 count = 40;
         if (educationEnabled) count += 4;
 
         targets = new address[](count);
@@ -943,6 +943,9 @@ contract OrgDeployer is Initializable {
     {
         targets[i] = tm;
         selectors[i] = bytes4(keccak256("createTask(uint256,bytes,bytes32,bytes32,address,uint256,bool)"));
+        i++;
+        targets[i] = tm;
+        selectors[i] = bytes4(keccak256("createTasksBatch(bytes32,(uint256,bytes,bytes32,address,uint256,bool)[])"));
         i++;
         targets[i] = tm;
         selectors[i] = bytes4(keccak256("claimTask(uint256)"));

--- a/test/DeployerTest.t.sol
+++ b/test/DeployerTest.t.sol
@@ -5461,11 +5461,16 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             "registerAndQuickJoinWithPasskey selector mismatch"
         );
 
-        // ── TaskManager (9) ──
+        // ── TaskManager (10) ──
         assertEq(
             bytes4(keccak256("createTask(uint256,bytes,bytes32,bytes32,address,uint256,bool)")),
             TaskManager.createTask.selector,
             "createTask selector mismatch"
+        );
+        assertEq(
+            bytes4(keccak256("createTasksBatch(bytes32,(uint256,bytes,bytes32,address,uint256,bool)[])")),
+            TaskManager.createTasksBatch.selector,
+            "createTasksBatch selector mismatch"
         );
         assertEq(bytes4(keccak256("claimTask(uint256)")), TaskManager.claimTask.selector, "claimTask selector mismatch");
         assertEq(

--- a/test/PoaManager.t.sol
+++ b/test/PoaManager.t.sol
@@ -9,8 +9,7 @@ import "../src/ImplementationRegistry.sol";
 
 contract DummyImpl {
     // Mock implementation for testing
-
-    }
+}
 
 /// @dev Mock target that gates a function behind msg.sender == poaManager
 contract MockAdminTarget {


### PR DESCRIPTION
## Summary
- **OrgDeployer v11**: includes `TaskManager.createTasksBatch` (`0xc18aa1c9`) in the default paymaster ruleset so newly deployed orgs sponsor batch task creation OOTB. Cross-chain upgrade script lives at `script/upgrades/UpgradeOrgDeployerCreateTasksBatch.s.sol`; broadcasted, both Arbitrum and Gnosis are now on the new impl `0x851e0bb67eBBF700D8cBe675974b2F436E3c344F`.
- **Retroactive fix for live orgs**: `script/fixes/AddCreateTasksBatchSelectorRules.s.sol` adds the selector to Poa (Arbitrum, `Hub.adminCall`) and KUBI/Test6 (Gnosis, `Satellite.adminCall`); all three on-chain confirmed `allowed=true` post-broadcast. TaskManager proxies were resolved via the Poa subgraph.
- **Drift guards**: `testPaymasterSelectorAccuracy` extended to assert the new selector matches the `TaskManager.createTasksBatch.selector`, and `CLAUDE.md` gains a subgraph-lookup recipe plus a "simulate every state-mutating script on a real fork" rule (paired sims caught a `Rule` struct field-order bug before broadcast).

## Test plan
- [x] `forge fmt && forge build` clean (default profile)
- [x] `forge test --match-contract DeployerTest` — 94/94 pass, including the new selector assertion
- [x] `SimAddBatchSelectorArbitrum` against arbitrum fork → PASS
- [x] `SimAddBatchSelectorGnosis` against gnosis fork → PASS
- [x] `SimulateOrgDeployerUpgrade` against arbitrum fork → PASS (impl 19053 bytes, well under EIP-170)
- [x] Live verification post-broadcast: Poa/KUBI/Test6 rules all `(0, true)`; OrgDeployer impl on both chains == predicted v11 address

🤖 Generated with [Claude Code](https://claude.com/claude-code)