### PR TITLE
feat(TaskManager v6): task deadlines + expired-claim takeover

### DIFF
--- a/docs/TASK_MANAGER.md
+++ b/docs/TASK_MANAGER.md
@@ -437,7 +437,76 @@ setConfig(ConfigKey.PROJECT_MANAGER, abi.encode(projectId, oldManager, false)); 
 | `UNCLAIMED` | `updateTask` | CREATE permission |
 | `UNCLAIMED` | `cancelTask` | CREATE permission |
 | `CLAIMED` | `submitTask` | Only the claimer |
+| `CLAIMED` (claim expired) | `claimTask` / `assignTask` / `approveApplication` — takeover | CLAIM / ASSIGN / ASSIGN |
+| `CLAIMED` (claim expired, requiresApplication) | `applyForTask` | CLAIM permission |
 | `SUBMITTED` | `completeTask` | REVIEW permission |
+
+---
+
+## Deadlines & Takeover (v6)
+
+Tasks carry three deadline fields. Two are configured by creators/editors; the third is
+derived per claim. All are optional — `0` means "no deadline", and every task created
+before v6 reads zeros (no behavior change).
+
+| Field | Type | Set by | Meaning |
+|-------|------|--------|---------|
+| `absoluteDeadline` | `uint48` unix | create / `updateTask` | Calendar cutoff. While the task is CLAIMED past this moment, the claim is open to takeover. |
+| `completionWindow` | `uint32` seconds | create / `updateTask` | Per-claim window: each claimer must submit within this many seconds of claiming, or the claim becomes open to takeover. |
+| `claimDeadline` | `uint48` unix | contract | `claimTime + completionWindow`, recomputed at every claim, assignment, application approval, and rejection (fresh window for rework). `0` when no window. |
+
+A fourth, **soft due date** lives only in the task's IPFS metadata JSON (`dueDate`,
+unix seconds) — display-only, never enforced on-chain.
+
+### Lenient enforcement model
+
+Deadlines never block work — they only remove claim *protection*:
+
+- **`submitTask` is never deadline-gated.** A late claimer can still submit (and be
+  paid) right up until someone actually takes the task over.
+- A CLAIMED task is **expired** when `claimDeadline` or `absoluteDeadline` (whichever
+  is set) is strictly in the past. The deadline second itself is still protected.
+- An expired claim can be **taken over** in one transaction: `claimTask` (CLAIM
+  permission), `assignTask` (ASSIGN), or `approveApplication` (ASSIGN, for
+  application-gated tasks). The contract emits `TaskClaimExpired(id, previousClaimer,
+  newClaimer)` followed by the normal lifecycle event, and the new claimer gets a
+  fresh window. The ousted claimer can no longer submit.
+- For `requiresApplication` tasks, direct `claimTask` still reverts — but new
+  applicants may `applyForTask` while the task is CLAIMED-and-expired, and any past
+  or new applicant (including the ousted claimer) can be approved into the takeover.
+- The expired claimer may re-claim their own task to refresh the window — visible
+  on-chain as `TaskClaimExpired(prev == new)`.
+- `SUBMITTED` tasks are **never** takeover-able: delivered work must be reviewed
+  (completed or rejected) first. `rejectTask` restarts the window so rework gets a
+  fresh allowance.
+- Past the `absoluteDeadline`, claims (and takeovers) are still allowed — they are
+  simply born unprotected. Reviewers keep full control via `completeTask`.
+
+### Editing deadlines
+
+`updateTask` carries both knobs under its existing permission gates (executor / PM /
+`EDIT_FULL` any non-terminal status; `CREATE` while UNCLAIMED):
+
+- Changing `completionWindow` while a task is claimed adjusts the live
+  `claimDeadline`, preserving the original claim start (`claimDeadline - oldWindow +
+  newWindow`); a previously windowless claim starts `now + newWindow`; setting `0`
+  clears it.
+- A **past `absoluteDeadline` is deliberately accepted on update** (create paths
+  revert `InvalidDeadline` for non-future values). This is the admin lever that opens
+  an abandoned CLAIMED task to takeover — `cancelTask` is UNCLAIMED-only, so no other
+  remedy exists, including for tasks claimed before v6.
+
+### Events (indexer contract)
+
+| Event | Emitted |
+|-------|---------|
+| `TaskDeadlinesSet(uint256 indexed id, uint48 absoluteDeadline, uint32 completionWindow)` | At create only when at least one value is non-zero; on `updateTask` whenever either value changes. |
+| `TaskClaimDeadlineSet(uint256 indexed id, uint48 claimDeadline)` | Only when the stored value changes (claim/assign/approve start, reject reset, window-edit adjustment, clear). |
+| `TaskClaimExpired(uint256 indexed id, address indexed previousClaimer, address indexed newClaimer)` | On takeover, always before the lifecycle event (`TaskClaimed` / `TaskAssigned` / `TaskApplicationApproved`) in the same transaction. |
+
+Intra-tx ordering guarantees: `TaskCreated` → `TaskDeadlinesSet?` →
+`TaskClaimDeadlineSet?` (create paths); `TaskClaimExpired` → lifecycle event →
+`TaskClaimDeadlineSet?` (takeovers).
 
 ---
 

--- a/script/fixes/WhitelistTaskDeadlineRulesDecentralParkViaGovernance.s.sol
+++ b/script/fixes/WhitelistTaskDeadlineRulesDecentralParkViaGovernance.s.sol
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import {IExecutor} from "../../src/Executor.sol";
+import {HybridVoting} from "../../src/HybridVoting.sol";
+
+/*
+ * ============================================================================
+ * Decentral Park (Gnosis) — paymaster rules for the TaskManager v6 deadline
+ * selectors, via governance (proposal + creator vote in one broadcast)
+ * ============================================================================
+ *
+ * Decentral Park twin of WhitelistTaskDeadlineRulesTest6KubiViaGovernance —
+ * see WhitelistTaskDeadlineRulesPoaViaGovernance for the full rationale.
+ * One proposal whose single Executor call is:
+ *   paymaster.setRulesBatch(orgId, [TM x8], [4 v6 selectors, 4 dead v5],
+ *                           [true x4, false x4], [0 x8])
+ *
+ *   allow  createTask          v6 0x4d0265d4   disallow v5 0x22fa79bc
+ *   allow  createTasksBatch    v6 0xf31d148f   disallow v5 0xc18aa1c9
+ *   allow  createAndAssignTask v6 0x98e30e89   disallow v5 0xaf425951
+ *   allow  updateTask          v6 0xb7c288e8   disallow v5 0x48db6f65
+ *
+ * Usage:
+ *   # Sim (run first)
+ *   FOUNDRY_PROFILE=production forge script \
+ *     script/fixes/WhitelistTaskDeadlineRulesDecentralParkViaGovernance.s.sol:SimWhitelistTaskDeadlineDecentralPark \
+ *     --fork-url gnosis -vvv
+ *
+ *   # Broadcast (creates the proposal AND votes)
+ *   source .env && FOUNDRY_PROFILE=production forge script \
+ *     script/fixes/WhitelistTaskDeadlineRulesDecentralParkViaGovernance.s.sol:BroadcastWhitelistTaskDeadlineDecentralPark \
+ *     --rpc-url gnosis --broadcast --slow
+ *
+ * Optional env override:
+ *   PROPOSAL_DURATION — voting window in minutes (default 30; HybridVoting min 10)
+ * ============================================================================
+ */
+
+// PaymasterHub on Gnosis.
+address constant GNOSIS_PAYMASTER_HUB = 0xdEf1038C297493c0b5f82F0CDB49e929B53B4108;
+
+// Decentral Park (Gnosis) — same org constants as WhitelistTaskEditRulesDecentralParkViaGovernance.
+bytes32 constant DECENTRAL_PARK_ORG_ID = 0x3721271eb827a52a5adf676136d302efe19c34e72f08e080b07b225eecf27d78;
+address constant DECENTRAL_PARK_TM = 0x2D9d397A842B8D691ea2A232062CbC8eF8eBbdB7;
+address constant DECENTRAL_PARK_HV = 0x1B80CA1EF7F274E141658A666fc12277957bF7A1;
+
+// TaskManager v6 selectors (cast sig verified 2026-06-09).
+bytes4 constant SEL_CREATE_TASK_V6 = 0x4d0265d4;
+bytes4 constant SEL_CREATE_TASKS_BATCH_V6 = 0xf31d148f;
+bytes4 constant SEL_CREATE_AND_ASSIGN_V6 = 0x98e30e89;
+bytes4 constant SEL_UPDATE_TASK_V6 = 0xb7c288e8;
+// Dead v5 selectors (replaced by v6; disallowed in the same batch).
+bytes4 constant SEL_CREATE_TASK_OLD = 0x22fa79bc;
+bytes4 constant SEL_CREATE_TASKS_BATCH_OLD = 0xc18aa1c9;
+bytes4 constant SEL_CREATE_AND_ASSIGN_OLD = 0xaf425951;
+bytes4 constant SEL_UPDATE_TASK_OLD = 0x48db6f65;
+
+// Hudson — verified creator-hat wearer on Decentral Park's HybridVoting (see the edit-rules twin).
+address constant HUDSON = 0xA6F4D9f44Dd980b7168D829d5f74c2b00a46b2c9;
+
+uint32 constant DEFAULT_PROPOSAL_DURATION_MINUTES = 30;
+
+interface IPaymasterHubMinimal {
+    // Field order matches PaymasterHub.sol's Rule struct exactly: (uint32 maxCallGasHint, bool allowed).
+    struct Rule {
+        uint32 maxCallGasHint;
+        bool allowed;
+    }
+
+    function setRulesBatch(
+        bytes32 orgId,
+        address[] calldata targets,
+        bytes4[] calldata selectors,
+        bool[] calldata allowed,
+        uint32[] calldata maxCallGasHints
+    ) external;
+
+    function getRule(bytes32 orgId, address target, bytes4 selector) external view returns (Rule memory);
+}
+
+interface IHatsMinimal {
+    function balanceOf(address user, uint256 hatId) external view returns (uint256);
+}
+
+interface ITaskManagerLensMinimal {
+    function getLensData(uint8 t, bytes calldata d) external view returns (bytes memory);
+}
+
+abstract contract WhitelistTaskDeadlineDecentralParkBase is Script {
+    function _resolveDuration() internal view returns (uint32) {
+        return uint32(vm.envOr("PROPOSAL_DURATION", uint256(DEFAULT_PROPOSAL_DURATION_MINUTES)));
+    }
+
+    function _newSelectors() internal pure returns (bytes4[4] memory) {
+        return [SEL_CREATE_TASK_V6, SEL_CREATE_TASKS_BATCH_V6, SEL_CREATE_AND_ASSIGN_V6, SEL_UPDATE_TASK_V6];
+    }
+
+    function _oldSelectors() internal pure returns (bytes4[4] memory) {
+        return [SEL_CREATE_TASK_OLD, SEL_CREATE_TASKS_BATCH_OLD, SEL_CREATE_AND_ASSIGN_OLD, SEL_UPDATE_TASK_OLD];
+    }
+
+    function _buildBatch() internal pure returns (IExecutor.Call[] memory batch) {
+        bytes4[4] memory news = _newSelectors();
+        bytes4[4] memory olds = _oldSelectors();
+
+        address[] memory targets = new address[](8);
+        bytes4[] memory selectors = new bytes4[](8);
+        bool[] memory allowed = new bool[](8);
+        uint32[] memory hints = new uint32[](8);
+
+        for (uint256 i; i < 4; ++i) {
+            targets[i] = DECENTRAL_PARK_TM;
+            selectors[i] = news[i];
+            allowed[i] = true;
+            targets[4 + i] = DECENTRAL_PARK_TM;
+            selectors[4 + i] = olds[i];
+            allowed[4 + i] = false;
+        }
+
+        batch = new IExecutor.Call[](1);
+        batch[0] = IExecutor.Call({
+            target: GNOSIS_PAYMASTER_HUB,
+            value: 0,
+            data: abi.encodeCall(
+                IPaymasterHubMinimal.setRulesBatch, (DECENTRAL_PARK_ORG_ID, targets, selectors, allowed, hints)
+            )
+        });
+    }
+
+    function _ruleAllowed(bytes4 selector) internal view returns (bool) {
+        return
+            IPaymasterHubMinimal(GNOSIS_PAYMASTER_HUB)
+            .getRule(DECENTRAL_PARK_ORG_ID, DECENTRAL_PARK_TM, selector)
+            .allowed;
+    }
+
+    function _ballot() internal pure returns (uint8[] memory idxs, uint8[] memory weights) {
+        idxs = new uint8[](1);
+        weights = new uint8[](1);
+        idxs[0] = 0;
+        weights[0] = 100;
+    }
+
+    function _printPreview() internal view {
+        console.log("\n=== v6 deadline-selector paymaster rules preview: Decentral Park (Gnosis) ===");
+        console.log("  PaymasterHub:        ", GNOSIS_PAYMASTER_HUB);
+        console.log("  TaskManager (target):", DECENTRAL_PARK_TM);
+        console.log("  createTask v6 allowed now:         ", _ruleAllowed(SEL_CREATE_TASK_V6));
+        console.log("  createTasksBatch v6 allowed now:   ", _ruleAllowed(SEL_CREATE_TASKS_BATCH_V6));
+        console.log("  createAndAssignTask v6 allowed now:", _ruleAllowed(SEL_CREATE_AND_ASSIGN_V6));
+        console.log("  updateTask v6 allowed now:         ", _ruleAllowed(SEL_UPDATE_TASK_V6));
+        console.log("  -> 4 v6 selectors will be allowed, 4 dead v5 selectors disallowed");
+    }
+
+    /// @dev Full sim (real Hats, prank Hudson): create -> vote -> warp -> announceWinner -> assert.
+    function _simFlow() internal {
+        _printPreview();
+
+        IExecutor.Call[][] memory batches = new IExecutor.Call[][](1);
+        batches[0] = _buildBatch();
+
+        uint32 minutesDuration = 10;
+        vm.prank(HUDSON);
+        HybridVoting(DECENTRAL_PARK_HV)
+            .createProposal(
+                bytes("Decentral Park: paymaster rules for TaskManager v6 deadline selectors (sim)"),
+                bytes32(0),
+                minutesDuration,
+                1,
+                batches,
+                new uint256[](0)
+            );
+        uint256 proposalId = HybridVoting(DECENTRAL_PARK_HV).proposalsCount() - 1;
+        console.log("  Proposal id:", proposalId);
+
+        (uint8[] memory idxs, uint8[] memory weights) = _ballot();
+        vm.prank(HUDSON);
+        HybridVoting(DECENTRAL_PARK_HV).vote(proposalId, idxs, weights);
+
+        vm.warp(block.timestamp + uint256(minutesDuration) * 60 + 10);
+        (uint256 winner, bool valid) = HybridVoting(DECENTRAL_PARK_HV).announceWinner(proposalId);
+        require(valid, "Sim DecentralPark: proposal did not pass with the creator's single vote");
+        console.log("  Winner option:", winner, " valid:", valid);
+
+        bytes4[4] memory news = _newSelectors();
+        bytes4[4] memory olds = _oldSelectors();
+        for (uint256 i; i < 4; ++i) {
+            require(_ruleAllowed(news[i]), "Sim: v6 selector still not allowed");
+            require(!_ruleAllowed(olds[i]), "Sim: dead v5 selector still allowed");
+        }
+        console.log("PASS: Decentral Park v6 deadline selectors allowed, dead v5 selectors disallowed.");
+    }
+
+    /// @dev Broadcast: create the proposal AND cast the creator's vote, in one signed session.
+    function _broadcast() internal {
+        uint256 key = vm.envOr("PRIVATE_KEY", uint256(0));
+        if (key == 0) key = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address sender = vm.addr(key);
+        uint32 minutesDuration = _resolveDuration();
+
+        console.log("\n=== Broadcasting Decentral Park v6 deadline-selector rules proposal + vote ===");
+        console.log("  Sender:       ", sender);
+        console.log("  HybridVoting: ", DECENTRAL_PARK_HV);
+        console.log("  Duration:     ", minutesDuration, "minutes");
+        _printPreview();
+
+        // Sanity: sender must wear a creator hat or createProposal reverts.
+        IHatsMinimal hats =
+            IHatsMinimal(abi.decode(ITaskManagerLensMinimal(DECENTRAL_PARK_TM).getLensData(3, ""), (address)));
+        uint256[] memory creatorHats = HybridVoting(DECENTRAL_PARK_HV).creatorHats();
+        bool isCreator = false;
+        for (uint256 i; i < creatorHats.length; ++i) {
+            if (hats.balanceOf(sender, creatorHats[i]) > 0) {
+                isCreator = true;
+                break;
+            }
+        }
+        require(isCreator, "Sender wears no creator hat on Decentral Park HybridVoting");
+
+        IExecutor.Call[][] memory batches = new IExecutor.Call[][](1);
+        batches[0] = _buildBatch();
+
+        (uint8[] memory idxs, uint8[] memory weights) = _ballot();
+
+        vm.startBroadcast(key);
+        HybridVoting(DECENTRAL_PARK_HV)
+            .createProposal(
+                bytes("Decentral Park: paymaster rules for TaskManager v6 deadline selectors"),
+                bytes32(0),
+                minutesDuration,
+                1,
+                batches,
+                new uint256[](0)
+            );
+        uint256 proposalId = HybridVoting(DECENTRAL_PARK_HV).proposalsCount() - 1;
+        HybridVoting(DECENTRAL_PARK_HV).vote(proposalId, idxs, weights);
+        vm.stopBroadcast();
+
+        console.log("  Proposal ID:", proposalId, "(vote cast)");
+        console.log("  After the window expires, anyone calls announceWinner(", proposalId, ") to execute.");
+    }
+}
+
+contract SimWhitelistTaskDeadlineDecentralPark is WhitelistTaskDeadlineDecentralParkBase {
+    function run() public {
+        _simFlow();
+    }
+}
+
+contract BroadcastWhitelistTaskDeadlineDecentralPark is WhitelistTaskDeadlineDecentralParkBase {
+    function run() public {
+        _broadcast();
+    }
+}

--- a/script/fixes/WhitelistTaskDeadlineRulesPoaViaGovernance.s.sol
+++ b/script/fixes/WhitelistTaskDeadlineRulesPoaViaGovernance.s.sol
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import {IExecutor} from "../../src/Executor.sol";
+import {HybridVoting} from "../../src/HybridVoting.sol";
+
+/*
+ * ============================================================================
+ * Poa (Arbitrum) — paymaster rules for the TaskManager v6 deadline selectors,
+ * via governance (proposal + creator vote in one broadcast)
+ * ============================================================================
+ *
+ * TaskManager v6 REPLACED four selectors (deadline params appended). For the
+ * live Poa org the paymaster must:
+ *   allow  createTask          v6 0x4d0265d4   disallow v5 0x22fa79bc
+ *   allow  createTasksBatch    v6 0xf31d148f   disallow v5 0xc18aa1c9
+ *   allow  createAndAssignTask v6 0x98e30e89   disallow v5 0xaf425951
+ *   allow  updateTask          v6 0xb7c288e8   disallow v5 0x48db6f65
+ * The dead selectors are disallowed in the same batch — they no longer exist
+ * on the upgraded impl, and leaving them allowed lets griefers burn sponsored
+ * gas on guaranteed-revert userops.
+ *
+ * NOTE: rules are keyed by (orgId, target, selector), so this proposal can be
+ * created/executed BEFORE the v6 beacon upgrade lands — sponsorship for the old
+ * selectors only degrades between announceWinner and the beacon upgrade, an
+ * ops-controlled window of minutes (see UpgradeTaskManagerDeadlines runbook).
+ *
+ * Single governance proposal whose one call the Poa Executor runs on execution:
+ *   paymaster.setRulesBatch(orgId, [TM x8], [4 new, 4 old], [true x4, false x4], [0 x8])
+ * Auth: setRulesBatch is `onlyOrgOperator`, satisfied by the org's adminHat
+ * wearer (the Executor) when announceWinner fires Executor.execute.
+ *
+ * The BROADCAST creates the proposal AND casts the creator's vote (option 0,
+ * 100%) — same mechanics proven by WhitelistTaskEditRulesPoaViaGovernance.
+ *
+ * Usage:
+ *   # Sim (run first — note --fork-url arbitrum)
+ *   FOUNDRY_PROFILE=production forge script \
+ *     script/fixes/WhitelistTaskDeadlineRulesPoaViaGovernance.s.sol:SimWhitelistTaskDeadlinePoa \
+ *     --fork-url arbitrum -vvv
+ *
+ *   # Broadcast (creates the proposal AND votes)
+ *   source .env && FOUNDRY_PROFILE=production forge script \
+ *     script/fixes/WhitelistTaskDeadlineRulesPoaViaGovernance.s.sol:BroadcastWhitelistTaskDeadlinePoa \
+ *     --rpc-url arbitrum --broadcast --slow
+ *
+ * Optional env override:
+ *   PROPOSAL_DURATION — voting window in minutes (default 10 = HybridVoting min)
+ * ============================================================================
+ */
+
+// PaymasterHub on Arbitrum.
+address constant ARB_PAYMASTER_HUB = 0xD6659bCaFAdCB9CC2F57B7aE923c7F1Ca4438a11;
+
+// Poa (Arbitrum) — same org constants as WhitelistTaskEditRulesPoaViaGovernance.
+bytes32 constant POA_ORG = 0xa71879ef0e38b15fe7080196c0102f859e0ca8e7b8c0703ec8df03c66befd069;
+address constant POA_TM = 0x681f29751724D2bED331d3EB35e0C9B1C57aF9F0;
+address constant POA_HV = 0x34aa1bD79a3A5eb5d2B208eb4f091ccF6B1081d5;
+
+// TaskManager v6 selectors (cast sig verified 2026-06-09).
+bytes4 constant SEL_CREATE_TASK_V6 = 0x4d0265d4;
+bytes4 constant SEL_CREATE_TASKS_BATCH_V6 = 0xf31d148f;
+bytes4 constant SEL_CREATE_AND_ASSIGN_V6 = 0x98e30e89;
+bytes4 constant SEL_UPDATE_TASK_V6 = 0xb7c288e8;
+// Dead v5 selectors (replaced by v6; disallowed in the same batch).
+bytes4 constant SEL_CREATE_TASK_OLD = 0x22fa79bc;
+bytes4 constant SEL_CREATE_TASKS_BATCH_OLD = 0xc18aa1c9;
+bytes4 constant SEL_CREATE_AND_ASSIGN_OLD = 0xaf425951;
+bytes4 constant SEL_UPDATE_TASK_OLD = 0x48db6f65;
+
+// Hudson — verified wearer of Poa HybridVoting's sole creator hat (see the edit-rules
+// twin). Pranked in the sim; also the expected broadcaster.
+address constant HUDSON = 0xA6F4D9f44Dd980b7168D829d5f74c2b00a46b2c9;
+
+uint32 constant DEFAULT_PROPOSAL_DURATION_MINUTES = 10;
+
+interface IPaymasterHubMinimal {
+    // Field order matches PaymasterHub.sol's Rule struct exactly: (uint32 maxCallGasHint, bool allowed).
+    // Decoding as (bool, uint32) would silently swap the values — see CLAUDE.md.
+    struct Rule {
+        uint32 maxCallGasHint;
+        bool allowed;
+    }
+
+    function setRulesBatch(
+        bytes32 orgId,
+        address[] calldata targets,
+        bytes4[] calldata selectors,
+        bool[] calldata allowed,
+        uint32[] calldata maxCallGasHints
+    ) external;
+
+    function getRule(bytes32 orgId, address target, bytes4 selector) external view returns (Rule memory);
+}
+
+interface IHatsMinimal {
+    function balanceOf(address user, uint256 hatId) external view returns (uint256);
+}
+
+interface ITaskManagerLensMinimal {
+    function getLensData(uint8 t, bytes calldata d) external view returns (bytes memory);
+}
+
+abstract contract WhitelistTaskDeadlinePoaBase is Script {
+    function _resolveDuration() internal view returns (uint32) {
+        return uint32(vm.envOr("PROPOSAL_DURATION", uint256(DEFAULT_PROPOSAL_DURATION_MINUTES)));
+    }
+
+    function _newSelectors() internal pure returns (bytes4[4] memory) {
+        return [SEL_CREATE_TASK_V6, SEL_CREATE_TASKS_BATCH_V6, SEL_CREATE_AND_ASSIGN_V6, SEL_UPDATE_TASK_V6];
+    }
+
+    function _oldSelectors() internal pure returns (bytes4[4] memory) {
+        return [SEL_CREATE_TASK_OLD, SEL_CREATE_TASKS_BATCH_OLD, SEL_CREATE_AND_ASSIGN_OLD, SEL_UPDATE_TASK_OLD];
+    }
+
+    /// @dev Single-call batch: setRulesBatch allowing the 4 v6 selectors and
+    /// disallowing the 4 dead v5 ones on Poa's TaskManager.
+    function _buildBatch() internal pure returns (IExecutor.Call[] memory batch) {
+        bytes4[4] memory news = _newSelectors();
+        bytes4[4] memory olds = _oldSelectors();
+
+        address[] memory targets = new address[](8);
+        bytes4[] memory selectors = new bytes4[](8);
+        bool[] memory allowed = new bool[](8);
+        uint32[] memory hints = new uint32[](8);
+
+        for (uint256 i; i < 4; ++i) {
+            targets[i] = POA_TM;
+            selectors[i] = news[i];
+            allowed[i] = true;
+            targets[4 + i] = POA_TM;
+            selectors[4 + i] = olds[i];
+            allowed[4 + i] = false;
+        }
+
+        batch = new IExecutor.Call[](1);
+        batch[0] = IExecutor.Call({
+            target: ARB_PAYMASTER_HUB,
+            value: 0,
+            data: abi.encodeCall(IPaymasterHubMinimal.setRulesBatch, (POA_ORG, targets, selectors, allowed, hints))
+        });
+    }
+
+    function _ruleAllowed(bytes4 selector) internal view returns (bool) {
+        return IPaymasterHubMinimal(ARB_PAYMASTER_HUB).getRule(POA_ORG, POA_TM, selector).allowed;
+    }
+
+    function _ballot() internal pure returns (uint8[] memory idxs, uint8[] memory weights) {
+        idxs = new uint8[](1);
+        weights = new uint8[](1);
+        idxs[0] = 0;
+        weights[0] = 100;
+    }
+
+    function _printPreview() internal view {
+        console.log("\n=== v6 deadline-selector paymaster rules preview: Poa (Arbitrum) ===");
+        console.log("  PaymasterHub:        ", ARB_PAYMASTER_HUB);
+        console.log("  TaskManager (target):", POA_TM);
+        console.log("  createTask v6 allowed now:         ", _ruleAllowed(SEL_CREATE_TASK_V6));
+        console.log("  createTasksBatch v6 allowed now:   ", _ruleAllowed(SEL_CREATE_TASKS_BATCH_V6));
+        console.log("  createAndAssignTask v6 allowed now:", _ruleAllowed(SEL_CREATE_AND_ASSIGN_V6));
+        console.log("  updateTask v6 allowed now:         ", _ruleAllowed(SEL_UPDATE_TASK_V6));
+        console.log("  -> 4 v6 selectors will be allowed, 4 dead v5 selectors disallowed");
+    }
+
+    /// @dev Full sim (real Hats, prank Hudson): create -> vote -> warp -> announceWinner -> assert.
+    function _simFlow() internal {
+        _printPreview();
+
+        IExecutor.Call[] memory batch = _buildBatch();
+        IExecutor.Call[][] memory batches = new IExecutor.Call[][](1);
+        batches[0] = batch;
+
+        uint32 minutesDuration = 10;
+        vm.prank(HUDSON);
+        HybridVoting(POA_HV)
+            .createProposal(
+                bytes("Poa: paymaster rules for TaskManager v6 deadline selectors (sim)"),
+                bytes32(0),
+                minutesDuration,
+                1,
+                batches,
+                new uint256[](0)
+            );
+        uint256 proposalId = HybridVoting(POA_HV).proposalsCount() - 1;
+        console.log("  Proposal id:", proposalId);
+
+        (uint8[] memory idxs, uint8[] memory weights) = _ballot();
+        vm.prank(HUDSON);
+        HybridVoting(POA_HV).vote(proposalId, idxs, weights);
+
+        vm.warp(block.timestamp + uint256(minutesDuration) * 60 + 10);
+        (uint256 winner, bool valid) = HybridVoting(POA_HV).announceWinner(proposalId);
+        require(valid, "Sim Poa: proposal did not pass with the creator's single vote");
+        console.log("  Winner option:", winner, " valid:", valid);
+
+        bytes4[4] memory news = _newSelectors();
+        bytes4[4] memory olds = _oldSelectors();
+        for (uint256 i; i < 4; ++i) {
+            require(_ruleAllowed(news[i]), "Sim: v6 selector still not allowed");
+            require(!_ruleAllowed(olds[i]), "Sim: dead v5 selector still allowed");
+        }
+        console.log("PASS: Poa v6 deadline selectors allowed, dead v5 selectors disallowed.");
+    }
+
+    /// @dev Broadcast: create the proposal AND cast the creator's vote, in one signed session.
+    function _broadcast() internal {
+        uint256 key = vm.envOr("PRIVATE_KEY", uint256(0));
+        if (key == 0) key = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address sender = vm.addr(key);
+        uint32 minutesDuration = _resolveDuration();
+
+        console.log("\n=== Broadcasting Poa v6 deadline-selector rules proposal + vote ===");
+        console.log("  Sender:       ", sender);
+        console.log("  HybridVoting: ", POA_HV);
+        console.log("  PaymasterHub: ", ARB_PAYMASTER_HUB);
+        console.log("  Duration:     ", minutesDuration, "minutes");
+        _printPreview();
+
+        // Sanity: sender must wear a creator hat or createProposal reverts.
+        IHatsMinimal hats = IHatsMinimal(abi.decode(ITaskManagerLensMinimal(POA_TM).getLensData(3, ""), (address)));
+        uint256[] memory creatorHats = HybridVoting(POA_HV).creatorHats();
+        bool isCreator = false;
+        for (uint256 i; i < creatorHats.length; ++i) {
+            if (hats.balanceOf(sender, creatorHats[i]) > 0) {
+                isCreator = true;
+                break;
+            }
+        }
+        require(isCreator, "Sender wears no creator hat on Poa HybridVoting");
+
+        IExecutor.Call[] memory batch = _buildBatch();
+        IExecutor.Call[][] memory batches = new IExecutor.Call[][](1);
+        batches[0] = batch;
+
+        (uint8[] memory idxs, uint8[] memory weights) = _ballot();
+
+        vm.startBroadcast(key);
+        HybridVoting(POA_HV)
+            .createProposal(
+                bytes("Poa: paymaster rules for TaskManager v6 deadline selectors"),
+                bytes32(0),
+                minutesDuration,
+                1,
+                batches,
+                new uint256[](0)
+            );
+        uint256 proposalId = HybridVoting(POA_HV).proposalsCount() - 1;
+        HybridVoting(POA_HV).vote(proposalId, idxs, weights);
+        vm.stopBroadcast();
+
+        console.log("  Proposal ID:", proposalId, "(vote cast)");
+        console.log("  After the window expires, anyone calls announceWinner(", proposalId, ") to execute.");
+    }
+}
+
+contract SimWhitelistTaskDeadlinePoa is WhitelistTaskDeadlinePoaBase {
+    function run() public {
+        _simFlow();
+    }
+}
+
+contract BroadcastWhitelistTaskDeadlinePoa is WhitelistTaskDeadlinePoaBase {
+    function run() public {
+        _broadcast();
+    }
+}

--- a/script/fixes/WhitelistTaskDeadlineRulesTest6KubiViaGovernance.s.sol
+++ b/script/fixes/WhitelistTaskDeadlineRulesTest6KubiViaGovernance.s.sol
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import {IExecutor} from "../../src/Executor.sol";
+import {HybridVoting} from "../../src/HybridVoting.sol";
+
+/*
+ * ============================================================================
+ * Test6 + KUBI (Gnosis) — paymaster rules for the TaskManager v6 deadline
+ * selectors, via governance (proposal + creator vote per org)
+ * ============================================================================
+ *
+ * Gnosis twin of WhitelistTaskDeadlineRulesPoaViaGovernance — see that header
+ * for the full rationale. Per org, one proposal whose single Executor call is:
+ *   paymaster.setRulesBatch(orgId, [TM x8], [4 v6 selectors, 4 dead v5],
+ *                           [true x4, false x4], [0 x8])
+ *
+ *   allow  createTask          v6 0x4d0265d4   disallow v5 0x22fa79bc
+ *   allow  createTasksBatch    v6 0xf31d148f   disallow v5 0xc18aa1c9
+ *   allow  createAndAssignTask v6 0x98e30e89   disallow v5 0xaf425951
+ *   allow  updateTask          v6 0xb7c288e8   disallow v5 0x48db6f65
+ *
+ * Usage:
+ *   # Sims (run first)
+ *   FOUNDRY_PROFILE=production forge script \
+ *     script/fixes/WhitelistTaskDeadlineRulesTest6KubiViaGovernance.s.sol:SimWhitelistTaskDeadlineTest6 \
+ *     --fork-url gnosis -vvv
+ *   FOUNDRY_PROFILE=production forge script \
+ *     script/fixes/WhitelistTaskDeadlineRulesTest6KubiViaGovernance.s.sol:SimWhitelistTaskDeadlineKubi \
+ *     --fork-url gnosis -vvv
+ *
+ *   # Broadcasts (each creates its org's proposal AND votes)
+ *   source .env && FOUNDRY_PROFILE=production forge script \
+ *     script/fixes/WhitelistTaskDeadlineRulesTest6KubiViaGovernance.s.sol:BroadcastWhitelistTaskDeadlineTest6 \
+ *     --rpc-url gnosis --broadcast --slow
+ *   source .env && FOUNDRY_PROFILE=production forge script \
+ *     script/fixes/WhitelistTaskDeadlineRulesTest6KubiViaGovernance.s.sol:BroadcastWhitelistTaskDeadlineKubi \
+ *     --rpc-url gnosis --broadcast --slow
+ *
+ * Optional env override:
+ *   PROPOSAL_DURATION — voting window in minutes (default 10 = HybridVoting min)
+ * ============================================================================
+ */
+
+// PaymasterHub on Gnosis.
+address constant GNOSIS_PAYMASTER_HUB = 0xdEf1038C297493c0b5f82F0CDB49e929B53B4108;
+
+// Test6 (Gnosis) — same org constants as WhitelistTaskEditRulesTest6KubiViaGovernance.
+bytes32 constant TEST6_ORG = 0x263b2b29f392647f0fb8ddbb26f099e812ab4ba2777e5e07b906277164181f6b;
+address constant TEST6_TM = 0x3d93f0D090356D25E7a1614F0F8764b103ca99bc;
+address constant TEST6_HV = 0xF642DdE77848dC195c8089F4042A311Ed650d7a6;
+
+// KUBI (Gnosis).
+bytes32 constant KUBI_ORG = 0xc0f2765d555e21bfad5c6b05accef86a5758e0dee3e9a5b4ee3c3f3069c2102e;
+address constant KUBI_TM = 0xF57024fC77915Fce8f2608afdd027941bCEE3336;
+address constant KUBI_HV = 0x13CBd5eD47bF177968B24D84516a75879c23971E;
+
+// TaskManager v6 selectors (cast sig verified 2026-06-09).
+bytes4 constant SEL_CREATE_TASK_V6 = 0x4d0265d4;
+bytes4 constant SEL_CREATE_TASKS_BATCH_V6 = 0xf31d148f;
+bytes4 constant SEL_CREATE_AND_ASSIGN_V6 = 0x98e30e89;
+bytes4 constant SEL_UPDATE_TASK_V6 = 0xb7c288e8;
+// Dead v5 selectors (replaced by v6; disallowed in the same batch).
+bytes4 constant SEL_CREATE_TASK_OLD = 0x22fa79bc;
+bytes4 constant SEL_CREATE_TASKS_BATCH_OLD = 0xc18aa1c9;
+bytes4 constant SEL_CREATE_AND_ASSIGN_OLD = 0xaf425951;
+bytes4 constant SEL_UPDATE_TASK_OLD = 0x48db6f65;
+
+// Hudson — verified creator-hat wearer on both orgs' HybridVoting (see the edit-rules twin).
+address constant HUDSON = 0xA6F4D9f44Dd980b7168D829d5f74c2b00a46b2c9;
+
+uint32 constant DEFAULT_PROPOSAL_DURATION_MINUTES = 10;
+
+interface IPaymasterHubMinimal {
+    // Field order matches PaymasterHub.sol's Rule struct exactly: (uint32 maxCallGasHint, bool allowed).
+    struct Rule {
+        uint32 maxCallGasHint;
+        bool allowed;
+    }
+
+    function setRulesBatch(
+        bytes32 orgId,
+        address[] calldata targets,
+        bytes4[] calldata selectors,
+        bool[] calldata allowed,
+        uint32[] calldata maxCallGasHints
+    ) external;
+
+    function getRule(bytes32 orgId, address target, bytes4 selector) external view returns (Rule memory);
+}
+
+interface IHatsMinimal {
+    function balanceOf(address user, uint256 hatId) external view returns (uint256);
+}
+
+interface ITaskManagerLensMinimal {
+    function getLensData(uint8 t, bytes calldata d) external view returns (bytes memory);
+}
+
+abstract contract WhitelistTaskDeadlineGnosisBase is Script {
+    function _resolveDuration() internal view returns (uint32) {
+        return uint32(vm.envOr("PROPOSAL_DURATION", uint256(DEFAULT_PROPOSAL_DURATION_MINUTES)));
+    }
+
+    function _resolveKey() internal view returns (uint256 key) {
+        key = vm.envOr("PRIVATE_KEY", uint256(0));
+        if (key == 0) key = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    }
+
+    function _newSelectors() internal pure returns (bytes4[4] memory) {
+        return [SEL_CREATE_TASK_V6, SEL_CREATE_TASKS_BATCH_V6, SEL_CREATE_AND_ASSIGN_V6, SEL_UPDATE_TASK_V6];
+    }
+
+    function _oldSelectors() internal pure returns (bytes4[4] memory) {
+        return [SEL_CREATE_TASK_OLD, SEL_CREATE_TASKS_BATCH_OLD, SEL_CREATE_AND_ASSIGN_OLD, SEL_UPDATE_TASK_OLD];
+    }
+
+    function _buildBatch(bytes32 orgId, address tm) internal pure returns (IExecutor.Call[] memory batch) {
+        bytes4[4] memory news = _newSelectors();
+        bytes4[4] memory olds = _oldSelectors();
+
+        address[] memory targets = new address[](8);
+        bytes4[] memory selectors = new bytes4[](8);
+        bool[] memory allowed = new bool[](8);
+        uint32[] memory hints = new uint32[](8);
+
+        for (uint256 i; i < 4; ++i) {
+            targets[i] = tm;
+            selectors[i] = news[i];
+            allowed[i] = true;
+            targets[4 + i] = tm;
+            selectors[4 + i] = olds[i];
+            allowed[4 + i] = false;
+        }
+
+        batch = new IExecutor.Call[](1);
+        batch[0] = IExecutor.Call({
+            target: GNOSIS_PAYMASTER_HUB,
+            value: 0,
+            data: abi.encodeCall(IPaymasterHubMinimal.setRulesBatch, (orgId, targets, selectors, allowed, hints))
+        });
+    }
+
+    function _ruleAllowed(bytes32 orgId, address tm, bytes4 selector) internal view returns (bool) {
+        return IPaymasterHubMinimal(GNOSIS_PAYMASTER_HUB).getRule(orgId, tm, selector).allowed;
+    }
+
+    function _ballot() internal pure returns (uint8[] memory idxs, uint8[] memory weights) {
+        idxs = new uint8[](1);
+        weights = new uint8[](1);
+        idxs[0] = 0;
+        weights[0] = 100;
+    }
+
+    function _printPreview(string memory name, bytes32 orgId, address tm) internal view {
+        console.log("\n=== v6 deadline-selector paymaster rules preview:", name, "(Gnosis) ===");
+        console.log("  PaymasterHub:        ", GNOSIS_PAYMASTER_HUB);
+        console.log("  TaskManager (target):", tm);
+        console.log("  createTask v6 allowed now:         ", _ruleAllowed(orgId, tm, SEL_CREATE_TASK_V6));
+        console.log("  createTasksBatch v6 allowed now:   ", _ruleAllowed(orgId, tm, SEL_CREATE_TASKS_BATCH_V6));
+        console.log("  createAndAssignTask v6 allowed now:", _ruleAllowed(orgId, tm, SEL_CREATE_AND_ASSIGN_V6));
+        console.log("  updateTask v6 allowed now:         ", _ruleAllowed(orgId, tm, SEL_UPDATE_TASK_V6));
+        console.log("  -> 4 v6 selectors will be allowed, 4 dead v5 selectors disallowed");
+    }
+
+    /// @dev Full sim (real Hats, prank Hudson): create -> vote -> warp -> announceWinner -> assert.
+    function _simFlow(string memory name, bytes32 orgId, address tm, address hv) internal {
+        _printPreview(name, orgId, tm);
+
+        IExecutor.Call[][] memory batches = new IExecutor.Call[][](1);
+        batches[0] = _buildBatch(orgId, tm);
+
+        uint32 minutesDuration = 10;
+        vm.prank(HUDSON);
+        HybridVoting(hv)
+            .createProposal(
+                bytes("Paymaster rules for TaskManager v6 deadline selectors (sim)"),
+                bytes32(0),
+                minutesDuration,
+                1,
+                batches,
+                new uint256[](0)
+            );
+        uint256 proposalId = HybridVoting(hv).proposalsCount() - 1;
+        console.log("  Proposal id:", proposalId);
+
+        (uint8[] memory idxs, uint8[] memory weights) = _ballot();
+        vm.prank(HUDSON);
+        HybridVoting(hv).vote(proposalId, idxs, weights);
+
+        vm.warp(block.timestamp + uint256(minutesDuration) * 60 + 10);
+        (uint256 winner, bool valid) = HybridVoting(hv).announceWinner(proposalId);
+        require(valid, "Sim: proposal did not pass with the creator's single vote");
+        console.log("  Winner option:", winner, " valid:", valid);
+
+        bytes4[4] memory news = _newSelectors();
+        bytes4[4] memory olds = _oldSelectors();
+        for (uint256 i; i < 4; ++i) {
+            require(_ruleAllowed(orgId, tm, news[i]), "Sim: v6 selector still not allowed");
+            require(!_ruleAllowed(orgId, tm, olds[i]), "Sim: dead v5 selector still allowed");
+        }
+        console.log("PASS:", name, "v6 deadline selectors allowed, dead v5 selectors disallowed.");
+    }
+
+    /// @dev Broadcast: create the proposal AND cast the creator's vote, in one signed session.
+    function _broadcastCreateAndVote(uint256 key, string memory name, bytes32 orgId, address tm, address hv) internal {
+        address sender = vm.addr(key);
+        uint32 minutesDuration = _resolveDuration();
+
+        console.log("\n=== Broadcasting", name, "v6 deadline-selector rules proposal + vote ===");
+        console.log("  Sender:       ", sender);
+        console.log("  HybridVoting: ", hv);
+        console.log("  Duration:     ", minutesDuration, "minutes");
+        _printPreview(name, orgId, tm);
+
+        // Sanity: sender must wear a creator hat or createProposal reverts.
+        IHatsMinimal hats = IHatsMinimal(abi.decode(ITaskManagerLensMinimal(tm).getLensData(3, ""), (address)));
+        uint256[] memory creatorHats = HybridVoting(hv).creatorHats();
+        bool isCreator = false;
+        for (uint256 i; i < creatorHats.length; ++i) {
+            if (hats.balanceOf(sender, creatorHats[i]) > 0) {
+                isCreator = true;
+                break;
+            }
+        }
+        require(isCreator, "Sender wears no creator hat on this org's HybridVoting");
+
+        IExecutor.Call[][] memory batches = new IExecutor.Call[][](1);
+        batches[0] = _buildBatch(orgId, tm);
+
+        (uint8[] memory idxs, uint8[] memory weights) = _ballot();
+
+        vm.startBroadcast(key);
+        HybridVoting(hv)
+            .createProposal(
+                bytes("Paymaster rules for TaskManager v6 deadline selectors"),
+                bytes32(0),
+                minutesDuration,
+                1,
+                batches,
+                new uint256[](0)
+            );
+        uint256 proposalId = HybridVoting(hv).proposalsCount() - 1;
+        HybridVoting(hv).vote(proposalId, idxs, weights);
+        vm.stopBroadcast();
+
+        console.log("  Proposal ID:", proposalId, "(vote cast)");
+        console.log("  After the window expires, anyone calls announceWinner(", proposalId, ") to execute.");
+    }
+}
+
+contract SimWhitelistTaskDeadlineTest6 is WhitelistTaskDeadlineGnosisBase {
+    function run() public {
+        _simFlow("Test6", TEST6_ORG, TEST6_TM, TEST6_HV);
+    }
+}
+
+contract BroadcastWhitelistTaskDeadlineTest6 is WhitelistTaskDeadlineGnosisBase {
+    function run() public {
+        _broadcastCreateAndVote(_resolveKey(), "Test6", TEST6_ORG, TEST6_TM, TEST6_HV);
+    }
+}
+
+contract SimWhitelistTaskDeadlineKubi is WhitelistTaskDeadlineGnosisBase {
+    function run() public {
+        _simFlow("KUBI", KUBI_ORG, KUBI_TM, KUBI_HV);
+    }
+}
+
+contract BroadcastWhitelistTaskDeadlineKubi is WhitelistTaskDeadlineGnosisBase {
+    function run() public {
+        _broadcastCreateAndVote(_resolveKey(), "KUBI", KUBI_ORG, KUBI_TM, KUBI_HV);
+    }
+}

--- a/script/org/RunOrgActions.s.sol
+++ b/script/org/RunOrgActions.s.sol
@@ -462,7 +462,9 @@ contract RunOrgActions is Script {
             projectId,
             address(0), // bountyToken (0 = no bounty)
             0, // bountyPayout
-            false // requiresApplication (can be claimed directly)
+            false, // requiresApplication (can be claimed directly)
+            0,
+            0
         );
         uint256 task0 = 0; // First task ID starts at 0
         console.log("  [OK] Task 0 Created");
@@ -476,7 +478,9 @@ contract RunOrgActions is Script {
             projectId,
             address(0),
             0,
-            true // Requires application for this one
+            true, // Requires application for this one
+            0,
+            0
         );
         uint256 task1 = 1; // Second task ID
         console.log("  [OK] Task 1 Created");

--- a/script/org/RunOrgActionsAdvanced.s.sol
+++ b/script/org/RunOrgActionsAdvanced.s.sol
@@ -579,7 +579,9 @@ contract RunOrgActionsAdvanced is Script {
             projectId,
             address(0), // bountyToken (0 = no bounty)
             0, // bountyPayout
-            false // requiresApplication (can be claimed directly)
+            false, // requiresApplication (can be claimed directly)
+            0,
+            0
         );
         uint256 task0 = 0; // First task ID starts at 0
         console.log("  [OK] Task 0 Created");
@@ -593,7 +595,9 @@ contract RunOrgActionsAdvanced is Script {
             projectId,
             address(0),
             0,
-            true // Requires application for this one
+            true, // Requires application for this one
+            0,
+            0
         );
         uint256 task1 = 1; // Second task ID
         console.log("  [OK] Task 1 Created");

--- a/script/upgrades/UpgradeEligibilitySuperAdminLockdown.s.sol
+++ b/script/upgrades/UpgradeEligibilitySuperAdminLockdown.s.sol
@@ -316,9 +316,7 @@ contract DryRun_GnosisUpgrade is Script {
 
         vm.prank(KUBI_EXECUTOR);
         (bool okExecOn,) = KUBI_ELIG_MODULE.call(
-            abi.encodeWithSignature(
-                "setWearerEligibility(address,uint256,bool,bool)", probe, MEMBER_HAT, true, true
-            )
+            abi.encodeWithSignature("setWearerEligibility(address,uint256,bool,bool)", probe, MEMBER_HAT, true, true)
         );
         require(okExecOn, "DryRun: superAdmin setWearerEligibility(true,true) reverted");
         {
@@ -328,9 +326,7 @@ contract DryRun_GnosisUpgrade is Script {
 
         vm.prank(KUBI_EXECUTOR);
         (bool okExecOff,) = KUBI_ELIG_MODULE.call(
-            abi.encodeWithSignature(
-                "setWearerEligibility(address,uint256,bool,bool)", probe, MEMBER_HAT, false, false
-            )
+            abi.encodeWithSignature("setWearerEligibility(address,uint256,bool,bool)", probe, MEMBER_HAT, false, false)
         );
         require(okExecOff, "DryRun: superAdmin setWearerEligibility(false,false) reverted");
         {

--- a/script/upgrades/UpgradeOrgDeployerDeadlineRules.s.sol
+++ b/script/upgrades/UpgradeOrgDeployerDeadlineRules.s.sol
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import {OrgDeployer} from "../../src/OrgDeployer.sol";
+import {PoaManagerHub} from "../../src/crosschain/PoaManagerHub.sol";
+import {PoaManager} from "../../src/PoaManager.sol";
+import {DeterministicDeployer} from "../../src/crosschain/DeterministicDeployer.sol";
+
+/*
+ * ============================================================================
+ * OrgDeployer v15 — TaskManager v6 deadline selectors in the default whitelist
+ * ============================================================================
+ *
+ * TaskManager v6 REPLACED four selectors (deadline params appended):
+ *   createTask           0x22fa79bc -> 0x4d0265d4
+ *   createTasksBatch     0xc18aa1c9 -> 0xf31d148f
+ *   createAndAssignTask  0xaf425951 -> 0x98e30e89
+ *   updateTask           0x48db6f65 -> 0xb7c288e8
+ *
+ * This upgrade swaps the four signature strings in
+ * OrgDeployer._appendTaskManagerRules so NEW orgs auto-whitelist the v6
+ * selectors at deploy. Rule counts unchanged (4 replaced, 0 added; base count
+ * stays 43).
+ *
+ * Version selection (CLAUDE.md probing recipe, both surfaces, both chains, 2026-06-09):
+ *   v12/v13/v14 TAKEN (registry + CREATE2) on Gnosis AND Arbitrum;
+ *   v15 FREE on both surfaces on both chains
+ *   (predicted 0xFa5Bc9343631489094e68a6059E93994C33127A3). Live impl is v14.
+ *
+ * Forward-only: existing orgs keep their current rules — the retroactive
+ * per-org governance scripts (WhitelistTaskDeadlineRules*ViaGovernance) flip
+ * the 4 new selectors on and the 4 dead ones off for live orgs.
+ *
+ * Usage (sim first — CLAUDE.md requires PASS before broadcast):
+ *   FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeOrgDeployerDeadlineRules.s.sol:SimulateOrgDeployerDeadlineRulesUpgrade \
+ *     --fork-url arbitrum -vvv
+ *
+ * Broadcast:
+ *   source .env && FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeOrgDeployerDeadlineRules.s.sol:Step1_DeployImplOnGnosis \
+ *     --rpc-url gnosis --broadcast --slow
+ *   source .env && FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeOrgDeployerDeadlineRules.s.sol:Step2_UpgradeFromArbitrum \
+ *     --rpc-url arbitrum --broadcast --slow
+ *   forge script script/upgrades/UpgradeOrgDeployerDeadlineRules.s.sol:Step3_Verify --rpc-url gnosis
+ * ============================================================================
+ */
+
+address constant DD = 0x4aC8B5ebEb9D8C3dE3180ddF381D552d59e8835a;
+address constant HUB = 0xB72840B343654eAfb2CFf7acC4Fc6b59E6c3CC71;
+address constant GNOSIS_POA_MANAGER = 0x794fD39e75140ee1545B1B022E5486B7c863789b;
+uint256 constant HYPERLANE_FEE = 0.005 ether;
+// Hudson — owner of PoaManagerHub + DeterministicDeployer (pranked in the sim).
+address constant HUDSON_ADMIN = 0xA6F4D9f44Dd980b7168D829d5f74c2b00a46b2c9;
+string constant VERSION = "v15";
+
+// TaskManager v6 selectors now emitted by _appendTaskManagerRules (cast sig verified).
+bytes4 constant SEL_CREATE_TASK_V6 = 0x4d0265d4;
+bytes4 constant SEL_CREATE_TASKS_BATCH_V6 = 0xf31d148f;
+bytes4 constant SEL_CREATE_AND_ASSIGN_V6 = 0x98e30e89;
+bytes4 constant SEL_UPDATE_TASK_V6 = 0xb7c288e8;
+
+contract Step1_DeployImplOnGnosis is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+
+        bytes32 salt = dd.computeSalt("OrgDeployer", VERSION);
+        address predicted = dd.computeAddress(salt);
+        console.log("\n=== Step 1: Deploy OrgDeployer v15 on Gnosis ===");
+        console.log("Predicted:", predicted);
+
+        if (predicted.code.length > 0) {
+            console.log("Already deployed. Skipping.");
+            return;
+        }
+
+        vm.startBroadcast(deployerKey);
+        address deployed = dd.deploy(salt, type(OrgDeployer).creationCode);
+        vm.stopBroadcast();
+
+        require(deployed == predicted, "Address mismatch");
+        console.log("Deployed:", deployed);
+        console.log("\nNext: Run Step2_UpgradeFromArbitrum on Arbitrum");
+    }
+}
+
+contract Step2_UpgradeFromArbitrum is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        address deployer = vm.addr(deployerKey);
+
+        PoaManagerHub hub = PoaManagerHub(payable(HUB));
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+
+        console.log("\n=== Step 2: Upgrade OrgDeployer from Arbitrum ===");
+        require(hub.owner() == deployer, "Deployer must own Hub");
+        require(!hub.paused(), "Hub is paused");
+
+        bytes32 salt = dd.computeSalt("OrgDeployer", VERSION);
+        address impl = dd.computeAddress(salt);
+        console.log("OrgDeployer v15 impl:", impl);
+
+        vm.startBroadcast(deployerKey);
+
+        if (impl.code.length == 0) {
+            address deployed = dd.deploy(salt, type(OrgDeployer).creationCode);
+            require(deployed == impl, "Address mismatch on Arbitrum");
+            console.log("Deployed on Arbitrum");
+        } else {
+            console.log("Already deployed on Arbitrum");
+        }
+
+        hub.upgradeBeaconCrossChain{value: HYPERLANE_FEE}("OrgDeployer", impl, VERSION);
+        console.log("Beacon upgrade dispatched (Arbitrum local + Gnosis cross-chain)");
+
+        vm.stopBroadcast();
+
+        address pm = address(hub.poaManager());
+        address current = PoaManager(pm).getCurrentImplementationById(keccak256("OrgDeployer"));
+        require(current == impl, "Arbitrum impl not upgraded");
+        console.log("Arbitrum upgrade: PASS");
+        console.log("\nWait ~5 min for Hyperlane relay, then run Step3_Verify on Gnosis");
+    }
+}
+
+contract Step3_Verify is Script {
+    function run() public view {
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+        address expected = dd.computeAddress(dd.computeSalt("OrgDeployer", VERSION));
+        address current = PoaManager(GNOSIS_POA_MANAGER).getCurrentImplementationById(keccak256("OrgDeployer"));
+
+        console.log("\n=== Verify Gnosis OrgDeployer Upgrade ===");
+        console.log("Expected:", expected);
+        console.log("Current: ", current);
+        if (current == expected) {
+            console.log("PASS: OrgDeployer v15 live on Gnosis");
+            console.log("New orgs now auto-whitelist the TaskManager v6 deadline selectors:");
+            console.log("  createTask 0x4d0265d4 / createTasksBatch 0xf31d148f");
+            console.log("  createAndAssignTask 0x98e30e89 / updateTask 0xb7c288e8");
+        } else {
+            console.log("WAITING: Hyperlane message not yet relayed.");
+        }
+    }
+}
+
+/**
+ * @title SimulateOrgDeployerDeadlineRulesUpgrade
+ * @notice Fork-simulates the upgrade end-to-end on Arbitrum: deploys v15 via DD
+ *         (prank Hudson — no env needed), calls upgradeBeaconCrossChain, and
+ *         verifies the Arbitrum beacon impl switched. Gnosis relay isn't
+ *         fork-simulatable; Step3 verifies it after broadcast.
+ *
+ *         Behavior verification (the v6 selectors actually land in the default
+ *         rule batch) is covered by test/DeployerTest.t.sol —
+ *         testDeployFullOrgWithPaymasterAutoWhitelist asserts
+ *         getRule(orgId, taskManager, <v6 selectors>).allowed and the
+ *         selector-accuracy asserts pin the signature strings to the real
+ *         TaskManager selectors.
+ *
+ * Usage:
+ *   FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeOrgDeployerDeadlineRules.s.sol:SimulateOrgDeployerDeadlineRulesUpgrade \
+ *     --fork-url arbitrum -vvv
+ */
+contract SimulateOrgDeployerDeadlineRulesUpgrade is Script {
+    function run() public {
+        PoaManagerHub hub = PoaManagerHub(payable(HUB));
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+        address pm = address(hub.poaManager());
+
+        console.log("\n=== SIM: OrgDeployer v15 upgrade (Arbitrum fork) ===");
+        console.log("Selectors swapped to v6: createTask 0x4d0265d4, createTasksBatch 0xf31d148f,");
+        console.log("createAndAssignTask 0x98e30e89, updateTask 0xb7c288e8");
+
+        address before = PoaManager(pm).getCurrentImplementationById(keccak256("OrgDeployer"));
+        console.log("Current impl:", before);
+
+        bytes32 salt = dd.computeSalt("OrgDeployer", VERSION);
+        address predicted = dd.computeAddress(salt);
+        console.log("Predicted v15:", predicted);
+        require(before != predicted, "Sim: v15 already live (nothing to upgrade)");
+
+        vm.deal(HUDSON_ADMIN, 1 ether);
+        vm.startPrank(HUDSON_ADMIN);
+
+        if (predicted.code.length == 0) {
+            address deployed = dd.deploy(salt, type(OrgDeployer).creationCode);
+            require(deployed == predicted, "Address mismatch");
+            console.log("v15 deployed at:", deployed);
+        }
+
+        hub.upgradeBeaconCrossChain{value: HYPERLANE_FEE}("OrgDeployer", predicted, VERSION);
+
+        vm.stopPrank();
+
+        address after_ = PoaManager(pm).getCurrentImplementationById(keccak256("OrgDeployer"));
+        console.log("New impl:", after_);
+        require(after_ == predicted, "Upgrade failed");
+        require(after_.code.length > 0, "Impl has no code");
+        console.log("New impl codesize:", after_.code.length, "bytes");
+
+        console.log("\nArbitrum upgrade simulation: PASS");
+        console.log(
+            "Behavior verification: DeployerTest.testDeployFullOrgWithPaymasterAutoWhitelist asserts the v6 deadline rules auto-set on deploy."
+        );
+    }
+}

--- a/script/upgrades/UpgradeTaskManagerCreateTasksBatch.s.sol
+++ b/script/upgrades/UpgradeTaskManagerCreateTasksBatch.s.sol
@@ -294,7 +294,9 @@ contract DryRun_GnosisUpgrade is Script {
             metadataHash: bytes32(0),
             bountyToken: address(0),
             bountyPayout: 0,
-            requiresApplication: false
+            requiresApplication: false,
+            absoluteDeadline: 0,
+            completionWindow: 0
         });
         inputs[1] = TaskManager.CreateTaskInput({
             payout: 2 ether,
@@ -302,7 +304,9 @@ contract DryRun_GnosisUpgrade is Script {
             metadataHash: bytes32(0),
             bountyToken: address(0),
             bountyPayout: 0,
-            requiresApplication: false
+            requiresApplication: false,
+            absoluteDeadline: 0,
+            completionWindow: 0
         });
         inputs[2] = TaskManager.CreateTaskInput({
             payout: 3 ether,
@@ -310,7 +314,9 @@ contract DryRun_GnosisUpgrade is Script {
             metadataHash: bytes32(0),
             bountyToken: address(0),
             bountyPayout: 0,
-            requiresApplication: false
+            requiresApplication: false,
+            absoluteDeadline: 0,
+            completionWindow: 0
         });
 
         vm.prank(executor);
@@ -345,7 +351,9 @@ contract DryRun_GnosisUpgrade is Script {
             metadataHash: bytes32(0),
             bountyToken: address(0),
             bountyPayout: 0,
-            requiresApplication: false
+            requiresApplication: false,
+            absoluteDeadline: 0,
+            completionWindow: 0
         });
 
         vm.prank(executor);

--- a/script/upgrades/UpgradeTaskManagerDeadlines.s.sol
+++ b/script/upgrades/UpgradeTaskManagerDeadlines.s.sol
@@ -1,0 +1,476 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import {TaskManager} from "../../src/TaskManager.sol";
+import {PoaManagerHub} from "../../src/crosschain/PoaManagerHub.sol";
+import {PoaManager} from "../../src/PoaManager.sol";
+import {DeterministicDeployer} from "../../src/crosschain/DeterministicDeployer.sol";
+
+/*
+ * ============================================================================
+ * TaskManager Upgrade — Deadlines & Claim Takeover (v6)
+ * ============================================================================
+ *
+ * Adds three Task fields (append-only; pre-v6 tasks read zeros = "no deadlines"):
+ *   uint48 absoluteDeadline  — unix cutoff for any claim (0 = none)
+ *   uint32 completionWindow  — per-claim submission window in seconds (0 = none)
+ *   uint48 claimDeadline     — current claim's deadline, set per claim/assign/approve
+ *
+ * Lenient enforcement: submitTask is NEVER blocked. An expired claim (claimDeadline
+ * or absoluteDeadline strictly passed while CLAIMED) simply loses protection —
+ * claimTask / assignTask / approveApplication take the task over directly, emitting
+ * TaskClaimExpired before the normal lifecycle event. rejectTask restarts the
+ * window. updateTask can adjust both knobs (a PAST absoluteDeadline is allowed
+ * there: the admin lever that opens an abandoned CLAIMED task to takeover).
+ *
+ * SIGNATURE CHANGES (selectors replaced; paymaster + frontend ship in lockstep):
+ *   createTask           0x22fa79bc -> 0x4d0265d4 (…,bool,uint48,uint32)
+ *   createTasksBatch     0xc18aa1c9 -> 0xf31d148f (CreateTaskInput +2 fields)
+ *   createAndAssignTask  0xaf425951 -> 0x98e30e89 (…,bool,uint48,uint32)
+ *   updateTask           0x48db6f65 -> 0xb7c288e8 (…,uint256,uint48,uint32)
+ * New events (existing event signatures untouched):
+ *   TaskDeadlinesSet(uint256 indexed,uint48,uint32)
+ *   TaskClaimDeadlineSet(uint256 indexed,uint48)
+ *   TaskClaimExpired(uint256 indexed,address indexed,address indexed)
+ *
+ * No Layout struct change (only the Task mapping value grows, end-append) — no
+ * reinitializer needed.
+ *
+ * Version selection (CLAUDE.md probing recipe, both surfaces, both chains, 2026-06-09):
+ *   TaskManager: registry has 4 versions on Gnosis AND Arbitrum; v5 TAKEN
+ *   (registry + CREATE2) on both; v6 FREE on both surfaces on both chains
+ *   (predicted 0x7833c4670C42dbCe1a7aB1BAB7e7Baf0A982ff57).
+ *
+ * Three-step cross-chain upgrade pattern (mirrors UpgradeTaskManagerEditPerms):
+ *   1. Deploy impl on Gnosis via DeterministicDeployer
+ *   2. Deploy on Arbitrum + upgradeBeaconCrossChain
+ *   3. Verify on Gnosis after Hyperlane relay (~5 min)
+ *
+ * Companion ops (broadcast in the same window — old selectors die at upgrade):
+ *   - UpgradeOrgDeployerDeadlineRules (v15): new orgs auto-whitelist v6 selectors
+ *   - WhitelistTaskDeadlineRules{Poa,Test6Kubi,DecentralPark}ViaGovernance:
+ *     retroactive per-org paymaster rules (4 new allowed, 4 dead disallowed)
+ *
+ * Usage (sim first — CLAUDE.md requires PASS before broadcast):
+ *   FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeTaskManagerDeadlines.s.sol:DryRun_GnosisUpgrade --fork-url gnosis -vvv
+ *   FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeTaskManagerDeadlines.s.sol:DryRun_ArbitrumUpgrade --fork-url arbitrum -vvv
+ *
+ * Broadcast:
+ *   source .env && FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeTaskManagerDeadlines.s.sol:Step1_DeployImplOnGnosis \
+ *     --rpc-url gnosis --broadcast --slow
+ *   source .env && FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeTaskManagerDeadlines.s.sol:Step2_UpgradeFromArbitrum \
+ *     --rpc-url arbitrum --broadcast --slow
+ *   forge script script/upgrades/UpgradeTaskManagerDeadlines.s.sol:Step3_VerifyGnosis --rpc-url gnosis
+ * ============================================================================
+ */
+
+address constant DD = 0x4aC8B5ebEb9D8C3dE3180ddF381D552d59e8835a;
+address constant HUB = 0xB72840B343654eAfb2CFf7acC4Fc6b59E6c3CC71;
+address constant GNOSIS_POA_MANAGER = 0x794fD39e75140ee1545B1B022E5486B7c863789b;
+// PoaManager on Arbitrum (read once via Hub.poaManager(); hardcoded for the DryRun).
+address constant ARBITRUM_POA_MANAGER = 0xFF585Fae4A944cD173B19158C6FC5E08980b0815;
+uint256 constant HYPERLANE_FEE = 0.005 ether;
+// Hudson — owner of PoaManagerHub (Arbitrum), PoaManagerSatellite (Gnosis), DeterministicDeployer.
+// Hardcoded per CLAUDE.md: prank as it, don't read owner() mid-fork.
+address constant HUDSON_ADMIN = 0xA6F4D9f44Dd980b7168D829d5f74c2b00a46b2c9;
+// PoaManagerSatellite on Gnosis — owner of the Gnosis PoaManager. The DryRun pranks it
+// directly; in production it invokes upgradeBeacon when the Hyperlane message relays.
+address constant GNOSIS_SATELLITE = 0x4Ad70029a9247D369a5bEA92f90840B9ee58eD06;
+// v5 (edit perms) is the latest registered impl on both chains. v6 probed FREE on both
+// surfaces (registry + CREATE2) on both chains 2026-06-09.
+string constant VERSION = "v6";
+
+/**
+ * @title Step1_DeployImplOnGnosis
+ * @notice Deploy TaskManager v6 implementation on Gnosis via DD.
+ */
+contract Step1_DeployImplOnGnosis is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+
+        bytes32 salt = dd.computeSalt("TaskManager", VERSION);
+        address predicted = dd.computeAddress(salt);
+        console.log("\n=== Step 1: Deploy TaskManager v6 impl on Gnosis ===");
+        console.log("Predicted:", predicted);
+
+        if (predicted.code.length > 0) {
+            console.log("Already deployed. Skipping.");
+            return;
+        }
+
+        vm.startBroadcast(deployerKey);
+        address deployed = dd.deploy(salt, type(TaskManager).creationCode);
+        vm.stopBroadcast();
+
+        require(deployed == predicted, "Address mismatch");
+        console.log("Deployed:", deployed);
+        console.log("\nNext: Run Step2_UpgradeFromArbitrum on Arbitrum");
+    }
+}
+
+/**
+ * @title Step2_UpgradeFromArbitrum
+ * @notice Deploy impl on Arbitrum via DD, upgrade beacon cross-chain.
+ */
+contract Step2_UpgradeFromArbitrum is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        address deployer = vm.addr(deployerKey);
+
+        PoaManagerHub hub = PoaManagerHub(payable(HUB));
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+
+        require(hub.owner() == deployer, "Deployer must own Hub");
+        require(!hub.paused(), "Hub is paused");
+
+        bytes32 salt = dd.computeSalt("TaskManager", VERSION);
+        address predicted = dd.computeAddress(salt);
+        console.log("\n=== Step 2: Upgrade TaskManager from Arbitrum ===");
+        console.log("DD impl address:", predicted);
+
+        vm.startBroadcast(deployerKey);
+
+        if (predicted.code.length == 0) {
+            dd.deploy(salt, type(TaskManager).creationCode);
+            console.log("Deployed on Arbitrum");
+        } else {
+            console.log("Already deployed on Arbitrum");
+        }
+
+        hub.upgradeBeaconCrossChain{value: HYPERLANE_FEE}("TaskManager", predicted, VERSION);
+        console.log("Beacon upgraded cross-chain");
+
+        vm.stopBroadcast();
+        console.log("\nWait ~5 min for Hyperlane relay, then run Step3 on Gnosis.");
+    }
+}
+
+/**
+ * @title Step3_VerifyGnosis
+ * @notice Verify the Gnosis beacon upgrade landed.
+ */
+contract Step3_VerifyGnosis is Script {
+    function run() public view {
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+        bytes32 salt = dd.computeSalt("TaskManager", VERSION);
+        address expectedImpl = dd.computeAddress(salt);
+
+        address currentImpl = PoaManager(GNOSIS_POA_MANAGER).getCurrentImplementationById(keccak256("TaskManager"));
+
+        console.log("\n=== Step 3: Verify Gnosis TaskManager Upgrade ===");
+        console.log("Expected impl:", expectedImpl);
+        console.log("Current impl: ", currentImpl);
+
+        if (currentImpl == expectedImpl) {
+            console.log("PASS: TaskManager upgraded to v6 on Gnosis");
+            console.log("\nNew capabilities:");
+            console.log("  - absoluteDeadline + completionWindow on create/update (new selectors)");
+            console.log("  - claimTask/assignTask/approveApplication take over expired claims");
+            console.log("  - rejectTask restarts the claim window; submitTask never deadline-blocked");
+        } else {
+            console.log("WAITING: Hyperlane message not yet relayed.");
+        }
+    }
+}
+
+interface IOrgRegistry {
+    function orgIds(uint256 index) external view returns (bytes32);
+    function proxyOf(bytes32 orgId, bytes32 typeId) external view returns (address);
+}
+
+/**
+ * @title DeadlineDryRunBase
+ * @notice Shared fork-sim: deploys v6 via DD (prank Hudson), upgrades the chain's
+ *         beacon, then exercises deadlines + takeover against a live TaskManager proxy.
+ *
+ *         Asserts:
+ *           1. DD-predicted address matches deployed address.
+ *           2. PoaManager beacon updates to the new impl.
+ *           3. New createTask v6 selector (0x4d0265d4) present in impl bytecode.
+ *           4. Live proxy:
+ *              a. Storage preserved (executor survives the impl swap).
+ *              b. Pre-v6 tasks read zero deadlines via the appended lens fields.
+ *              c. Born-expired absoluteDeadline reverts InvalidDeadline at create.
+ *              d. Window task: assignment sets claimDeadline = now + window.
+ *              e. Expiry boundary: at the deadline second the claim is protected;
+ *                 one second later a takeover claim succeeds (claimer switches,
+ *                 fresh window).
+ *              f. Late submit by the NEW claimer works (lenient), task completes.
+ *              g. updateTask window edit preserves the original claim start.
+ *              h. Pre-v6-style CLAIMED task (no deadlines) is NOT takeover-able.
+ */
+abstract contract DeadlineDryRunBase is Script {
+    // OrgRegistry CREATE2 address (holds org #0 on Gnosis; the Arbitrum instance has no
+    // registrations — the Arbitrum DryRun resolves the Poa proxy from verified constants).
+    address constant ORG_REGISTRY = 0x3744b372abc41589226313F2bB1dB3aCAa22A854;
+
+    function _poaManager() internal pure virtual returns (address);
+    function _upgradeBeacon(address newImpl) internal virtual;
+    function _chainName() internal pure virtual returns (string memory);
+    /// @dev Resolve a live TaskManager proxy to exercise on this chain's fork.
+    function _liveProxy() internal view virtual returns (address);
+
+    function run() public {
+        console.log("\n=== DRY RUN: TaskManager v6 (deadlines) upgrade on", _chainName(), "fork ===\n");
+
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+        PoaManager pm = PoaManager(_poaManager());
+
+        // 1. Pre-state snapshot.
+        address implBefore = pm.getCurrentImplementationById(keccak256("TaskManager"));
+        console.log("Impl before:", implBefore);
+
+        // 2. Step1/Step2 simulation: deploy v6 impl via DD (Hudson owns DD on both chains).
+        bytes32 salt = dd.computeSalt("TaskManager", VERSION);
+        address predicted = dd.computeAddress(salt);
+        console.log("DD predicted impl:", predicted);
+
+        address deployed;
+        if (predicted.code.length == 0) {
+            vm.prank(HUDSON_ADMIN);
+            deployed = dd.deploy(salt, type(TaskManager).creationCode);
+        } else {
+            console.log("Already deployed at predicted (skipping deploy)");
+            deployed = predicted;
+        }
+        require(deployed == predicted, "DryRun: DD address mismatch");
+        require(deployed.code.length > 0, "DryRun: impl code missing");
+        console.log("Deployed impl:", deployed);
+
+        // 3. Beacon upgrade as the chain's real production caller.
+        _upgradeBeacon(deployed);
+        address implAfter = pm.getCurrentImplementationById(keccak256("TaskManager"));
+        require(implAfter == deployed, "DryRun: beacon upgrade did not stick");
+        console.log("Impl after :", implAfter);
+
+        // 4. v6 createTask selector present in impl bytecode.
+        bytes4 sel = TaskManager.createTask.selector; // 0x4d0265d4 in v6
+        bytes memory code = deployed.code;
+        bool found = false;
+        for (uint256 i; i + 4 <= code.length; ++i) {
+            if (code[i] == sel[0] && code[i + 1] == sel[1] && code[i + 2] == sel[2] && code[i + 3] == sel[3]) {
+                found = true;
+                break;
+            }
+        }
+        require(found, "DryRun: v6 createTask selector missing from impl bytecode");
+        console.log("v6 createTask selector present in impl bytecode");
+
+        // 5. Live-proxy exercise.
+        _exerciseLiveProxy();
+
+        console.log("\n=== ALL DRY-RUN CHECKS PASSED ===");
+        console.log("Safe to broadcast Step1/Step2/Step3 against mainnet.");
+    }
+
+    function _exerciseLiveProxy() internal {
+        address proxy = _liveProxy();
+        require(proxy != address(0), "DryRun: no TaskManager proxy to exercise");
+        TaskManager tm = TaskManager(proxy);
+
+        console.log("\n--- Live-proxy exercise ---");
+        console.log("TaskManager proxy:", proxy);
+
+        // 5a. Storage preservation.
+        address executor = abi.decode(tm.getLensData(4, ""), (address));
+        require(executor != address(0), "DryRun: executor unset post-upgrade (storage drift?)");
+        console.log("Executor (preserved):", executor);
+
+        // 5b. Pre-v6 task zero-state: any pre-existing task must read zero deadlines.
+        uint256 preExisting = _nextAvailableTaskId(proxy);
+        if (preExisting > 0) {
+            (,, uint48 cd0, uint48 abs0, uint32 win0) = _readDeadlines(tm, 0);
+            require(abs0 == 0 && win0 == 0 && cd0 == 0, "DryRun: pre-v6 task has nonzero deadlines");
+            console.log("Pre-v6 task 0 reads zero deadlines OK");
+        } else {
+            console.log("(org has no pre-existing tasks; zero-state check vacuous)");
+        }
+
+        // 5c. Fresh project for the exercise (executor bypasses _requireCreator).
+        TaskManager.BootstrapProjectConfig memory cfg = TaskManager.BootstrapProjectConfig({
+            title: bytes("dryrun-deadlines"),
+            metadataHash: bytes32(0),
+            cap: 0,
+            managers: new address[](0),
+            createHats: new uint256[](0),
+            claimHats: new uint256[](0),
+            reviewHats: new uint256[](0),
+            assignHats: new uint256[](0),
+            bountyTokens: new address[](0),
+            bountyCaps: new uint256[](0)
+        });
+        vm.prank(executor);
+        bytes32 pid = tm.createProject(cfg);
+        console.log("Test project pid:", vm.toString(pid));
+
+        // 5d. Born-expired absolute deadline reverts at create.
+        vm.prank(executor);
+        (bool okBorn,) = proxy.call(
+            abi.encodeCall(
+                TaskManager.createTask,
+                (
+                    1 ether,
+                    bytes("born-expired"),
+                    bytes32(0),
+                    pid,
+                    address(0),
+                    0,
+                    false,
+                    uint48(vm.getBlockTimestamp()),
+                    0
+                )
+            )
+        );
+        require(!okBorn, "DryRun: born-expired create must revert InvalidDeadline");
+        console.log("Born-expired create reverts OK");
+
+        // 5e. Window task: create + assign, deadline = now + window.
+        uint32 window = 3 days;
+        uint256 taskId = _nextAvailableTaskId(proxy);
+        address claimerA = makeAddr("dryrun-claimer-a");
+        vm.prank(executor);
+        tm.createTask(2 ether, bytes("windowed"), bytes32(0), pid, address(0), 0, false, 0, window);
+        vm.prank(executor);
+        tm.assignTask(taskId, claimerA);
+
+        (address claimer1,, uint48 cd1,, uint32 win1) = _readDeadlines(tm, taskId);
+        require(claimer1 == claimerA, "DryRun: assignee wrong");
+        require(win1 == window, "DryRun: window not stored");
+        require(cd1 == uint48(vm.getBlockTimestamp()) + window, "DryRun: claimDeadline != now + window");
+        console.log("Assignment started the claim window OK");
+
+        // 5f. Boundary: protected at the deadline second, takeover-able one second later.
+        vm.warp(uint256(cd1));
+        vm.prank(executor);
+        (bool okEarly,) = proxy.call(abi.encodeCall(TaskManager.claimTask, (taskId)));
+        require(!okEarly, "DryRun: claim at the deadline second must stay protected");
+
+        vm.warp(uint256(cd1) + 1);
+        vm.prank(executor);
+        tm.claimTask(taskId); // executor takes the task over (PM bypass covers CLAIM perm)
+        (address claimer2,, uint48 cd2,,) = _readDeadlines(tm, taskId);
+        require(claimer2 == executor, "DryRun: takeover did not switch claimer");
+        require(cd2 == uint48(vm.getBlockTimestamp()) + window, "DryRun: takeover did not restart window");
+        console.log("Expiry boundary + takeover OK (claimer A -> executor, fresh window)");
+
+        // 5g. Lenient: the new claimer submits AFTER its own deadline, then completes.
+        vm.warp(uint256(cd2) + 12 hours);
+        vm.prank(executor);
+        tm.submitTask(taskId, keccak256("late-but-fine"));
+        vm.prank(executor);
+        tm.completeTask(taskId);
+        console.log("Late submit + complete OK (lenient enforcement)");
+
+        // 5h. updateTask window edit preserves the claim start.
+        uint256 task2 = _nextAvailableTaskId(proxy);
+        vm.prank(executor);
+        tm.createTask(1 ether, bytes("arith"), bytes32(0), pid, address(0), 0, false, 0, window);
+        vm.prank(executor);
+        tm.assignTask(task2, claimerA);
+        uint48 claimStart = uint48(vm.getBlockTimestamp());
+
+        vm.warp(vm.getBlockTimestamp() + 1 days);
+        uint32 newWindow = 10 days;
+        vm.prank(executor);
+        tm.updateTask(task2, 1 ether, bytes("arith"), bytes32(0), address(0), 0, 0, newWindow);
+        (,, uint48 cdAdj,, uint32 winAdj) = _readDeadlines(tm, task2);
+        require(winAdj == newWindow, "DryRun: window not updated");
+        require(cdAdj == claimStart + newWindow, "DryRun: window edit lost the claim start");
+        console.log("updateTask window arithmetic OK (claim start preserved)");
+
+        // 5i. Pre-v6-style CLAIMED task (no deadlines) stays protected forever.
+        uint256 task3 = _nextAvailableTaskId(proxy);
+        vm.prank(executor);
+        tm.createTask(1 ether, bytes("no-deadlines"), bytes32(0), pid, address(0), 0, false, 0, 0);
+        vm.prank(executor);
+        tm.assignTask(task3, claimerA);
+        vm.warp(vm.getBlockTimestamp() + 365 days);
+        vm.prank(executor);
+        (bool okSteal,) = proxy.call(abi.encodeCall(TaskManager.claimTask, (task3)));
+        require(!okSteal, "DryRun: deadline-less claim must never be takeover-able");
+        console.log("Deadline-less CLAIMED task stays protected OK");
+    }
+
+    /// @dev Finds the next unused task id by probing the lens.
+    function _nextAvailableTaskId(address proxy) internal view returns (uint256) {
+        for (uint256 i; i < 1_000_000; ++i) {
+            (bool ok,) =
+                proxy.staticcall(abi.encodeWithSelector(TaskManager.getLensData.selector, uint8(1), abi.encode(i)));
+            if (!ok) return i;
+        }
+        revert("DryRun: nextAvailableTaskId search exhausted");
+    }
+
+    function _readDeadlines(TaskManager tm, uint256 id)
+        internal
+        view
+        returns (address claimer, TaskManager.Status status, uint48 claimDeadline, uint48 absDeadline, uint32 window)
+    {
+        bytes memory data = tm.getLensData(1, abi.encode(id));
+        // tuple: (projectId, payout, claimer, bountyPayout, requiresApplication, status,
+        //         bountyToken, absoluteDeadline, completionWindow, claimDeadline)
+        (,, claimer,,, status,, absDeadline, window, claimDeadline) = abi.decode(
+            data, (bytes32, uint96, address, uint96, bool, TaskManager.Status, address, uint48, uint32, uint48)
+        );
+    }
+}
+
+/**
+ * @title DryRun_GnosisUpgrade
+ * @notice v6 dry run on a Gnosis fork (beacon upgraded by pranking the Satellite —
+ *         the real production caller after the Hyperlane relay).
+ */
+contract DryRun_GnosisUpgrade is DeadlineDryRunBase {
+    function _poaManager() internal pure override returns (address) {
+        return GNOSIS_POA_MANAGER;
+    }
+
+    function _chainName() internal pure override returns (string memory) {
+        return "Gnosis";
+    }
+
+    function _upgradeBeacon(address newImpl) internal override {
+        vm.prank(GNOSIS_SATELLITE);
+        PoaManager(GNOSIS_POA_MANAGER).upgradeBeacon("TaskManager", newImpl, VERSION);
+    }
+
+    function _liveProxy() internal view override returns (address) {
+        IOrgRegistry reg = IOrgRegistry(ORG_REGISTRY);
+        return reg.proxyOf(reg.orgIds(0), keccak256("TaskManager"));
+    }
+}
+
+/**
+ * @title DryRun_ArbitrumUpgrade
+ * @notice v6 dry run on an Arbitrum fork (beacon upgraded through the Hub exactly
+ *         like Step2, pranking Hudson as Hub owner).
+ */
+contract DryRun_ArbitrumUpgrade is DeadlineDryRunBase {
+    function _poaManager() internal pure override returns (address) {
+        return ARBITRUM_POA_MANAGER;
+    }
+
+    function _chainName() internal pure override returns (string memory) {
+        return "Arbitrum";
+    }
+
+    function _upgradeBeacon(address newImpl) internal override {
+        vm.deal(HUDSON_ADMIN, 1 ether);
+        vm.prank(HUDSON_ADMIN);
+        PoaManagerHub(payable(HUB)).upgradeBeaconCrossChain{value: HYPERLANE_FEE}("TaskManager", newImpl, VERSION);
+    }
+
+    function _liveProxy() internal pure override returns (address) {
+        // Poa's TaskManager on Arbitrum — verified constant (same source as the
+        // WhitelistTaskDeadlineRulesPoaViaGovernance script); the Arbitrum OrgRegistry
+        // instance holds no registrations to resolve from.
+        return 0x681f29751724D2bED331d3EB35e0C9B1C57aF9F0;
+    }
+}

--- a/script/upgrades/UpgradeTaskManagerEditPerms.s.sol
+++ b/script/upgrades/UpgradeTaskManagerEditPerms.s.sol
@@ -296,7 +296,7 @@ contract DryRun_GnosisUpgrade is Script {
 
         address assignee = makeAddr("dryrun-claimer");
         vm.prank(executor);
-        tm.createTask(2 ether, bytes("orig-title"), bytes32(0), pid, address(0), 0, false);
+        tm.createTask(2 ether, bytes("orig-title"), bytes32(0), pid, address(0), 0, false, 0, 0);
         vm.prank(executor);
         tm.assignTask(candidateId, assignee);
 
@@ -308,7 +308,7 @@ contract DryRun_GnosisUpgrade is Script {
 
         // 5d. Executor edits payout on the CLAIMED task.
         vm.prank(executor);
-        tm.updateTask(candidateId, 5 ether, bytes("edited-title"), bytes32(0), address(0), 0);
+        tm.updateTask(candidateId, 5 ether, bytes("edited-title"), bytes32(0), address(0), 0, 0, 0);
         (uint96 payoutAfter,,,,, TaskManager.Status statusAfter,) = _readTask(tm, candidateId);
         require(payoutAfter == 5 ether, "DryRun: post-edit payout wrong");
         require(statusAfter == TaskManager.Status.CLAIMED, "DryRun: post-edit status changed");
@@ -325,7 +325,9 @@ contract DryRun_GnosisUpgrade is Script {
         address outsider = makeAddr("dryrun-outsider");
         vm.prank(outsider);
         (bool okOut,) = proxy.call(
-            abi.encodeCall(TaskManager.updateTask, (candidateId, 1 ether, bytes("nope"), bytes32(0), address(0), 0))
+            abi.encodeCall(
+                TaskManager.updateTask, (candidateId, 1 ether, bytes("nope"), bytes32(0), address(0), 0, 0, 0)
+            )
         );
         require(!okOut, "DryRun: outsider updateTask must revert");
         console.log("Outsider updateTask -> Unauthorized OK");
@@ -345,7 +347,7 @@ contract DryRun_GnosisUpgrade is Script {
 
         vm.prank(executor);
         (bool okComplete,) = proxy.call(
-            abi.encodeCall(TaskManager.updateTask, (candidateId, 9 ether, bytes("x"), bytes32(0), address(0), 0))
+            abi.encodeCall(TaskManager.updateTask, (candidateId, 9 ether, bytes("x"), bytes32(0), address(0), 0, 0, 0))
         );
         require(!okComplete, "DryRun: COMPLETED updateTask must revert");
         vm.prank(executor);
@@ -357,13 +359,13 @@ contract DryRun_GnosisUpgrade is Script {
         // 5i. CANCELLED edits also blocked.
         uint256 cancelId = _nextAvailableTaskId(proxy);
         vm.prank(executor);
-        tm.createTask(1 ether, bytes("to-cancel"), bytes32(0), pid, address(0), 0, false);
+        tm.createTask(1 ether, bytes("to-cancel"), bytes32(0), pid, address(0), 0, false, 0, 0);
         vm.prank(executor);
         tm.cancelTask(cancelId);
 
         vm.prank(executor);
         (bool okCancel,) = proxy.call(
-            abi.encodeCall(TaskManager.updateTask, (cancelId, 2 ether, bytes("x"), bytes32(0), address(0), 0))
+            abi.encodeCall(TaskManager.updateTask, (cancelId, 2 ether, bytes("x"), bytes32(0), address(0), 0, 0, 0))
         );
         require(!okCancel, "DryRun: CANCELLED updateTask must revert");
         console.log("CANCELLED edits blocked OK");

--- a/src/OrgDeployer.sol
+++ b/src/OrgDeployer.sol
@@ -978,11 +978,14 @@ contract OrgDeployer is Initializable {
         pure
         returns (uint256)
     {
+        // TaskManager v6: create/update selectors carry deadline params (uint48 absoluteDeadline,
+        // uint32 completionWindow appended).
         targets[i] = tm;
-        selectors[i] = bytes4(keccak256("createTask(uint256,bytes,bytes32,bytes32,address,uint256,bool)"));
+        selectors[i] = bytes4(keccak256("createTask(uint256,bytes,bytes32,bytes32,address,uint256,bool,uint48,uint32)"));
         i++;
         targets[i] = tm;
-        selectors[i] = bytes4(keccak256("createTasksBatch(bytes32,(uint256,bytes,bytes32,address,uint256,bool)[])"));
+        selectors[i] =
+            bytes4(keccak256("createTasksBatch(bytes32,(uint256,bytes,bytes32,address,uint256,bool,uint48,uint32)[])"));
         i++;
         targets[i] = tm;
         selectors[i] = bytes4(keccak256("claimTask(uint256)"));
@@ -1009,8 +1012,9 @@ contract OrgDeployer is Initializable {
         selectors[i] = bytes4(keccak256("cancelTask(uint256)"));
         i++;
         targets[i] = tm;
-        selectors[i] =
-            bytes4(keccak256("createAndAssignTask(uint256,bytes,bytes32,bytes32,address,address,uint256,bool)"));
+        selectors[i] = bytes4(
+            keccak256("createAndAssignTask(uint256,bytes,bytes32,bytes32,address,address,uint256,bool,uint48,uint32)")
+        );
         i++;
         targets[i] = tm;
         selectors[i] = bytes4(
@@ -1029,8 +1033,9 @@ contract OrgDeployer is Initializable {
         i++;
         // TaskManager v5: post-claim edit functions, gated on EDIT_META / EDIT_FULL perms.
         // Whitelist for gasless 4337/passkey calls by edit-permitted hat holders.
+        // (updateTask signature is the v6 variant with deadline params.)
         targets[i] = tm;
-        selectors[i] = bytes4(keccak256("updateTask(uint256,uint256,bytes,bytes32,address,uint256)"));
+        selectors[i] = bytes4(keccak256("updateTask(uint256,uint256,bytes,bytes32,address,uint256,uint48,uint32)"));
         i++;
         targets[i] = tm;
         selectors[i] = bytes4(keccak256("updateTaskMetadata(uint256,bytes,bytes32)"));

--- a/src/TaskManager.sol
+++ b/src/TaskManager.sol
@@ -65,6 +65,8 @@ contract TaskManager is Initializable, ContextUpgradeable {
     /// @param expected Root the caller believed was current.
     /// @param actual   Root that is actually current on-chain.
     error FoldersRootStale(bytes32 expected, bytes32 actual);
+    /// @notice Non-zero absolute deadline supplied at task creation must be in the future.
+    error InvalidDeadline();
 
     /*──────── Constants ─────*/
     bytes4 public constant MODULE_ID = 0x54534b32; // "TSK2"
@@ -102,6 +104,10 @@ contract TaskManager is Initializable, ContextUpgradeable {
         bool requiresApplication; // slot 3: 1 byte
         Status status; // slot 3: 1 byte (enum fits in 1 byte)
         address bountyToken; // slot 4: 20 bytes (optimized packing: small fields grouped together)
+        // ─── Deadlines (v6) ─── appended only: pre-v6 tasks read zeros = "no deadlines".
+        uint48 absoluteDeadline; // slot 4: 6 bytes — unix cutoff for any claim (0 = none)
+        uint32 completionWindow; // slot 4: 4 bytes — per-claim submission window in seconds (0 = none)
+        uint48 claimDeadline; // slot 5: 6 bytes — current claim's deadline, set on claim/assign/approve (0 = none)
     }
 
     struct Project {
@@ -144,6 +150,8 @@ contract TaskManager is Initializable, ContextUpgradeable {
         address bountyToken;
         uint256 bountyPayout;
         bool requiresApplication;
+        uint48 absoluteDeadline; // unix cutoff (0 = none); must be in the future when set
+        uint32 completionWindow; // per-claim submission window in seconds (0 = none)
     }
 
     /*──────── Storage (ERC-7201) ───────*/
@@ -236,6 +244,18 @@ contract TaskManager is Initializable, ContextUpgradeable {
     event TaskApplicationSubmitted(uint256 indexed id, address indexed applicant, bytes32 applicationHash);
     /// @notice An application was approved and the task moved to CLAIMED for `applicant`.
     event TaskApplicationApproved(uint256 indexed id, address indexed applicant, address indexed approver);
+    /// @notice A task's deadline configuration was set at creation or changed via `updateTask`.
+    /// @dev `absoluteDeadline` is a unix cutoff (0 = none); `completionWindow` is the per-claim
+    ///      submission window in seconds (0 = none). Emitted at creation only when at least one
+    ///      value is non-zero; emitted on update whenever either value changes.
+    event TaskDeadlinesSet(uint256 indexed id, uint48 absoluteDeadline, uint32 completionWindow);
+    /// @notice The current claim's submission deadline changed (claim/assign/approve start,
+    ///         reject reset, window edit adjustment, or clear). Emitted only on value change.
+    event TaskClaimDeadlineSet(uint256 indexed id, uint48 claimDeadline);
+    /// @notice An expired claim was taken over: `previousClaimer` lost the task to `newClaimer`.
+    /// @dev Always followed in the same tx by the lifecycle event recording the new claim
+    ///      (`TaskClaimed`, `TaskAssigned`, or `TaskApplicationApproved`).
+    event TaskClaimExpired(uint256 indexed id, address indexed previousClaimer, address indexed newClaimer);
     /// @notice The executor address was set or changed.
     event ExecutorUpdated(address newExecutor);
 
@@ -556,6 +576,10 @@ contract TaskManager is Initializable, ContextUpgradeable {
      * @param bountyToken         ERC-20 bounty token; `address(0)` for no bounty.
      * @param bountyPayout        Bounty amount in `bountyToken` units.
      * @param requiresApplication If true, claimants must submit an application first.
+     * @param absoluteDeadline    Unix cutoff after which any claim is open to takeover (0 = none);
+     *                            must be in the future when non-zero.
+     * @param completionWindow    Per-claim submission window in seconds (0 = none). Each claimer's
+     *                            deadline is set to `claimTime + completionWindow`.
      */
     function createTask(
         uint256 payout,
@@ -564,10 +588,13 @@ contract TaskManager is Initializable, ContextUpgradeable {
         bytes32 pid,
         address bountyToken,
         uint256 bountyPayout,
-        bool requiresApplication
+        bool requiresApplication,
+        uint48 absoluteDeadline,
+        uint32 completionWindow
     ) external {
         _requireCanCreate(pid);
-        _createTask(payout, title, metadataHash, pid, requiresApplication, bountyToken, bountyPayout);
+        uint48 id = _createTask(payout, title, metadataHash, pid, requiresApplication, bountyToken, bountyPayout);
+        _setTaskDeadlines(id, _layout()._tasks[id], absoluteDeadline, completionWindow);
     }
 
     /**
@@ -586,14 +613,17 @@ contract TaskManager is Initializable, ContextUpgradeable {
         if (tasks.length == 0) revert EmptyBatch();
         _requireCanCreate(pid);
 
+        Layout storage l = _layout();
         uint256 len = tasks.length;
         taskIds = new uint256[](len);
 
         for (uint256 i; i < len;) {
             CreateTaskInput calldata t = tasks[i];
-            taskIds[i] = _createTask(
+            uint48 id = _createTask(
                 t.payout, t.title, t.metadataHash, pid, t.requiresApplication, t.bountyToken, t.bountyPayout
             );
+            taskIds[i] = id;
+            _setTaskDeadlines(id, l._tasks[id], t.absoluteDeadline, t.completionWindow);
             unchecked {
                 ++i;
             }
@@ -630,9 +660,18 @@ contract TaskManager is Initializable, ContextUpgradeable {
         }
 
         id = l.nextTaskId++;
-        l._tasks[id] = Task(
-            pid, uint96(payout), address(0), uint96(bountyPayout), requiresApplication, Status.UNCLAIMED, bountyToken
-        );
+        l._tasks[id] = Task({
+            projectId: pid,
+            payout: uint96(payout),
+            claimer: address(0),
+            bountyPayout: uint96(bountyPayout),
+            requiresApplication: requiresApplication,
+            status: Status.UNCLAIMED,
+            bountyToken: bountyToken,
+            absoluteDeadline: 0, // set via _setTaskDeadlines after creation (create paths only)
+            completionWindow: 0,
+            claimDeadline: 0
+        });
         emit TaskCreated(id, pid, payout, bountyToken, bountyPayout, requiresApplication, title, metadataHash);
     }
 
@@ -654,12 +693,20 @@ contract TaskManager is Initializable, ContextUpgradeable {
      *      with `setConfig(BOUNTY_CAP, ...)`.
      *
      *      Re-runs validation on the new values and adjusts both PT and bounty budgets.
-     * @param id               Task ID.
-     * @param newPayout        New participation-token payout.
-     * @param newTitle         New title.
-     * @param newMetadataHash  New IPFS CID (emitted; not stored).
-     * @param newBountyToken   New bounty token (or `address(0)` to clear).
-     * @param newBountyPayout  New bounty amount.
+     *
+     *      Deadline fields: unlike the create paths, a past `newAbsoluteDeadline` is deliberately
+     *      accepted here — it is the admin lever that opens an abandoned CLAIMED task to takeover
+     *      (cancelTask is UNCLAIMED-only, so no other remedy exists, including for tasks claimed
+     *      before v6). Changing `newCompletionWindow` while the task is claimed adjusts the
+     *      current claim's deadline, preserving the original claim start where derivable.
+     * @param id                  Task ID.
+     * @param newPayout           New participation-token payout.
+     * @param newTitle            New title.
+     * @param newMetadataHash     New IPFS CID (emitted; not stored).
+     * @param newBountyToken      New bounty token (or `address(0)` to clear).
+     * @param newBountyPayout     New bounty amount.
+     * @param newAbsoluteDeadline New unix cutoff (0 = none); past values allowed (see above).
+     * @param newCompletionWindow New per-claim submission window in seconds (0 = none).
      */
     function updateTask(
         uint256 id,
@@ -667,7 +714,9 @@ contract TaskManager is Initializable, ContextUpgradeable {
         bytes calldata newTitle,
         bytes32 newMetadataHash,
         address newBountyToken,
-        uint256 newBountyPayout
+        uint256 newBountyPayout,
+        uint48 newAbsoluteDeadline,
+        uint32 newCompletionWindow
     ) external {
         Layout storage l = _layout();
         Task storage t = _task(l, id);
@@ -711,6 +760,7 @@ contract TaskManager is Initializable, ContextUpgradeable {
         t.bountyPayout = uint96(newBountyPayout);
 
         emit TaskUpdated(id, newPayout, newBountyToken, newBountyPayout, newTitle, newMetadataHash);
+        _updateTaskDeadlines(id, t, newAbsoluteDeadline, newCompletionWindow);
     }
 
     /**
@@ -750,26 +800,44 @@ contract TaskManager is Initializable, ContextUpgradeable {
     }
 
     /**
-     * @notice Claim an UNCLAIMED task that does not require an application.
+     * @notice Claim an UNCLAIMED task — or take over a CLAIMED task whose claim has expired.
      * @dev Permission: CLAIM on the task's project. Reverts RequiresApplication for
      *      application-only tasks (use `applyForTask`).
+     *
+     *      Takeover (v6): if the task is CLAIMED and its claim has expired (per-claim deadline
+     *      or absolute deadline passed), the claim is unprotected and any eligible caller may
+     *      claim it directly — `TaskClaimExpired` is emitted for the ousted claimer, then the
+     *      claim proceeds as normal with a fresh completion window. The expired claimer may
+     *      re-claim their own task to refresh the window. SUBMITTED tasks are never
+     *      takeover-able: delivered work must be reviewed (completed or rejected) first.
      * @param id Task ID.
      */
     function claimTask(uint256 id) external {
         _requireCanClaim(id);
         Layout storage l = _layout();
         Task storage t = _task(l, id);
-        if (t.status != Status.UNCLAIMED) revert BadStatus();
         if (t.requiresApplication) revert RequiresApplication();
+        if (t.status == Status.CLAIMED) {
+            if (!_claimExpired(t)) revert BadStatus();
+            emit TaskClaimExpired(id, t.claimer, _msgSender());
+        } else if (t.status != Status.UNCLAIMED) {
+            revert BadStatus();
+        }
 
         t.status = Status.CLAIMED;
         t.claimer = _msgSender();
         emit TaskClaimed(id, _msgSender());
+        _startClaimWindow(id, t);
     }
 
     /**
-     * @notice Force-assign an UNCLAIMED task to `assignee`, bypassing the claim flow.
-     * @dev Permission: ASSIGN on the task's project. Task must be UNCLAIMED.
+     * @notice Force-assign an UNCLAIMED task to `assignee`, bypassing the claim flow —
+     *         or reassign a CLAIMED task whose claim has expired.
+     * @dev Permission: ASSIGN on the task's project.
+     *
+     *      Takeover (v6): an expired claim (see {claimTask}) may be reassigned to anyone —
+     *      including the same claimer, which acts as an explicit window refresh. Emits
+     *      `TaskClaimExpired` for the ousted claimer before the new assignment.
      * @param id       Task ID.
      * @param assignee Address to record as the claimer.
      */
@@ -779,11 +847,17 @@ contract TaskManager is Initializable, ContextUpgradeable {
         Layout storage l = _layout();
 
         Task storage t = _task(l, id);
-        if (t.status != Status.UNCLAIMED) revert BadStatus();
+        if (t.status == Status.CLAIMED) {
+            if (!_claimExpired(t)) revert BadStatus();
+            emit TaskClaimExpired(id, t.claimer, assignee);
+        } else if (t.status != Status.UNCLAIMED) {
+            revert BadStatus();
+        }
 
         t.status = Status.CLAIMED;
         t.claimer = assignee;
         emit TaskAssigned(id, assignee, _msgSender());
+        _startClaimWindow(id, t);
     }
 
     /**
@@ -840,6 +914,9 @@ contract TaskManager is Initializable, ContextUpgradeable {
     /**
      * @notice Reject a SUBMITTED task. Task reverts to CLAIMED so the claimer can resubmit.
      * @dev Permission: REVIEW on the project. `rejectionHash` must be non-zero (IPFS CID of feedback).
+     *      If the task has a completion window, the claimer's deadline restarts from now —
+     *      rejection means "revise and resubmit", so the rework gets a fresh window. A passed
+     *      absolute deadline still leaves the claim open to takeover (lenient model).
      * @param id             Task ID.
      * @param rejectionHash  IPFS CID of the rejection reasoning.
      */
@@ -852,6 +929,7 @@ contract TaskManager is Initializable, ContextUpgradeable {
 
         t.status = Status.CLAIMED;
         emit TaskRejected(id, _msgSender(), rejectionHash);
+        _startClaimWindow(id, t);
     }
 
     /**
@@ -891,6 +969,9 @@ contract TaskManager is Initializable, ContextUpgradeable {
      * @notice Apply to claim a task that requires applications.
      * @dev Permission: CLAIM on the task's project. Reverts AlreadyApplied if the
      *      caller already submitted an application for this task.
+     *      Takeover (v6): applications are also accepted while the task is CLAIMED with an
+     *      expired claim — otherwise application-gated tasks could only be taken over by the
+     *      original applicant pool. Approval (or assignment) still performs the takeover.
      * @param id              Task ID to apply for.
      * @param applicationHash IPFS CID of the application/submission payload.
      */
@@ -898,7 +979,7 @@ contract TaskManager is Initializable, ContextUpgradeable {
         _requireCanClaim(id);
         Layout storage l = _layout();
         Task storage t = _task(l, id);
-        if (t.status != Status.UNCLAIMED) revert BadStatus();
+        if (t.status != Status.UNCLAIMED && !(t.status == Status.CLAIMED && _claimExpired(t))) revert BadStatus();
         ValidationLib.requireValidApplicationHash(applicationHash);
         if (!t.requiresApplication) revert NoApplicationRequired();
 
@@ -918,6 +999,9 @@ contract TaskManager is Initializable, ContextUpgradeable {
      * @notice Approve a pending application: the task moves to CLAIMED for `applicant`
      *         and the remaining applicants are dropped.
      * @dev Permission: ASSIGN on the task's project.
+     *      Takeover (v6): an expired claim (see {claimTask}) may be handed to any past or new
+     *      applicant — application hashes persist, so the original applicant pool (including
+     *      the ousted claimer) stays approvable. Emits `TaskClaimExpired` before the approval.
      * @param id        Task ID.
      * @param applicant Address of the applicant to approve.
      */
@@ -925,13 +1009,19 @@ contract TaskManager is Initializable, ContextUpgradeable {
         _requireCanAssign(_layout()._tasks[id].projectId);
         Layout storage l = _layout();
         Task storage t = _task(l, id);
-        if (t.status != Status.UNCLAIMED) revert BadStatus();
+        if (t.status == Status.CLAIMED) {
+            if (!_claimExpired(t)) revert BadStatus();
+            emit TaskClaimExpired(id, t.claimer, applicant);
+        } else if (t.status != Status.UNCLAIMED) {
+            revert BadStatus();
+        }
         if (l.taskApplications[id][applicant] == bytes32(0)) revert NotApplicant();
 
         t.status = Status.CLAIMED;
         t.claimer = applicant;
         delete l.taskApplicants[id];
         emit TaskApplicationApproved(id, applicant, _msgSender());
+        _startClaimWindow(id, t);
     }
 
     /**
@@ -946,6 +1036,10 @@ contract TaskManager is Initializable, ContextUpgradeable {
      * @param bountyToken         ERC-20 bounty token (or `address(0)` for none).
      * @param bountyPayout        Bounty amount in `bountyToken` units.
      * @param requiresApplication Recorded on the task even though it's already claimed.
+     * @param absoluteDeadline    Unix cutoff after which the claim is open to takeover (0 = none);
+     *                            must be in the future when non-zero.
+     * @param completionWindow    Per-claim submission window in seconds (0 = none). The assignee's
+     *                            deadline starts at assignment: `now + completionWindow`.
      * @return taskId             ID of the created task.
      */
     function createAndAssignTask(
@@ -956,11 +1050,16 @@ contract TaskManager is Initializable, ContextUpgradeable {
         address assignee,
         address bountyToken,
         uint256 bountyPayout,
-        bool requiresApplication
+        bool requiresApplication,
+        uint48 absoluteDeadline,
+        uint32 completionWindow
     ) external returns (uint256 taskId) {
-        return _createAndAssignTask(
+        taskId = _createAndAssignTask(
             payout, title, metadataHash, pid, assignee, requiresApplication, bountyToken, bountyPayout
         );
+        Task storage t = _layout()._tasks[taskId];
+        _setTaskDeadlines(taskId, t, absoluteDeadline, completionWindow);
+        _startClaimWindow(taskId, t);
     }
 
     function _createAndAssignTask(
@@ -1006,12 +1105,100 @@ contract TaskManager is Initializable, ContextUpgradeable {
 
         // Create and assign task in one go
         taskId = l.nextTaskId++;
-        l._tasks[taskId] =
-            Task(pid, uint96(payout), assignee, uint96(bountyPayout), requiresApplication, Status.CLAIMED, bountyToken);
+        l._tasks[taskId] = Task({
+            projectId: pid,
+            payout: uint96(payout),
+            claimer: assignee,
+            bountyPayout: uint96(bountyPayout),
+            requiresApplication: requiresApplication,
+            status: Status.CLAIMED,
+            bountyToken: bountyToken,
+            absoluteDeadline: 0, // set via _setTaskDeadlines / _startClaimWindow by the caller
+            completionWindow: 0,
+            claimDeadline: 0
+        });
 
         // Emit events
         emit TaskCreated(taskId, pid, payout, bountyToken, bountyPayout, requiresApplication, title, metadataHash);
         emit TaskAssigned(taskId, assignee, sender);
+    }
+
+    /*──────── Deadline Logic (v6) ─────*/
+    /**
+     * @dev True iff a CLAIMED task's claim protection has lapsed: its per-claim deadline or
+     *      absolute deadline (when set) is strictly in the past. The deadline second itself is
+     *      still protected (`>` not `>=`). Enforcement is lenient — expiry never blocks the
+     *      claimer's `submitTask`; it only allows someone else to take the claim over.
+     *      Callers gate on `status == CLAIMED` before consulting this.
+     */
+    function _claimExpired(Task storage t) internal view returns (bool) {
+        uint48 cd = t.claimDeadline;
+        if (cd != 0 && block.timestamp > cd) return true;
+        uint48 ad = t.absoluteDeadline;
+        return ad != 0 && block.timestamp > ad;
+    }
+
+    /**
+     * @dev Create-path deadline init. No-op (no write, no event) when both values are zero so
+     *      deadline-less tasks cost exactly what they did pre-v6. Reverts InvalidDeadline for a
+     *      non-zero absolute deadline that is not in the future — born-expired tasks are a footgun.
+     */
+    function _setTaskDeadlines(uint256 id, Task storage t, uint48 absoluteDeadline, uint32 completionWindow) internal {
+        if (absoluteDeadline == 0 && completionWindow == 0) return;
+        if (absoluteDeadline != 0 && absoluteDeadline <= block.timestamp) revert InvalidDeadline();
+        t.absoluteDeadline = absoluteDeadline;
+        t.completionWindow = completionWindow;
+        emit TaskDeadlinesSet(id, absoluteDeadline, completionWindow);
+    }
+
+    /**
+     * @dev Update-path deadline write plus in-flight claim-window adjustment. A past
+     *      `newAbsoluteDeadline` is deliberately accepted (see {updateTask}). Window changes
+     *      while the task is claimed adjust the current claim's deadline preserving the original
+     *      claim start (`claimDeadline - oldWindow + newWindow`); a task claimed while windowless
+     *      gets `now + newWindow`; clearing the window clears the claim deadline.
+     */
+    function _updateTaskDeadlines(uint256 id, Task storage t, uint48 newAbsoluteDeadline, uint32 newCompletionWindow)
+        internal
+    {
+        uint32 oldWindow = t.completionWindow;
+        if (t.absoluteDeadline != newAbsoluteDeadline || oldWindow != newCompletionWindow) {
+            t.absoluteDeadline = newAbsoluteDeadline;
+            t.completionWindow = newCompletionWindow;
+            emit TaskDeadlinesSet(id, newAbsoluteDeadline, newCompletionWindow);
+        }
+        // claimer != 0 ⟺ status ∈ {CLAIMED, SUBMITTED} here (terminal states revert in updateTask)
+        if (t.claimer != address(0) && oldWindow != newCompletionWindow) {
+            uint48 cd = t.claimDeadline;
+            uint48 newClaimDeadline;
+            if (newCompletionWindow == 0) {
+                newClaimDeadline = 0;
+            } else if (cd == 0) {
+                newClaimDeadline = uint48(block.timestamp) + newCompletionWindow;
+            } else {
+                // cd was claimStart + oldWindow, so this preserves the original claim start.
+                newClaimDeadline = uint48(uint256(cd) - oldWindow + newCompletionWindow);
+            }
+            if (newClaimDeadline != cd) {
+                t.claimDeadline = newClaimDeadline;
+                emit TaskClaimDeadlineSet(id, newClaimDeadline);
+            }
+        }
+    }
+
+    /**
+     * @dev (Re)start the per-claim submission window for the task's current claimer:
+     *      `claimDeadline = now + completionWindow`, or 0 when no window is configured.
+     *      Called on claim, assignment, application approval, and rejection (fresh window for
+     *      rework). Emits only when the stored value changes.
+     */
+    function _startClaimWindow(uint256 id, Task storage t) internal {
+        uint32 window = t.completionWindow;
+        uint48 newClaimDeadline = window == 0 ? 0 : uint48(block.timestamp) + window;
+        if (newClaimDeadline != t.claimDeadline) {
+            t.claimDeadline = newClaimDeadline;
+            emit TaskClaimDeadlineSet(id, newClaimDeadline);
+        }
     }
 
     /*──────── Config Setter (Optimized) ─────── */
@@ -1298,7 +1485,8 @@ contract TaskManager is Initializable, ContextUpgradeable {
      * @notice Read-only dispatcher used by `TaskManagerLens` to surface storage fields
      *         without bloating the proxy ABI.
      * @dev Variants:
-     *      - `1` → Task: `d = abi.encode(uint256 id)` → `(bytes32 projectId, uint96 payout, address claimer, uint96 bountyPayout, bool requiresApplication, Status status, address bountyToken)`.
+     *      - `1` → Task: `d = abi.encode(uint256 id)` → `(bytes32 projectId, uint96 payout, address claimer, uint96 bountyPayout, bool requiresApplication, Status status, address bountyToken, uint48 absoluteDeadline, uint32 completionWindow, uint48 claimDeadline)`.
+     *             Deadline fields appended in v6 — `abi.decode` of the old 7-field tuple still works (trailing words are ignored for static tuples).
      *      - `2` → Project: `d = abi.encode(bytes32 pid)` → `(uint128 cap, uint128 spent, bool exists)`.
      *      - `3` → Hats contract: `d = ""` → `(address hats)`.
      *      - `4` → Executor: `d = ""` → `(address executor)`.
@@ -1327,7 +1515,10 @@ contract TaskManager is Initializable, ContextUpgradeable {
                 task.bountyPayout,
                 task.requiresApplication,
                 task.status,
-                task.bountyToken
+                task.bountyToken,
+                task.absoluteDeadline,
+                task.completionWindow,
+                task.claimDeadline
             );
         } else if (t == 2) {
             // Project

--- a/src/lens/TaskManagerLens.sol
+++ b/src/lens/TaskManagerLens.sol
@@ -29,7 +29,8 @@ contract TaskManagerLens {
         TASK_APPLICATION,
         TASK_APPLICANT_COUNT,
         HAS_APPLIED_FOR_TASK,
-        BOUNTY_BUDGET
+        BOUNTY_BUDGET,
+        TASK_DEADLINES
     }
 
     enum Status {
@@ -63,7 +64,7 @@ contract TaskManagerLens {
             uint256[] memory hats = abi.decode(tm.getLensData(6, ""), (uint256[]));
             return abi.encode(hats.length);
         } else if (key == StorageKey.VERSION) {
-            return abi.encode("v1");
+            return abi.encode("v2");
         } else if (key == StorageKey.TASK_INFO) {
             uint256 id = abi.decode(params, (uint256));
             bytes memory data = tm.getLensData(1, params);
@@ -86,9 +87,23 @@ contract TaskManagerLens {
                 uint96 bountyPayout,
                 bool requiresApplication,
                 Status status,
-                address bountyToken
-            ) = abi.decode(data, (bytes32, uint96, address, uint96, bool, Status, address));
-            return abi.encode(payout, bountyPayout, bountyToken, status, claimer, projectId, requiresApplication);
+                address bountyToken,
+                uint48 absoluteDeadline,
+                uint32 completionWindow,
+                uint48 claimDeadline
+            ) = abi.decode(data, (bytes32, uint96, address, uint96, bool, Status, address, uint48, uint32, uint48));
+            return abi.encode(
+                payout,
+                bountyPayout,
+                bountyToken,
+                status,
+                claimer,
+                projectId,
+                requiresApplication,
+                absoluteDeadline,
+                completionWindow,
+                claimDeadline
+            );
         } else if (key == StorageKey.PROJECT_INFO) {
             bytes32 pid = abi.decode(params, (bytes32));
             bytes memory data = tm.getLensData(2, params);
@@ -114,6 +129,12 @@ contract TaskManagerLens {
             bytes memory data = tm.getLensData(9, params);
             (uint128 cap, uint128 spent) = abi.decode(data, (uint128, uint128));
             return abi.encode(cap, spent);
+        } else if (key == StorageKey.TASK_DEADLINES) {
+            // v6: (uint48 absoluteDeadline, uint32 completionWindow, uint48 claimDeadline)
+            bytes memory data = tm.getLensData(1, params);
+            (,,,,,,, uint48 absoluteDeadline, uint32 completionWindow, uint48 claimDeadline) =
+                abi.decode(data, (bytes32, uint96, address, uint96, bool, Status, address, uint48, uint32, uint48));
+            return abi.encode(absoluteDeadline, completionWindow, claimDeadline);
         }
 
         revert("Invalid index");

--- a/test/DeployerTest.t.sol
+++ b/test/DeployerTest.t.sol
@@ -1146,7 +1146,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         // consumes the vm.prank and createTask runs as the test contract.
         taskId = _nextTaskId(tm);
         vm.prank(executorAddr);
-        tm.createTask(2 ether, bytes("fresh-task"), bytes32(0), pid, address(0), 0, false);
+        tm.createTask(2 ether, bytes("fresh-task"), bytes32(0), pid, address(0), 0, false, 0, 0);
 
         vm.prank(claimerAddr);
         tm.claimTask(taskId);
@@ -1188,7 +1188,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         // orgOwner wears EXECUTIVE → has global EDIT_FULL → can edit the CLAIMED task on the
         // fresh project (no per-project mask shadowing the global grant).
         vm.prank(orgOwner);
-        tm.updateTask(taskId, 25 ether, bytes("edited-at-deploy"), bytes32(0), address(0), 0);
+        tm.updateTask(taskId, 25 ether, bytes("edited-at-deploy"), bytes32(0), address(0), 0, 0, 0);
 
         // And updateTaskMetadata is also available to EDIT_FULL holders.
         vm.prank(orgOwner);
@@ -1217,7 +1217,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
 
         vm.prank(orgOwner);
         vm.expectRevert(TaskManager.Unauthorized.selector);
-        tm.updateTask(taskId, 50 ether, bytes("nope"), bytes32(0), address(0), 0);
+        tm.updateTask(taskId, 50 ether, bytes("nope"), bytes32(0), address(0), 0, 0, 0);
     }
 
     function testBootstrapTaskManagerPerms_BootstrapProjectOverrideShadowsGlobalGrant() public {
@@ -1243,7 +1243,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
 
         vm.prank(orgOwner);
         vm.expectRevert(TaskManager.Unauthorized.selector);
-        tm.updateTask(0, 25 ether, bytes("shadowed"), bytes32(0), address(0), 0);
+        tm.updateTask(0, 25 ether, bytes("shadowed"), bytes32(0), address(0), 0, 0, 0);
     }
 
     function testBootstrapTaskManagerPerms_EmptyRoleIndicesWithMasksRevertsAtomic() public {
@@ -1404,7 +1404,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
 
         vm.prank(orgOwner);
         vm.expectRevert(TaskManager.Unauthorized.selector);
-        tm.updateTask(0, 50 ether, bytes("nope"), bytes32(0), address(0), 0);
+        tm.updateTask(0, 50 ether, bytes("nope"), bytes32(0), address(0), 0, 0, 0);
     }
 
     function testDeployFullOrgMismatchExecutorReverts() public {
@@ -5685,7 +5685,16 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         PaymasterHub.OrgConfig memory orgConfig = paymasterHub.getOrgConfig(orgId);
         assertTrue(orgConfig.operatorHatId != 0, "Operator hat should be set");
 
-        // Verify auto-whitelisted rules exist for deployed contracts
+        // Verify auto-whitelisted rules exist for deployed contracts (helper keeps this
+        // function under the production-profile IR stack limit).
+        _assertAutoWhitelistRules(orgId, result);
+
+        // Verify deposit was also credited
+        PaymasterHub.OrgFinancials memory financials = paymasterHub.getOrgFinancials(orgId);
+        assertEq(financials.deposited, 0.05 ether, "Org should have 0.05 ETH deposited");
+    }
+
+    function _assertAutoWhitelistRules(bytes32 orgId, OrgDeployer.DeploymentResult memory result) internal view {
         PaymasterHub.Rule memory rule;
 
         // Check QuickJoin quickJoinWithUser() is whitelisted
@@ -5700,9 +5709,35 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         rule = paymasterHub.getRule(orgId, result.taskManager, bytes4(keccak256("setFolders(bytes32,bytes32)")));
         assertTrue(rule.allowed, "TaskManager setFolders should be whitelisted (v4 bootstrap)");
 
-        // Check TaskManager v5 post-claim edit functions are whitelisted
+        // Check TaskManager v6 create selectors (deadline params appended) are whitelisted
         rule = paymasterHub.getRule(
-            orgId, result.taskManager, bytes4(keccak256("updateTask(uint256,uint256,bytes,bytes32,address,uint256)"))
+            orgId,
+            result.taskManager,
+            bytes4(keccak256("createTask(uint256,bytes,bytes32,bytes32,address,uint256,bool,uint48,uint32)"))
+        );
+        assertTrue(rule.allowed, "TaskManager createTask should be whitelisted (v6 deadlines)");
+        rule = paymasterHub.getRule(
+            orgId,
+            result.taskManager,
+            bytes4(keccak256("createTasksBatch(bytes32,(uint256,bytes,bytes32,address,uint256,bool,uint48,uint32)[])"))
+        );
+        assertTrue(rule.allowed, "TaskManager createTasksBatch should be whitelisted (v6 deadlines)");
+        rule = paymasterHub.getRule(
+            orgId,
+            result.taskManager,
+            bytes4(
+                keccak256(
+                    "createAndAssignTask(uint256,bytes,bytes32,bytes32,address,address,uint256,bool,uint48,uint32)"
+                )
+            )
+        );
+        assertTrue(rule.allowed, "TaskManager createAndAssignTask should be whitelisted (v6 deadlines)");
+
+        // Check TaskManager v5 post-claim edit functions are whitelisted (v6 updateTask signature)
+        rule = paymasterHub.getRule(
+            orgId,
+            result.taskManager,
+            bytes4(keccak256("updateTask(uint256,uint256,bytes,bytes32,address,uint256,uint48,uint32)"))
         );
         assertTrue(rule.allowed, "TaskManager updateTask should be whitelisted (v5 edit)");
         rule = paymasterHub.getRule(
@@ -5726,10 +5761,6 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         // Check EducationHub completeModule is whitelisted
         rule = paymasterHub.getRule(orgId, result.educationHub, bytes4(keccak256("completeModule(uint256,uint8)")));
         assertTrue(rule.allowed, "EducationHub completeModule should be whitelisted");
-
-        // Verify deposit was also credited
-        PaymasterHub.OrgFinancials memory financials = paymasterHub.getOrgFinancials(orgId);
-        assertEq(financials.deposited, 0.05 ether, "Org should have 0.05 ETH deposited");
     }
 
     function testDeployFullOrgWithPaymasterFeeCaps() public {
@@ -6111,12 +6142,12 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
 
         // ── TaskManager (12) ──
         assertEq(
-            bytes4(keccak256("createTask(uint256,bytes,bytes32,bytes32,address,uint256,bool)")),
+            bytes4(keccak256("createTask(uint256,bytes,bytes32,bytes32,address,uint256,bool,uint48,uint32)")),
             TaskManager.createTask.selector,
             "createTask selector mismatch"
         );
         assertEq(
-            bytes4(keccak256("createTasksBatch(bytes32,(uint256,bytes,bytes32,address,uint256,bool)[])")),
+            bytes4(keccak256("createTasksBatch(bytes32,(uint256,bytes,bytes32,address,uint256,bool,uint48,uint32)[])")),
             TaskManager.createTasksBatch.selector,
             "createTasksBatch selector mismatch"
         );
@@ -6155,7 +6186,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             bytes4(keccak256("cancelTask(uint256)")), TaskManager.cancelTask.selector, "cancelTask selector mismatch"
         );
         assertEq(
-            bytes4(keccak256("updateTask(uint256,uint256,bytes,bytes32,address,uint256)")),
+            bytes4(keccak256("updateTask(uint256,uint256,bytes,bytes32,address,uint256,uint48,uint32)")),
             TaskManager.updateTask.selector,
             "updateTask selector mismatch"
         );

--- a/test/TaskManager.t.sol
+++ b/test/TaskManager.t.sol
@@ -251,7 +251,7 @@ contract MockToken is Test, IERC20 {
 
                 // creator2 creates a task (should succeed, cap == 0)
                 vm.prank(creator2);
-                tm.createTask(1 ether, bytes("ipfs://meta"), bytes32(0), UNLIM_ID, address(0), 0, false);
+                tm.createTask(1 ether, bytes("ipfs://meta"), bytes32(0), UNLIM_ID, address(0), 0, false, 0, 0);
                 bytes memory result = lens.getStorage(address(tm), TaskManagerLens.StorageKey.TASK_INFO, abi.encode(0));
                 (
                     uint256 payout,
@@ -284,15 +284,15 @@ contract MockToken is Test, IERC20 {
 
                 // pm1 can create tasks until cap reached
                 vm.prank(pm1);
-                tm.createTask(1 ether, bytes("a"), bytes32(0), CAPPED_ID, address(0), 0, false);
+                tm.createTask(1 ether, bytes("a"), bytes32(0), CAPPED_ID, address(0), 0, false, 0, 0);
 
                 vm.prank(pm1);
-                tm.createTask(2 ether, bytes("b"), bytes32(0), CAPPED_ID, address(0), 0, false);
+                tm.createTask(2 ether, bytes("b"), bytes32(0), CAPPED_ID, address(0), 0, false, 0, 0);
 
                 // next task (1 wei over budget) reverts
                 vm.prank(pm1);
                 vm.expectRevert(BudgetLib.BudgetExceeded.selector);
-                tm.createTask(1, bytes("c"), bytes32(0), CAPPED_ID, address(0), 0, false);
+                tm.createTask(1, bytes("c"), bytes32(0), CAPPED_ID, address(0), 0, false, 0, 0);
             }
 
             function test_ProjectSpecificRolePermissions() public {
@@ -323,7 +323,7 @@ contract MockToken is Test, IERC20 {
 
                 // Custom creator should be able to create tasks
                 vm.prank(customCreator);
-                tm.createTask(1 ether, bytes("custom_task"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("custom_task"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 // But not review tasks
                 vm.prank(member1);
@@ -371,7 +371,7 @@ contract MockToken is Test, IERC20 {
 
                 // Global user should be able to create (global permission)
                 vm.prank(globalUser);
-                tm.createTask(1 ether, bytes("task"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("task"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 // But not review (project override)
                 vm.prank(member1);
@@ -391,7 +391,7 @@ contract MockToken is Test, IERC20 {
                 BUD_ID = _createDefaultProject("BUD", 2 ether);
 
                 vm.prank(creator1);
-                tm.createTask(2 ether, bytes("foo"), bytes32(0), BUD_ID, address(0), 0, false);
+                tm.createTask(2 ether, bytes("foo"), bytes32(0), BUD_ID, address(0), 0, false, 0, 0);
 
                 // try lowering cap below spent
                 vm.prank(executor);
@@ -409,7 +409,7 @@ contract MockToken is Test, IERC20 {
                 tm.setConfig(TaskManager.ConfigKey.PROJECT_MANAGER, abi.encode(FLOW_ID, pm1, true));
 
                 vm.prank(pm1);
-                tm.createTask(1 ether, bytes("hash"), bytes32(0), FLOW_ID, address(0), 0, false);
+                tm.createTask(1 ether, bytes("hash"), bytes32(0), FLOW_ID, address(0), 0, false, 0, 0);
                 return 0;
             }
 
@@ -442,11 +442,11 @@ contract MockToken is Test, IERC20 {
                 UPD_ID = _createDefaultProject("UPD", 3 ether);
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("foo"), bytes32(0), UPD_ID, address(0), 0, false);
+                tm.createTask(1 ether, bytes("foo"), bytes32(0), UPD_ID, address(0), 0, false, 0, 0);
 
                 // raise payout by 1 ether
                 vm.prank(creator1);
-                tm.updateTask(0, 2 ether, bytes("bar"), bytes32(0), address(0), 0);
+                tm.updateTask(0, 2 ether, bytes("bar"), bytes32(0), address(0), 0, 0, 0);
 
                 // spent should now be 2 ether
                 bytes memory result = lens.getStorage(
@@ -469,7 +469,7 @@ contract MockToken is Test, IERC20 {
                 // paths are covered in TaskManagerEditPermsTest.)
                 vm.prank(outsider);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
-                tm.updateTask(id, 5 ether, bytes("newhash"), bytes32(0), address(0), 0);
+                tm.updateTask(id, 5 ether, bytes("newhash"), bytes32(0), address(0), 0, 0, 0);
             }
 
             function test_CancelTaskSpentUnderflowProtection() public {
@@ -477,7 +477,7 @@ contract MockToken is Test, IERC20 {
                 bytes32 projectId = _createDefaultProject("UNDERFLOW_TEST", 2 ether);
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("task1"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("task1"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 // Artificially manipulate project spent to be less than task payout
                 // This simulates a potential storage corruption or logic bug scenario
@@ -486,7 +486,7 @@ contract MockToken is Test, IERC20 {
 
                 // Create and complete another task to increase spent
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("task2"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("task2"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 vm.prank(creator1);
                 tm.assignTask(1, member1);
@@ -517,7 +517,7 @@ contract MockToken is Test, IERC20 {
                 CAN_ID = _createDefaultProject("CAN", 2 ether);
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("foo"), bytes32(0), CAN_ID, address(0), 0, false);
+                tm.createTask(1 ether, bytes("foo"), bytes32(0), CAN_ID, address(0), 0, false, 0, 0);
 
                 bytes memory result = lens.getStorage(
                     address(tm), TaskManagerLens.StorageKey.PROJECT_INFO, abi.encode(CAN_ID)
@@ -541,7 +541,7 @@ contract MockToken is Test, IERC20 {
                 // outsider has no role and no permissions
                 vm.prank(outsider);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
-                tm.createTask(1, bytes("x"), bytes32(0), ACC_ID, address(0), 0, false);
+                tm.createTask(1, bytes("x"), bytes32(0), ACC_ID, address(0), 0, false, 0, 0);
             }
 
             function test_OnlyAuthorizedCanAssignTask() public {
@@ -595,7 +595,7 @@ contract MockToken is Test, IERC20 {
 
                 // Custom user should be able to create tasks
                 vm.prank(customUser);
-                tm.createTask(1 ether, bytes("custom_task"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("custom_task"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 // But not assign tasks (no ASSIGN permission)
                 vm.prank(customUser);
@@ -649,7 +649,7 @@ contract MockToken is Test, IERC20 {
 
                 // User should only have CREATE permission in this project
                 vm.prank(globalUser);
-                tm.createTask(1 ether, bytes("task"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("task"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 // But not REVIEW (project override removed it)
                 vm.prank(member1);
@@ -724,13 +724,13 @@ contract MockToken is Test, IERC20 {
 
                 // Create multiple tasks across projects
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("task1_A"), bytes32(0), PROJECT_A_ID, address(0), 0, false);
+                tm.createTask(1 ether, bytes("task1_A"), bytes32(0), PROJECT_A_ID, address(0), 0, false, 0, 0);
 
                 vm.prank(creator1);
-                tm.createTask(2 ether, bytes("task1_B"), bytes32(0), PROJECT_B_ID, address(0), 0, false);
+                tm.createTask(2 ether, bytes("task1_B"), bytes32(0), PROJECT_B_ID, address(0), 0, false, 0, 0);
 
                 vm.prank(creator1);
-                tm.createTask(2 ether, bytes("task1_C"), bytes32(0), PROJECT_C_ID, address(0), 0, false);
+                tm.createTask(2 ether, bytes("task1_C"), bytes32(0), PROJECT_C_ID, address(0), 0, false, 0, 0);
 
                 // Member claims tasks from different projects
                 vm.startPrank(member1);
@@ -752,7 +752,7 @@ contract MockToken is Test, IERC20 {
                 // Test trying to exceed PROJECT_B budget
                 vm.prank(creator1);
                 vm.expectRevert(BudgetLib.BudgetExceeded.selector);
-                tm.createTask(1 ether + 1, bytes("task2_B"), bytes32(0), PROJECT_B_ID, address(0), 0, false); // Would exceed cap
+                tm.createTask(1 ether + 1, bytes("task2_B"), bytes32(0), PROJECT_B_ID, address(0), 0, false, 0, 0); // Would exceed cap
 
                 // Complete task from PROJECT_C
                 vm.prank(member1);
@@ -821,7 +821,7 @@ contract MockToken is Test, IERC20 {
 
                 // Verify new project exists by creating a task
                 vm.prank(newCreator);
-                tm.createTask(0.5 ether, bytes("new_task"), bytes32(0), NEW_PROJECT_ID, address(0), 0, false);
+                tm.createTask(0.5 ether, bytes("new_task"), bytes32(0), NEW_PROJECT_ID, address(0), 0, false, 0, 0);
 
                 // Disable the hat using the executor
                 vm.prank(executor);
@@ -882,10 +882,10 @@ contract MockToken is Test, IERC20 {
 
                 // Both PMs should be able to create tasks (as project managers)
                 vm.prank(pm1);
-                tm.createTask(2 ether, bytes("pm1_task"), bytes32(0), MULTI_PM_ID, address(0), 0, false);
+                tm.createTask(2 ether, bytes("pm1_task"), bytes32(0), MULTI_PM_ID, address(0), 0, false, 0, 0);
 
                 vm.prank(pm2);
-                tm.createTask(3 ether, bytes("pm2_task"), bytes32(0), MULTI_PM_ID, address(0), 0, false);
+                tm.createTask(3 ether, bytes("pm2_task"), bytes32(0), MULTI_PM_ID, address(0), 0, false, 0, 0);
 
                 // PM1 can complete PM2's task (as project manager)
                 vm.prank(member1);
@@ -904,18 +904,18 @@ contract MockToken is Test, IERC20 {
                 // PM2 can no longer create tasks (no longer a project manager and no role)
                 vm.prank(pm2);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
-                tm.createTask(1 ether, bytes("should_fail"), bytes32(0), MULTI_PM_ID, address(0), 0, false);
+                tm.createTask(1 ether, bytes("should_fail"), bytes32(0), MULTI_PM_ID, address(0), 0, false, 0, 0);
 
                 // But PM1 still can (still a project manager)
                 vm.prank(pm1);
-                tm.createTask(1 ether, bytes("still_works"), bytes32(0), MULTI_PM_ID, address(0), 0, false);
+                tm.createTask(1 ether, bytes("still_works"), bytes32(0), MULTI_PM_ID, address(0), 0, false, 0, 0);
 
                 // Now give PM2 the PM_HAT
                 setHat(pm2, PM_HAT);
 
                 // PM2 should now be able to create tasks again (has PM_HAT with CREATE permission)
                 vm.prank(pm2);
-                tm.createTask(1 ether, bytes("pm2_with_hat"), bytes32(0), MULTI_PM_ID, address(0), 0, false);
+                tm.createTask(1 ether, bytes("pm2_with_hat"), bytes32(0), MULTI_PM_ID, address(0), 0, false, 0, 0);
 
                 // Verify overall budget tracking
                 bytes memory result =
@@ -953,7 +953,7 @@ contract MockToken is Test, IERC20 {
 
                 // Create and immediately cancel a task
                 vm.startPrank(creator1);
-                tm.createTask(1 ether, bytes("to_cancel"), bytes32(0), EDGE_ID, address(0), 0, false);
+                tm.createTask(1 ether, bytes("to_cancel"), bytes32(0), EDGE_ID, address(0), 0, false, 0, 0);
                 tm.cancelTask(0);
                 vm.stopPrank();
 
@@ -965,7 +965,7 @@ contract MockToken is Test, IERC20 {
 
                 // Create a task, assign it, then try operations that should fail
                 vm.prank(creator1);
-                tm.createTask(2 ether, bytes("edge_task"), bytes32(0), EDGE_ID, address(0), 0, false);
+                tm.createTask(2 ether, bytes("edge_task"), bytes32(0), EDGE_ID, address(0), 0, false, 0, 0);
 
                 vm.prank(creator1);
                 tm.assignTask(1, member1);
@@ -1066,7 +1066,7 @@ contract MockToken is Test, IERC20 {
 
                     vm.prank(creator);
                     bytes memory taskMetadata = abi.encodePacked("task", i);
-                    tm.createTask(payout, taskMetadata, bytes32(0), MEGA_ID, address(0), 0, false);
+                    tm.createTask(payout, taskMetadata, bytes32(0), MEGA_ID, address(0), 0, false, 0, 0);
 
                     // Assign tasks to different members
                     address assignee = members[i % members.length];
@@ -1137,7 +1137,7 @@ contract MockToken is Test, IERC20 {
 
                     vm.prank(pms[0]);
                     bytes memory taskMetadata = abi.encodePacked("capped_task", cappedTaskCount);
-                    tm.createTask(payout, taskMetadata, bytes32(0), CAPPED_BIG_ID, address(0), 0, false);
+                    tm.createTask(payout, taskMetadata, bytes32(0), CAPPED_BIG_ID, address(0), 0, false, 0, 0);
 
                     cappedTaskCount++;
                     cappedSpent += payout;
@@ -1146,7 +1146,7 @@ contract MockToken is Test, IERC20 {
                 // Verify we can't exceed cap
                 vm.prank(pms[0]);
                 vm.expectRevert(BudgetLib.BudgetExceeded.selector);
-                tm.createTask(1 ether, bytes("exceeds_cap"), bytes32(0), CAPPED_BIG_ID, address(0), 0, false);
+                tm.createTask(1 ether, bytes("exceeds_cap"), bytes32(0), CAPPED_BIG_ID, address(0), 0, false, 0, 0);
 
                 // Verify task counts and budget usage
                 result = lens.getStorage(
@@ -1195,7 +1195,7 @@ contract MockToken is Test, IERC20 {
 
                 // Create a task, complete it, then verify project can be deleted
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("task1"), bytes32(0), TO_DELETE_ID, address(0), 0, false);
+                tm.createTask(1 ether, bytes("task1"), bytes32(0), TO_DELETE_ID, address(0), 0, false, 0, 0);
 
                 vm.prank(creator1);
                 tm.assignTask(0, member1);
@@ -1208,7 +1208,7 @@ contract MockToken is Test, IERC20 {
 
                 // Create another task and cancel it
                 vm.prank(creator1);
-                tm.createTask(2 ether, bytes("task2"), bytes32(0), TO_DELETE_ID, address(0), 0, false);
+                tm.createTask(2 ether, bytes("task2"), bytes32(0), TO_DELETE_ID, address(0), 0, false, 0, 0);
 
                 vm.prank(creator1);
                 tm.cancelTask(1);
@@ -1247,7 +1247,7 @@ contract MockToken is Test, IERC20 {
 
                 // Add tasks, verify we can still delete with non-zero spent
                 vm.prank(creator1);
-                tm.createTask(3 ether, bytes("unlimited_task"), bytes32(0), ZERO_CAP_ID, address(0), 0, false);
+                tm.createTask(3 ether, bytes("unlimited_task"), bytes32(0), ZERO_CAP_ID, address(0), 0, false, 0, 0);
 
                 // Delete should succeed with zero cap, non-zero spent
                 vm.prank(creator1);
@@ -1362,7 +1362,9 @@ contract MockToken is Test, IERC20 {
                 // Executor should be able to create tasks even without member role
                 // (executor address has no role but should bypass the member check)
                 vm.prank(executor);
-                tm.createTask(1 ether, bytes("executor_task"), bytes32(0), EXECUTOR_BYPASS_ID, address(0), 0, false);
+                tm.createTask(
+                    1 ether, bytes("executor_task"), bytes32(0), EXECUTOR_BYPASS_ID, address(0), 0, false, 0, 0
+                );
 
                 // Executor should be able to claim tasks
                 vm.prank(executor);
@@ -1416,7 +1418,7 @@ contract MockToken is Test, IERC20 {
 
                 // User should be able to create tasks with CREATE permission
                 vm.prank(multiUser);
-                tm.createTask(1 ether, bytes("multi_task"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("multi_task"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 // User should be able to claim tasks with CLAIM permission
                 vm.prank(multiUser);
@@ -1460,7 +1462,7 @@ contract MockToken is Test, IERC20 {
                 // User can't create tasks (no permissions)
                 vm.prank(dynamicUser);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
-                tm.createTask(1 ether, bytes("should_fail"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("should_fail"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 // Grant CREATE permission at project level
                 vm.prank(creator1);
@@ -1468,7 +1470,7 @@ contract MockToken is Test, IERC20 {
 
                 // Now user can create tasks
                 vm.prank(dynamicUser);
-                tm.createTask(1 ether, bytes("now_works"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("now_works"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 // Another user claims and submits
                 vm.prank(member1);
@@ -1545,10 +1547,10 @@ contract MockToken is Test, IERC20 {
 
                 // User can create tasks in both projects
                 vm.prank(overrideUser);
-                tm.createTask(1 ether, bytes("task1"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("task1"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 vm.prank(overrideUser);
-                tm.createTask(1 ether, bytes("task2"), bytes32(0), projectId2, address(0), 0, false);
+                tm.createTask(1 ether, bytes("task2"), bytes32(0), projectId2, address(0), 0, false, 0, 0);
 
                 // In first project, user can't assign tasks (project override)
                 vm.prank(overrideUser);
@@ -1608,7 +1610,7 @@ contract MockToken is Test, IERC20 {
 
                 // User can create tasks
                 vm.prank(tempUser);
-                tm.createTask(1 ether, bytes("task"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("task"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 // Revoke permission
                 vm.prank(executor);
@@ -1617,7 +1619,7 @@ contract MockToken is Test, IERC20 {
                 // User can't create tasks anymore
                 vm.prank(tempUser);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
-                tm.createTask(1 ether, bytes("fail"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("fail"), bytes32(0), projectId, address(0), 0, false, 0, 0);
             }
 
             function test_IndividualPermissionFlags() public {
@@ -1665,7 +1667,7 @@ contract MockToken is Test, IERC20 {
 
                 // Test CREATE permission - should succeed
                 vm.prank(createUser);
-                tm.createTask(1 ether, bytes("create_task"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("create_task"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 // createUser should not be able to claim or assign
                 vm.prank(createUser);
@@ -1683,12 +1685,12 @@ contract MockToken is Test, IERC20 {
                 // assignUser should not be able to create or review
                 vm.prank(assignUser);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
-                tm.createTask(1 ether, bytes("assign_fail"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("assign_fail"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 // Test CLAIM permission - indirectly tested by previous assign
                 // Create a new task for claiming
                 vm.prank(createUser);
-                tm.createTask(1 ether, bytes("for_claiming"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("for_claiming"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 // claimUser should be able to claim
                 vm.prank(claimUser);
@@ -1709,7 +1711,7 @@ contract MockToken is Test, IERC20 {
                 // reviewUser should not be able to create or assign
                 vm.prank(reviewUser);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
-                tm.createTask(1 ether, bytes("review_fail"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("review_fail"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 vm.prank(reviewUser);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
@@ -1747,9 +1749,8 @@ contract MockToken is Test, IERC20 {
 
                 // Test basic create and assign functionality
                 vm.prank(creator1);
-                uint256 taskId =
-                    tm.createAndAssignTask(
-                    1 ether, bytes("test_task"), bytes32(0), projectId, member1, address(0), 0, false
+                uint256 taskId = tm.createAndAssignTask(
+                    1 ether, bytes("test_task"), bytes32(0), projectId, member1, address(0), 0, false, 0, 0
                 );
 
                 // Verify task was created and assigned correctly
@@ -1812,7 +1813,7 @@ contract MockToken is Test, IERC20 {
                 vm.prank(createOnlyUser);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
                 tm.createAndAssignTask(
-                    1 ether, bytes("should_fail"), bytes32(0), projectId, member1, address(0), 0, false
+                    1 ether, bytes("should_fail"), bytes32(0), projectId, member1, address(0), 0, false, 0, 0
                 );
 
                 // Test that user with only ASSIGN permission cannot use createAndAssignTask
@@ -1826,7 +1827,7 @@ contract MockToken is Test, IERC20 {
                 vm.prank(assignOnlyUser);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
                 tm.createAndAssignTask(
-                    1 ether, bytes("should_fail"), bytes32(0), projectId, member1, address(0), 0, false
+                    1 ether, bytes("should_fail"), bytes32(0), projectId, member1, address(0), 0, false, 0, 0
                 );
 
                 // Test that user with both CREATE and ASSIGN permissions can use createAndAssignTask
@@ -1840,9 +1841,8 @@ contract MockToken is Test, IERC20 {
                 );
 
                 vm.prank(createAssignUser);
-                uint256 taskId =
-                    tm.createAndAssignTask(
-                    1 ether, bytes("should_work"), bytes32(0), projectId, member1, address(0), 0, false
+                uint256 taskId = tm.createAndAssignTask(
+                    1 ether, bytes("should_work"), bytes32(0), projectId, member1, address(0), 0, false, 0, 0
                 );
 
                 // Verify task was created successfully
@@ -1891,9 +1891,8 @@ contract MockToken is Test, IERC20 {
 
                 // Test that project manager can use createAndAssignTask
                 vm.prank(pm1);
-                uint256 taskId =
-                    tm.createAndAssignTask(
-                    1 ether, bytes("pm_task"), bytes32(0), projectId, member1, address(0), 0, false
+                uint256 taskId = tm.createAndAssignTask(
+                    1 ether, bytes("pm_task"), bytes32(0), projectId, member1, address(0), 0, false, 0, 0
                 );
 
                 // Verify task was created and assigned
@@ -1913,7 +1912,7 @@ contract MockToken is Test, IERC20 {
                 vm.prank(outsider);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
                 tm.createAndAssignTask(
-                    1 ether, bytes("should_fail"), bytes32(0), projectId, member1, address(0), 0, false
+                    1 ether, bytes("should_fail"), bytes32(0), projectId, member1, address(0), 0, false, 0, 0
                 );
             }
 
@@ -1947,28 +1946,30 @@ contract MockToken is Test, IERC20 {
                 // Test zero address assignee
                 vm.prank(creator1);
                 vm.expectRevert(ValidationLib.ZeroAddress.selector);
-                tm.createAndAssignTask(1 ether, bytes("test"), bytes32(0), projectId, address(0), address(0), 0, false);
+                tm.createAndAssignTask(
+                    1 ether, bytes("test"), bytes32(0), projectId, address(0), address(0), 0, false, 0, 0
+                );
 
                 // Test zero payout
                 vm.prank(creator1);
                 vm.expectRevert(ValidationLib.InvalidPayout.selector);
-                tm.createAndAssignTask(0, bytes("test"), bytes32(0), projectId, member1, address(0), 0, false);
+                tm.createAndAssignTask(0, bytes("test"), bytes32(0), projectId, member1, address(0), 0, false, 0, 0);
 
                 // Test excessive payout
                 vm.prank(creator1);
                 vm.expectRevert(ValidationLib.InvalidPayout.selector);
-                tm.createAndAssignTask(1e25, bytes("test"), bytes32(0), projectId, member1, address(0), 0, false); // Over MAX_PAYOUT
+                tm.createAndAssignTask(1e25, bytes("test"), bytes32(0), projectId, member1, address(0), 0, false, 0, 0); // Over MAX_PAYOUT
 
                 // Test empty title
                 vm.prank(creator1);
                 vm.expectRevert(ValidationLib.EmptyTitle.selector);
-                tm.createAndAssignTask(1 ether, bytes(""), bytes32(0), projectId, member1, address(0), 0, false);
+                tm.createAndAssignTask(1 ether, bytes(""), bytes32(0), projectId, member1, address(0), 0, false, 0, 0);
 
                 // Test non-existent project - this will fail with NotCreator() because permission check happens first
                 vm.prank(creator1);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
                 tm.createAndAssignTask(
-                    1 ether, bytes("test"), bytes32(0), bytes32(uint256(999)), member1, address(0), 0, false
+                    1 ether, bytes("test"), bytes32(0), bytes32(uint256(999)), member1, address(0), 0, false, 0, 0
                 );
             }
 
@@ -2003,20 +2004,22 @@ contract MockToken is Test, IERC20 {
                 vm.prank(creator1);
                 uint256 taskId1 =
                     tm.createAndAssignTask(
-                    1 ether, bytes("task1"), bytes32(0), projectId, member1, address(0), 0, false
+                    1 ether, bytes("task1"), bytes32(0), projectId, member1, address(0), 0, false, 0, 0
                 );
 
                 // Create second task within budget
                 vm.prank(creator1);
                 uint256 taskId2 =
                     tm.createAndAssignTask(
-                    1 ether, bytes("task2"), bytes32(0), projectId, member1, address(0), 0, false
+                    1 ether, bytes("task2"), bytes32(0), projectId, member1, address(0), 0, false, 0, 0
                 );
 
                 // Try to create third task that would exceed budget
                 vm.prank(creator1);
                 vm.expectRevert(BudgetLib.BudgetExceeded.selector);
-                tm.createAndAssignTask(1 ether, bytes("task3"), bytes32(0), projectId, member1, address(0), 0, false);
+                tm.createAndAssignTask(
+                    1 ether, bytes("task3"), bytes32(0), projectId, member1, address(0), 0, false, 0, 0
+                );
 
                 // Verify project budget tracking
                 bytes memory result =
@@ -2062,7 +2065,7 @@ contract MockToken is Test, IERC20 {
                 vm.expectEmit(true, true, true, true);
                 emit TaskManager.TaskAssigned(0, member1, creator1);
                 tm.createAndAssignTask(
-                    1 ether, bytes("event_test"), bytes32(0), projectId, member1, address(0), 0, false
+                    1 ether, bytes("event_test"), bytes32(0), projectId, member1, address(0), 0, false, 0, 0
                 );
             }
 
@@ -2096,7 +2099,7 @@ contract MockToken is Test, IERC20 {
                 // Create and assign task
                 vm.prank(creator1);
                 uint256 taskId = tm.createAndAssignTask(
-                    1 ether, bytes("lifecycle_test"), bytes32(0), projectId, member1, address(0), 0, false
+                    1 ether, bytes("lifecycle_test"), bytes32(0), projectId, member1, address(0), 0, false, 0, 0
                 );
 
                 // Verify task is in CLAIMED status
@@ -2156,9 +2159,8 @@ contract MockToken is Test, IERC20 {
                 // Measure gas for createAndAssignTask
                 vm.prank(creator1);
                 uint256 gasBefore = gasleft();
-                uint256 taskId =
-                    tm.createAndAssignTask(
-                    1 ether, bytes("gas_test"), bytes32(0), projectId, member1, address(0), 0, false
+                uint256 taskId = tm.createAndAssignTask(
+                    1 ether, bytes("gas_test"), bytes32(0), projectId, member1, address(0), 0, false, 0, 0
                 );
                 uint256 gasUsed = gasBefore - gasleft();
 
@@ -2174,7 +2176,7 @@ contract MockToken is Test, IERC20 {
                 // For comparison, measure gas for separate create + assign operations
                 vm.prank(creator1);
                 gasBefore = gasleft();
-                tm.createTask(1 ether, bytes("gas_test2"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("gas_test2"), bytes32(0), projectId, address(0), 0, false, 0, 0);
                 uint256 gasCreate = gasBefore - gasleft();
 
                 vm.prank(creator1);
@@ -2227,7 +2229,7 @@ contract MockToken is Test, IERC20 {
                 for (uint256 i = 0; i < users.length; i++) {
                     vm.prank(creator1);
                     uint256 taskId = tm.createAndAssignTask(
-                        1 ether, bytes("multi_user_task"), bytes32(0), projectId, users[i], address(0), 0, false
+                        1 ether, bytes("multi_user_task"), bytes32(0), projectId, users[i], address(0), 0, false, 0, 0
                     );
 
                     // Verify each task is assigned to the correct user
@@ -2276,7 +2278,7 @@ contract MockToken is Test, IERC20 {
                 // Test assigning to self
                 vm.prank(creator1);
                 uint256 taskId = tm.createAndAssignTask(
-                    1 ether, bytes("self_assign"), bytes32(0), projectId, creator1, address(0), 0, false
+                    1 ether, bytes("self_assign"), bytes32(0), projectId, creator1, address(0), 0, false, 0, 0
                 );
                 bytes memory ret = lens.getStorage(
                     address(tm), TaskManagerLens.StorageKey.TASK_INFO, abi.encode(taskId)
@@ -2287,7 +2289,7 @@ contract MockToken is Test, IERC20 {
                 // Test assigning to executor
                 vm.prank(creator1);
                 taskId = tm.createAndAssignTask(
-                    1 ether, bytes("executor_assign"), bytes32(0), projectId, executor, address(0), 0, false
+                    1 ether, bytes("executor_assign"), bytes32(0), projectId, executor, address(0), 0, false, 0, 0
                 );
 
                 ret = lens.getStorage(address(tm), TaskManagerLens.StorageKey.TASK_INFO, abi.encode(taskId));
@@ -2312,9 +2314,8 @@ contract MockToken is Test, IERC20 {
                 );
 
                 vm.prank(creator1);
-                taskId =
-                    tm.createAndAssignTask(
-                    1e24, bytes("max_payout"), bytes32(0), maxProjectId, member1, address(0), 0, false
+                taskId = tm.createAndAssignTask(
+                    1e24, bytes("max_payout"), bytes32(0), maxProjectId, member1, address(0), 0, false, 0, 0
                 ); // MAX_PAYOUT
 
                 ret = lens.getStorage(address(tm), TaskManagerLens.StorageKey.TASK_INFO, abi.encode(taskId));
@@ -2354,7 +2355,7 @@ contract MockToken is Test, IERC20 {
                 vm.prank(globalUser);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
                 tm.createAndAssignTask(
-                    1 ether, bytes("should_fail"), bytes32(0), projectId, member1, address(0), 0, false
+                    1 ether, bytes("should_fail"), bytes32(0), projectId, member1, address(0), 0, false, 0, 0
                 );
 
                 // Add ASSIGN permission at project level
@@ -2363,9 +2364,8 @@ contract MockToken is Test, IERC20 {
 
                 // Now user should be able to createAndAssignTask
                 vm.prank(globalUser);
-                uint256 taskId =
-                    tm.createAndAssignTask(
-                    1 ether, bytes("should_work"), bytes32(0), projectId, member1, address(0), 0, false
+                uint256 taskId = tm.createAndAssignTask(
+                    1 ether, bytes("should_work"), bytes32(0), projectId, member1, address(0), 0, false, 0, 0
                 );
 
                 // Verify task was created and assigned
@@ -2407,7 +2407,7 @@ contract MockToken is Test, IERC20 {
 
                 // Create a task that requires applications
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true, 0, 0);
 
                 // Member applies for task
                 bytes32 applicationHash = keccak256("application_content");
@@ -2472,7 +2472,7 @@ contract MockToken is Test, IERC20 {
                 );
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true, 0, 0);
 
                 // Test that only users with CLAIM permission can apply
                 vm.prank(outsider);
@@ -2525,7 +2525,7 @@ contract MockToken is Test, IERC20 {
                 );
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true, 0, 0);
 
                 // Test empty application hash
                 vm.prank(member1);
@@ -2574,7 +2574,7 @@ contract MockToken is Test, IERC20 {
                 );
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true, 0, 0);
 
                 // Member applies
                 vm.prank(member1);
@@ -2620,7 +2620,7 @@ contract MockToken is Test, IERC20 {
                 );
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true, 0, 0);
 
                 vm.prank(member1);
                 tm.applyForTask(0, keccak256("application"));
@@ -2671,7 +2671,7 @@ contract MockToken is Test, IERC20 {
                 );
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true, 0, 0);
 
                 // Test approving task without application
                 vm.prank(pm1);
@@ -2724,7 +2724,7 @@ contract MockToken is Test, IERC20 {
                 );
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true, 0, 0);
 
                 bytes32 applicationHash = keccak256("application_content");
 
@@ -2769,7 +2769,7 @@ contract MockToken is Test, IERC20 {
                 );
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true, 0, 0);
 
                 // 1. Apply for task
                 vm.prank(member1);
@@ -2822,7 +2822,7 @@ contract MockToken is Test, IERC20 {
                 );
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true, 0, 0);
 
                 // Apply for task
                 vm.prank(member1);
@@ -2872,9 +2872,9 @@ contract MockToken is Test, IERC20 {
 
                 // Create multiple tasks
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("task1"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(1 ether, bytes("task1"), bytes32(0), projectId, address(0), 0, true, 0, 0);
                 vm.prank(creator1);
-                tm.createTask(2 ether, bytes("task2"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(2 ether, bytes("task2"), bytes32(0), projectId, address(0), 0, true, 0, 0);
 
                 // Create multiple members
                 address member2 = makeAddr("member2");
@@ -2939,7 +2939,7 @@ contract MockToken is Test, IERC20 {
                 );
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true, 0, 0);
 
                 // Apply for task
                 vm.prank(member1);
@@ -2996,7 +2996,7 @@ contract MockToken is Test, IERC20 {
 
                 // Create application-required task
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("app_required_task"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(1 ether, bytes("app_required_task"), bytes32(0), projectId, address(0), 0, true, 0, 0);
 
                 // Verify task requires applications
                 bytes memory result = lens.getStorage(address(tm), TaskManagerLens.StorageKey.TASK_INFO, abi.encode(0));
@@ -3041,7 +3041,7 @@ contract MockToken is Test, IERC20 {
 
                 // Create application-required task
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("app_required_task"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(1 ether, bytes("app_required_task"), bytes32(0), projectId, address(0), 0, true, 0, 0);
 
                 // Test that direct claiming is prevented
                 vm.prank(member1);
@@ -3094,7 +3094,7 @@ contract MockToken is Test, IERC20 {
 
                 // Create regular task (doesn't require applications)
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("regular_task"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("regular_task"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 // Verify task doesn't require applications
                 bytes memory result = lens.getStorage(address(tm), TaskManagerLens.StorageKey.TASK_INFO, abi.encode(0));
@@ -3154,7 +3154,7 @@ contract MockToken is Test, IERC20 {
                 );
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true, 0, 0);
 
                 // Create multiple applicants
                 address member2 = makeAddr("member2");
@@ -3258,7 +3258,7 @@ contract MockToken is Test, IERC20 {
                 );
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true, 0, 0);
 
                 // Create multiple applicants
                 address member2 = makeAddr("member2");
@@ -3330,7 +3330,7 @@ contract MockToken is Test, IERC20 {
                 );
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true, 0, 0);
 
                 // Apply with specific application data
                 bytes32 applicationHash = keccak256("detailed_application_content");
@@ -3393,7 +3393,7 @@ contract MockToken is Test, IERC20 {
                 );
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true, 0, 0);
 
                 // Create multiple applicants
                 address member2 = makeAddr("member2");
@@ -3477,7 +3477,7 @@ contract MockToken is Test, IERC20 {
                 );
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true, 0, 0);
 
                 // First application succeeds
                 vm.prank(member1);
@@ -3528,7 +3528,7 @@ contract MockToken is Test, IERC20 {
                 );
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true);
+                tm.createTask(1 ether, bytes("test_task"), bytes32(0), projectId, address(0), 0, true, 0, 0);
 
                 bytes32 applicationHash = keccak256("application_content");
 
@@ -3553,7 +3553,7 @@ contract MockToken is Test, IERC20 {
                 tm.setConfig(TaskManager.ConfigKey.PROJECT_MANAGER, abi.encode(pid, pm1, true));
 
                 vm.prank(pm1);
-                tm.createTask(1 ether, bytes("reject_task"), bytes32(0), pid, address(0), 0, false);
+                tm.createTask(1 ether, bytes("reject_task"), bytes32(0), pid, address(0), 0, false, 0, 0);
                 id = 0;
 
                 vm.prank(member1);
@@ -3663,7 +3663,7 @@ contract MockToken is Test, IERC20 {
                 tm.setConfig(TaskManager.ConfigKey.PROJECT_MANAGER, abi.encode(pid, pm1, true));
 
                 vm.prank(pm1);
-                tm.createTask(1 ether, bytes("unclaimed"), bytes32(0), pid, address(0), 0, false);
+                tm.createTask(1 ether, bytes("unclaimed"), bytes32(0), pid, address(0), 0, false, 0, 0);
 
                 vm.prank(pm1);
                 vm.expectRevert(TaskManager.BadStatus.selector);
@@ -3676,7 +3676,7 @@ contract MockToken is Test, IERC20 {
                 tm.setConfig(TaskManager.ConfigKey.PROJECT_MANAGER, abi.encode(pid, pm1, true));
 
                 vm.prank(pm1);
-                tm.createTask(1 ether, bytes("claimed_only"), bytes32(0), pid, address(0), 0, false);
+                tm.createTask(1 ether, bytes("claimed_only"), bytes32(0), pid, address(0), 0, false, 0, 0);
 
                 vm.prank(member1);
                 tm.claimTask(0);
@@ -3703,7 +3703,7 @@ contract MockToken is Test, IERC20 {
                 tm.setConfig(TaskManager.ConfigKey.PROJECT_MANAGER, abi.encode(pid, pm1, true));
 
                 vm.prank(pm1);
-                tm.createTask(1 ether, bytes("to_cancel"), bytes32(0), pid, address(0), 0, false);
+                tm.createTask(1 ether, bytes("to_cancel"), bytes32(0), pid, address(0), 0, false, 0, 0);
 
                 vm.prank(pm1);
                 tm.cancelTask(0);
@@ -3765,7 +3765,7 @@ contract MockToken is Test, IERC20 {
 
                 // member1 can create tasks (global perm, no project override)
                 vm.prank(member1);
-                tm.createTask(1, bytes("before-remove"), bytes32(0), pid, address(0), 0, false);
+                tm.createTask(1, bytes("before-remove"), bytes32(0), pid, address(0), 0, false, 0, 0);
 
                 // Give MEMBER_HAT project-specific CREATE, then remove it
                 vm.prank(creator1);
@@ -3775,7 +3775,7 @@ contract MockToken is Test, IERC20 {
 
                 // member1 should STILL be able to create tasks via global perm
                 vm.prank(member1);
-                tm.createTask(1, bytes("after-remove"), bytes32(0), pid, address(0), 0, false);
+                tm.createTask(1, bytes("after-remove"), bytes32(0), pid, address(0), 0, false, 0, 0);
             }
 
             function test_RemovingGlobalPermKeepsProjectPermission() public {
@@ -3811,7 +3811,7 @@ contract MockToken is Test, IERC20 {
 
                 // member1 should STILL be able to create tasks via project-specific perm
                 vm.prank(member1);
-                tm.createTask(1, bytes("project-only-perm"), bytes32(0), pid, address(0), 0, false);
+                tm.createTask(1, bytes("project-only-perm"), bytes32(0), pid, address(0), 0, false, 0, 0);
             }
 
             function test_DeleteProjectCleansUpPermRefCounts() public {
@@ -3839,7 +3839,7 @@ contract MockToken is Test, IERC20 {
 
                 // member1 can create tasks via project perm
                 vm.prank(member1);
-                tm.createTask(1, bytes("before-delete"), bytes32(0), pid, address(0), 0, false);
+                tm.createTask(1, bytes("before-delete"), bytes32(0), pid, address(0), 0, false, 0, 0);
 
                 // Delete the project
                 vm.prank(creator1);
@@ -3866,7 +3866,7 @@ contract MockToken is Test, IERC20 {
                 // so the hat was removed from permissionHatIds
                 vm.prank(member1);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
-                tm.createTask(1, bytes("should-fail"), bytes32(0), pid2, address(0), 0, false);
+                tm.createTask(1, bytes("should-fail"), bytes32(0), pid2, address(0), 0, false, 0, 0);
             }
         }
 
@@ -3922,7 +3922,9 @@ contract MockToken is Test, IERC20 {
                     BOUNTY_PROJECT_ID,
                     address(bountyToken1),
                     0.5 ether,
-                    false
+                    false,
+                    0,
+                    0
                 );
 
                 // Verify task has bounty info
@@ -3947,7 +3949,9 @@ contract MockToken is Test, IERC20 {
             function test_CreateTaskWithoutBounty() public {
                 // Create task without bounty (backward compatibility)
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("no_bounty_task"), bytes32(0), NO_BOUNTY_PROJECT_ID, address(0), 0, false);
+                tm.createTask(
+                    1 ether, bytes("no_bounty_task"), bytes32(0), NO_BOUNTY_PROJECT_ID, address(0), 0, false, 0, 0
+                );
 
                 // Verify task has no bounty info
                 bytes memory result = lens.getStorage(
@@ -3977,7 +3981,9 @@ contract MockToken is Test, IERC20 {
                     BOUNTY_PROJECT_ID,
                     address(bountyToken1),
                     0.3 ether,
-                    true
+                    true,
+                    0,
+                    0
                 );
 
                 // Verify task has bounty info and requires application
@@ -4010,7 +4016,9 @@ contract MockToken is Test, IERC20 {
                     member1,
                     address(bountyToken1),
                     0.4 ether,
-                    false
+                    false,
+                    0,
+                    0
                 );
 
                 // Verify task is assigned and has bounty info
@@ -4042,7 +4050,9 @@ contract MockToken is Test, IERC20 {
                     BOUNTY_PROJECT_ID,
                     address(bountyToken1),
                     0.5 ether,
-                    false
+                    false,
+                    0,
+                    0
                 );
 
                 // Assign and complete task
@@ -4073,7 +4083,15 @@ contract MockToken is Test, IERC20 {
                 // Create task without bounty
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("complete_no_bounty_task"), bytes32(0), NO_BOUNTY_PROJECT_ID, address(0), 0, false
+                    1 ether,
+                    bytes("complete_no_bounty_task"),
+                    bytes32(0),
+                    NO_BOUNTY_PROJECT_ID,
+                    address(0),
+                    0,
+                    false,
+                    0,
+                    0
                 );
 
                 // Assign and complete task
@@ -4105,12 +4123,14 @@ contract MockToken is Test, IERC20 {
                     DUAL_BOUNTY_PROJECT_ID,
                     address(bountyToken1),
                     0.3 ether,
-                    false
+                    false,
+                    0,
+                    0
                 );
 
                 // Update bounty before claim (switch to bountyToken2)
                 vm.prank(creator1);
-                tm.updateTask(0, 1 ether, bytes("updated_metadata"), bytes32(0), address(bountyToken2), 0.6 ether);
+                tm.updateTask(0, 1 ether, bytes("updated_metadata"), bytes32(0), address(bountyToken2), 0.6 ether, 0, 0);
 
                 // Verify bounty was updated
                 bytes memory result = lens.getStorage(
@@ -4139,7 +4159,9 @@ contract MockToken is Test, IERC20 {
                     BOUNTY_PROJECT_ID,
                     address(bountyToken1),
                     0.3 ether,
-                    false
+                    false,
+                    0,
+                    0
                 );
 
                 // Assign task
@@ -4151,7 +4173,7 @@ contract MockToken is Test, IERC20 {
                 // dedicated positive-path tests.)
                 vm.prank(outsider);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
-                tm.updateTask(0, 1 ether, bytes("updated_metadata"), bytes32(0), address(bountyToken2), 0.6 ether);
+                tm.updateTask(0, 1 ether, bytes("updated_metadata"), bytes32(0), address(bountyToken2), 0.6 ether, 0, 0);
             }
 
             function test_UpdateTaskRemoveBounty() public {
@@ -4164,12 +4186,14 @@ contract MockToken is Test, IERC20 {
                     BOUNTY_PROJECT_ID,
                     address(bountyToken1),
                     0.3 ether,
-                    false
+                    false,
+                    0,
+                    0
                 );
 
                 // Remove bounty
                 vm.prank(creator1);
-                tm.updateTask(0, 1 ether, bytes("updated_metadata"), bytes32(0), address(0), 0);
+                tm.updateTask(0, 1 ether, bytes("updated_metadata"), bytes32(0), address(0), 0, 0, 0);
 
                 // Verify bounty was removed
                 bytes memory result = lens.getStorage(
@@ -4198,7 +4222,9 @@ contract MockToken is Test, IERC20 {
                     DUAL_BOUNTY_PROJECT_ID,
                     address(bountyToken1),
                     0.3 ether,
-                    false
+                    false,
+                    0,
+                    0
                 );
 
                 vm.prank(creator1);
@@ -4209,7 +4235,9 @@ contract MockToken is Test, IERC20 {
                     DUAL_BOUNTY_PROJECT_ID,
                     address(bountyToken2),
                     0.4 ether,
-                    false
+                    false,
+                    0,
+                    0
                 );
 
                 // Complete both tasks
@@ -4245,7 +4273,15 @@ contract MockToken is Test, IERC20 {
                 vm.prank(creator1);
                 vm.expectRevert(ValidationLib.InvalidPayout.selector);
                 tm.createTask(
-                    1 ether, bytes("invalid_bounty"), bytes32(0), BOUNTY_PROJECT_ID, address(bountyToken1), 0, false
+                    1 ether,
+                    bytes("invalid_bounty"),
+                    bytes32(0),
+                    BOUNTY_PROJECT_ID,
+                    address(bountyToken1),
+                    0,
+                    false,
+                    0,
+                    0
                 );
 
                 // Test excessive bounty payout
@@ -4258,14 +4294,24 @@ contract MockToken is Test, IERC20 {
                     BOUNTY_PROJECT_ID,
                     address(bountyToken1),
                     1e25,
-                    false
+                    false,
+                    0,
+                    0
                 ); // Over MAX_PAYOUT
 
                 // Test that zero bounty token with non-zero payout is not allowed
                 vm.prank(creator1);
                 vm.expectRevert(ValidationLib.ZeroAddress.selector);
                 tm.createTask(
-                    1 ether, bytes("invalid_zero_token"), bytes32(0), BOUNTY_PROJECT_ID, address(0), 0.5 ether, false
+                    1 ether,
+                    bytes("invalid_zero_token"),
+                    bytes32(0),
+                    BOUNTY_PROJECT_ID,
+                    address(0),
+                    0.5 ether,
+                    false,
+                    0,
+                    0
                 );
             }
 
@@ -4279,7 +4325,9 @@ contract MockToken is Test, IERC20 {
                     BOUNTY_PROJECT_ID,
                     address(bountyToken1),
                     0.3 ether,
-                    true
+                    true,
+                    0,
+                    0
                 );
 
                 // Apply for task
@@ -4321,7 +4369,9 @@ contract MockToken is Test, IERC20 {
                     BOUNTY_PROJECT_ID,
                     address(bountyToken1),
                     0.3 ether,
-                    false
+                    false,
+                    0,
+                    0
                 );
 
                 // Cancel task
@@ -4350,7 +4400,15 @@ contract MockToken is Test, IERC20 {
                 // Create task with bounty
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("full_task"), bytes32(0), BOUNTY_PROJECT_ID, address(bountyToken1), 0.3 ether, false
+                    1 ether,
+                    bytes("full_task"),
+                    bytes32(0),
+                    BOUNTY_PROJECT_ID,
+                    address(bountyToken1),
+                    0.3 ether,
+                    false,
+                    0,
+                    0
                 );
 
                 // Test getTaskFull function
@@ -4415,7 +4473,9 @@ contract MockToken is Test, IERC20 {
                     BOUNTY_PROJECT_ID,
                     address(bountyToken1),
                     0.3 ether,
-                    false
+                    false,
+                    0,
+                    0
                 );
 
                 // Complete task and verify events
@@ -4435,12 +4495,28 @@ contract MockToken is Test, IERC20 {
                 // Create multiple tasks with different bounty tokens (use dual project)
                 vm.startPrank(creator1);
                 tm.createTask(
-                    1 ether, bytes("task1"), bytes32(0), DUAL_BOUNTY_PROJECT_ID, address(bountyToken1), 0.2 ether, false
+                    1 ether,
+                    bytes("task1"),
+                    bytes32(0),
+                    DUAL_BOUNTY_PROJECT_ID,
+                    address(bountyToken1),
+                    0.2 ether,
+                    false,
+                    0,
+                    0
                 );
                 tm.createTask(
-                    1 ether, bytes("task2"), bytes32(0), DUAL_BOUNTY_PROJECT_ID, address(bountyToken2), 0.3 ether, false
+                    1 ether,
+                    bytes("task2"),
+                    bytes32(0),
+                    DUAL_BOUNTY_PROJECT_ID,
+                    address(bountyToken2),
+                    0.3 ether,
+                    false,
+                    0,
+                    0
                 );
-                tm.createTask(1 ether, bytes("task3"), bytes32(0), DUAL_BOUNTY_PROJECT_ID, address(0), 0, false); // No bounty
+                tm.createTask(1 ether, bytes("task3"), bytes32(0), DUAL_BOUNTY_PROJECT_ID, address(0), 0, false, 0, 0); // No bounty
                 vm.stopPrank();
 
                 // Complete all tasks
@@ -4497,7 +4573,9 @@ contract MockToken is Test, IERC20 {
                     BOUNTY_PROJECT_ID,
                     address(failingToken),
                     0.3 ether,
-                    false
+                    false,
+                    0,
+                    0
                 );
 
                 // Assign and submit task
@@ -4722,7 +4800,7 @@ contract MockToken is Test, IERC20 {
 
                 // Consume 2 ether of PT on BUDGET_PROJECT_ID (cap = 10 ether).
                 vm.prank(creator1);
-                tm.createTask(2 ether, bytes("burn"), bytes32(0), BUDGET_PROJECT_ID, address(0), 0, false);
+                tm.createTask(2 ether, bytes("burn"), bytes32(0), BUDGET_PROJECT_ID, address(0), 0, false, 0, 0);
 
                 // Hat-holder cannot lower cap below committed spend.
                 vm.prank(budgetEditor);
@@ -4830,7 +4908,15 @@ contract MockToken is Test, IERC20 {
                 // Create task within budget
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 1.5 ether, false
+                    1 ether,
+                    bytes("task1"),
+                    bytes32(0),
+                    BUDGET_PROJECT_ID,
+                    address(bountyToken1),
+                    1.5 ether,
+                    false,
+                    0,
+                    0
                 );
 
                 // Verify budget tracking
@@ -4846,7 +4932,15 @@ contract MockToken is Test, IERC20 {
                 // Create another task within budget
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("task2"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 1.5 ether, false
+                    1 ether,
+                    bytes("task2"),
+                    bytes32(0),
+                    BUDGET_PROJECT_ID,
+                    address(bountyToken1),
+                    1.5 ether,
+                    false,
+                    0,
+                    0
                 );
 
                 // Verify budget tracking
@@ -4862,7 +4956,15 @@ contract MockToken is Test, IERC20 {
                 vm.prank(creator1);
                 vm.expectRevert(BudgetLib.BudgetExceeded.selector);
                 tm.createTask(
-                    1 ether, bytes("task3"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 0.1 ether, false
+                    1 ether,
+                    bytes("task3"),
+                    bytes32(0),
+                    BUDGET_PROJECT_ID,
+                    address(bountyToken1),
+                    0.1 ether,
+                    false,
+                    0,
+                    0
                 );
             }
 
@@ -4871,7 +4973,15 @@ contract MockToken is Test, IERC20 {
                 vm.prank(creator1);
                 vm.expectRevert(BudgetLib.BudgetExceeded.selector);
                 tm.createTask(
-                    1 ether, bytes("task1"), bytes32(0), DISABLED_PROJECT_ID, address(bountyToken1), 5 ether, false
+                    1 ether,
+                    bytes("task1"),
+                    bytes32(0),
+                    DISABLED_PROJECT_ID,
+                    address(bountyToken1),
+                    5 ether,
+                    false,
+                    0,
+                    0
                 );
             }
 
@@ -4879,7 +4989,7 @@ contract MockToken is Test, IERC20 {
                 // BUDGET_PROJECT_ID has unlimited bountyToken1 budget (cap = type(uint128).max)
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 5 ether, false
+                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 5 ether, false, 0, 0
                 );
 
                 // Verify budget tracking
@@ -4895,7 +5005,7 @@ contract MockToken is Test, IERC20 {
                 // Create another large task (should work since budget is unlimited)
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("task2"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 10 ether, false
+                    1 ether, bytes("task2"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 10 ether, false, 0, 0
                 );
 
                 result = lens.getStorage(
@@ -4921,13 +5031,37 @@ contract MockToken is Test, IERC20 {
                 // Create tasks with different tokens
                 vm.startPrank(creator1);
                 tm.createTask(
-                    1 ether, bytes("task1"), bytes32(0), MULTI_TOKEN_PROJECT_ID, address(bountyToken1), 1 ether, false
+                    1 ether,
+                    bytes("task1"),
+                    bytes32(0),
+                    MULTI_TOKEN_PROJECT_ID,
+                    address(bountyToken1),
+                    1 ether,
+                    false,
+                    0,
+                    0
                 );
                 tm.createTask(
-                    1 ether, bytes("task2"), bytes32(0), MULTI_TOKEN_PROJECT_ID, address(bountyToken2), 2 ether, false
+                    1 ether,
+                    bytes("task2"),
+                    bytes32(0),
+                    MULTI_TOKEN_PROJECT_ID,
+                    address(bountyToken2),
+                    2 ether,
+                    false,
+                    0,
+                    0
                 );
                 tm.createTask(
-                    1 ether, bytes("task3"), bytes32(0), MULTI_TOKEN_PROJECT_ID, address(bountyToken1), 1 ether, false
+                    1 ether,
+                    bytes("task3"),
+                    bytes32(0),
+                    MULTI_TOKEN_PROJECT_ID,
+                    address(bountyToken1),
+                    1 ether,
+                    false,
+                    0,
+                    0
                 );
                 vm.stopPrank();
 
@@ -4954,13 +5088,29 @@ contract MockToken is Test, IERC20 {
                 vm.prank(creator1);
                 vm.expectRevert(BudgetLib.BudgetExceeded.selector);
                 tm.createTask(
-                    1 ether, bytes("task4"), bytes32(0), MULTI_TOKEN_PROJECT_ID, address(bountyToken1), 0.1 ether, false
+                    1 ether,
+                    bytes("task4"),
+                    bytes32(0),
+                    MULTI_TOKEN_PROJECT_ID,
+                    address(bountyToken1),
+                    0.1 ether,
+                    false,
+                    0,
+                    0
                 );
 
                 // But token2 should still work
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("task5"), bytes32(0), MULTI_TOKEN_PROJECT_ID, address(bountyToken2), 1 ether, false
+                    1 ether,
+                    bytes("task5"),
+                    bytes32(0),
+                    MULTI_TOKEN_PROJECT_ID,
+                    address(bountyToken2),
+                    1 ether,
+                    false,
+                    0,
+                    0
                 );
 
                 result = lens.getStorage(
@@ -4982,7 +5132,7 @@ contract MockToken is Test, IERC20 {
                 // Create task
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 2 ether, false
+                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 2 ether, false, 0, 0
                 );
 
                 // Verify initial budget
@@ -4996,7 +5146,7 @@ contract MockToken is Test, IERC20 {
 
                 // Update task to higher bounty (within budget)
                 vm.prank(creator1);
-                tm.updateTask(0, 1 ether, bytes("updated"), bytes32(0), address(bountyToken1), 3 ether);
+                tm.updateTask(0, 1 ether, bytes("updated"), bytes32(0), address(bountyToken1), 3 ether, 0, 0);
 
                 // Verify budget updated
                 result = lens.getStorage(
@@ -5010,7 +5160,7 @@ contract MockToken is Test, IERC20 {
                 // Try to update to exceed budget
                 vm.prank(creator1);
                 vm.expectRevert(BudgetLib.BudgetExceeded.selector);
-                tm.updateTask(0, 1 ether, bytes("updated2"), bytes32(0), address(bountyToken1), 5.1 ether);
+                tm.updateTask(0, 1 ether, bytes("updated2"), bytes32(0), address(bountyToken1), 5.1 ether, 0, 0);
             }
 
             function test_UpdateTaskChangeBountyToken() public {
@@ -5027,7 +5177,7 @@ contract MockToken is Test, IERC20 {
                 // Create task with token1
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 2 ether, false
+                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 2 ether, false, 0, 0
                 );
 
                 // Verify initial budgets
@@ -5048,7 +5198,7 @@ contract MockToken is Test, IERC20 {
 
                 // Update task to use token2
                 vm.prank(creator1);
-                tm.updateTask(0, 1 ether, bytes("updated"), bytes32(0), address(bountyToken2), 3 ether);
+                tm.updateTask(0, 1 ether, bytes("updated"), bytes32(0), address(bountyToken2), 3 ether, 0, 0);
 
                 // Verify budgets updated correctly
                 result = lens.getStorage(
@@ -5077,7 +5227,7 @@ contract MockToken is Test, IERC20 {
                 // Create task with bounty
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 3 ether, false
+                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 3 ether, false, 0, 0
                 );
 
                 // Verify budget
@@ -5091,7 +5241,7 @@ contract MockToken is Test, IERC20 {
 
                 // Remove bounty from task
                 vm.prank(creator1);
-                tm.updateTask(0, 1 ether, bytes("updated"), bytes32(0), address(0), 0);
+                tm.updateTask(0, 1 ether, bytes("updated"), bytes32(0), address(0), 0, 0, 0);
 
                 // Verify budget rolled back
                 result = lens.getStorage(
@@ -5113,7 +5263,7 @@ contract MockToken is Test, IERC20 {
                 // Create task
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 2 ether, false
+                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 2 ether, false, 0, 0
                 );
 
                 // Verify budget
@@ -5156,7 +5306,9 @@ contract MockToken is Test, IERC20 {
                     member1,
                     address(bountyToken1),
                     3 ether,
-                    false
+                    false,
+                    0,
+                    0
                 );
 
                 // Verify budget tracking
@@ -5179,7 +5331,9 @@ contract MockToken is Test, IERC20 {
                     member1,
                     address(bountyToken1),
                     2.1 ether,
-                    false
+                    false,
+                    0,
+                    0
                 );
             }
 
@@ -5193,7 +5347,15 @@ contract MockToken is Test, IERC20 {
                 // Create application task
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("app_task"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 4 ether, true
+                    1 ether,
+                    bytes("app_task"),
+                    bytes32(0),
+                    BUDGET_PROJECT_ID,
+                    address(bountyToken1),
+                    4 ether,
+                    true,
+                    0,
+                    0
                 );
 
                 // Verify budget tracking
@@ -5209,7 +5371,15 @@ contract MockToken is Test, IERC20 {
                 vm.prank(creator1);
                 vm.expectRevert(BudgetLib.BudgetExceeded.selector);
                 tm.createTask(
-                    1 ether, bytes("app_task2"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 1.1 ether, true
+                    1 ether,
+                    bytes("app_task2"),
+                    bytes32(0),
+                    BUDGET_PROJECT_ID,
+                    address(bountyToken1),
+                    1.1 ether,
+                    true,
+                    0,
+                    0
                 );
             }
 
@@ -5217,7 +5387,7 @@ contract MockToken is Test, IERC20 {
                 // Create task first
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 3 ether, false
+                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 3 ether, false, 0, 0
                 );
 
                 // Verify spent
@@ -5294,7 +5464,15 @@ contract MockToken is Test, IERC20 {
                 // Create task that uses both budgets
                 vm.prank(creator1);
                 tm.createTask(
-                    1.5 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 2 ether, false
+                    1.5 ether,
+                    bytes("task1"),
+                    bytes32(0),
+                    BUDGET_PROJECT_ID,
+                    address(bountyToken1),
+                    2 ether,
+                    false,
+                    0,
+                    0
                 );
 
                 // Verify both budgets are tracked independently
@@ -5316,14 +5494,30 @@ contract MockToken is Test, IERC20 {
                 vm.prank(creator1);
                 vm.expectRevert(BudgetLib.BudgetExceeded.selector);
                 tm.createTask(
-                    0.6 ether, bytes("task2"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 0.5 ether, false
+                    0.6 ether,
+                    bytes("task2"),
+                    bytes32(0),
+                    BUDGET_PROJECT_ID,
+                    address(bountyToken1),
+                    0.5 ether,
+                    false,
+                    0,
+                    0
                 );
 
                 // Create task that only exceeds bounty budget
                 vm.prank(creator1);
                 vm.expectRevert(BudgetLib.BudgetExceeded.selector);
                 tm.createTask(
-                    0.5 ether, bytes("task3"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 1.1 ether, false
+                    0.5 ether,
+                    bytes("task3"),
+                    bytes32(0),
+                    BUDGET_PROJECT_ID,
+                    address(bountyToken1),
+                    1.1 ether,
+                    false,
+                    0,
+                    0
                 );
             }
 
@@ -5337,7 +5531,7 @@ contract MockToken is Test, IERC20 {
                 // Create and complete task
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 3 ether, false
+                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 3 ether, false, 0, 0
                 );
 
                 vm.prank(creator1);
@@ -5386,7 +5580,7 @@ contract MockToken is Test, IERC20 {
                 // Create and claim task
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 2 ether, false
+                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 2 ether, false, 0, 0
                 );
 
                 vm.prank(creator1);
@@ -5395,7 +5589,7 @@ contract MockToken is Test, IERC20 {
                 // outsider has no EDIT_FULL grant and is not a PM — post-claim updates revert Unauthorized.
                 vm.prank(outsider);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
-                tm.updateTask(0, 1 ether, bytes("updated"), bytes32(0), address(bountyToken2), 3 ether);
+                tm.updateTask(0, 1 ether, bytes("updated"), bytes32(0), address(bountyToken2), 3 ether, 0, 0);
             }
 
             function test_ZeroBountyCapMeansDisabled() public {
@@ -5403,12 +5597,20 @@ contract MockToken is Test, IERC20 {
                 vm.prank(creator1);
                 vm.expectRevert(BudgetLib.BudgetExceeded.selector);
                 tm.createTask(
-                    1 ether, bytes("task1"), bytes32(0), DISABLED_PROJECT_ID, address(bountyToken1), 1 ether, false
+                    1 ether,
+                    bytes("task1"),
+                    bytes32(0),
+                    DISABLED_PROJECT_ID,
+                    address(bountyToken1),
+                    1 ether,
+                    false,
+                    0,
+                    0
                 );
 
                 // Non-bounty tasks still work on disabled project
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("task2"), bytes32(0), DISABLED_PROJECT_ID, address(0), 0, false);
+                tm.createTask(1 ether, bytes("task2"), bytes32(0), DISABLED_PROJECT_ID, address(0), 0, false, 0, 0);
             }
 
             function test_GetBountyBudgetUnusedToken() public {
@@ -5463,7 +5665,9 @@ contract MockToken is Test, IERC20 {
                         MULTI_TOKEN_PROJECT_ID,
                         token,
                         bountyAmount,
-                        false
+                        false,
+                        0,
+                        0
                     );
                 }
 
@@ -5501,7 +5705,9 @@ contract MockToken is Test, IERC20 {
                     MULTI_TOKEN_PROJECT_ID,
                     address(bountyToken1),
                     7.6 ether,
-                    false
+                    false,
+                    0,
+                    0
                 );
 
                 vm.prank(creator1);
@@ -5513,7 +5719,9 @@ contract MockToken is Test, IERC20 {
                     MULTI_TOKEN_PROJECT_ID,
                     address(bountyToken2),
                     11.1 ether,
-                    false
+                    false,
+                    0,
+                    0
                 );
 
                 vm.prank(creator1);
@@ -5525,7 +5733,9 @@ contract MockToken is Test, IERC20 {
                     MULTI_TOKEN_PROJECT_ID,
                     address(bountyToken3),
                     14.1 ether,
-                    false
+                    false,
+                    0,
+                    0
                 );
             }
 
@@ -5533,7 +5743,7 @@ contract MockToken is Test, IERC20 {
                 // Create task with bounty
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 2 ether, false
+                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 2 ether, false, 0, 0
                 );
 
                 // Artificially corrupt the bounty budget to simulate underflow scenario
@@ -5545,7 +5755,7 @@ contract MockToken is Test, IERC20 {
                 // Create another task to test the protection
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("task2"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 1 ether, false
+                    1 ether, bytes("task2"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 1 ether, false, 0, 0
                 );
 
                 // Verify budget is correct
@@ -5573,7 +5783,7 @@ contract MockToken is Test, IERC20 {
                 // Create task with bounty
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 2 ether, false
+                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 2 ether, false, 0, 0
                 );
 
                 // Verify budget
@@ -5587,7 +5797,7 @@ contract MockToken is Test, IERC20 {
 
                 // Normal update should work (rolling back and applying new bounty)
                 vm.prank(creator1);
-                tm.updateTask(0, 1 ether, bytes("updated"), bytes32(0), address(bountyToken1), 1.5 ether);
+                tm.updateTask(0, 1 ether, bytes("updated"), bytes32(0), address(bountyToken1), 1.5 ether, 0, 0);
                 result = lens.getStorage(
                     address(tm),
                     TaskManagerLens.StorageKey.BOUNTY_BUDGET,
@@ -5602,14 +5812,14 @@ contract MockToken is Test, IERC20 {
 
                 vm.prank(outsider);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
-                tm.updateTask(0, 1 ether, bytes("updated2"), bytes32(0), address(bountyToken1), 1 ether);
+                tm.updateTask(0, 1 ether, bytes("updated2"), bytes32(0), address(bountyToken1), 1 ether, 0, 0);
             }
 
             function test_BountyBudgetUnderflowProtectionEdgeCase() public {
                 // Test edge case where bounty payout equals spent
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 3 ether, false
+                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 3 ether, false, 0, 0
                 );
 
                 bytes memory result = lens.getStorage(
@@ -5647,12 +5857,12 @@ contract MockToken is Test, IERC20 {
                 // Create task with token1
                 vm.prank(creator1);
                 tm.createTask(
-                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 2 ether, false
+                    1 ether, bytes("task1"), bytes32(0), BUDGET_PROJECT_ID, address(bountyToken1), 2 ether, false, 0, 0
                 );
 
                 // Update to token2 (should roll back token1 and apply token2)
                 vm.prank(creator1);
-                tm.updateTask(0, 1 ether, bytes("updated"), bytes32(0), address(bountyToken2), 3 ether);
+                tm.updateTask(0, 1 ether, bytes("updated"), bytes32(0), address(bountyToken2), 3 ether, 0, 0);
 
                 // Verify budgets
                 bytes memory result = lens.getStorage(
@@ -5705,13 +5915,13 @@ contract MockToken is Test, IERC20 {
             /// @dev Helper: creates an application-required task and returns its ID
             function _createAppTask(uint256 payout) internal returns (uint256 id) {
                 vm.prank(creator1);
-                tm.createTask(payout, bytes("app_task"), bytes32(0), APP_PROJECT_ID, address(0), 0, true);
+                tm.createTask(payout, bytes("app_task"), bytes32(0), APP_PROJECT_ID, address(0), 0, true, 0, 0);
                 id = 0; // first task
             }
 
             function _createAppTaskN(uint256 payout, uint256 expectedId) internal returns (uint256 id) {
                 vm.prank(creator1);
-                tm.createTask(payout, bytes("app_task"), bytes32(0), APP_PROJECT_ID, address(0), 0, true);
+                tm.createTask(payout, bytes("app_task"), bytes32(0), APP_PROJECT_ID, address(0), 0, true, 0, 0);
                 id = expectedId;
             }
 
@@ -5965,7 +6175,7 @@ contract MockToken is Test, IERC20 {
             function test_ApplyForNonApplicationTaskReverts() public {
                 // Create a regular (non-application) task
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("regular_task"), bytes32(0), APP_PROJECT_ID, address(0), 0, false);
+                tm.createTask(1 ether, bytes("regular_task"), bytes32(0), APP_PROJECT_ID, address(0), 0, false, 0, 0);
                 uint256 id = 0;
 
                 vm.prank(member1);
@@ -6584,7 +6794,7 @@ contract MockToken is Test, IERC20 {
 
             function test_SelfReviewBlockedWithoutPermission() public {
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("task"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("task"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 vm.prank(reviewer);
                 tm.claimTask(0);
@@ -6606,7 +6816,7 @@ contract MockToken is Test, IERC20 {
                 );
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("task"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("task"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 vm.prank(reviewer);
                 tm.claimTask(0);
@@ -6625,7 +6835,7 @@ contract MockToken is Test, IERC20 {
                 tm.setConfig(TaskManager.ConfigKey.PROJECT_MANAGER, abi.encode(projectId, pm1, true));
 
                 vm.prank(pm1);
-                tm.createTask(1 ether, bytes("pm_task"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("pm_task"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 // PM bypasses _checkPerm, so can claim even without CLAIM flag
                 vm.prank(pm1);
@@ -6643,7 +6853,7 @@ contract MockToken is Test, IERC20 {
 
             function test_DifferentReviewerCanAlwaysComplete() public {
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("task"), bytes32(0), projectId, address(0), 0, false);
+                tm.createTask(1 ether, bytes("task"), bytes32(0), projectId, address(0), 0, false, 0, 0);
 
                 // reviewer claims and submits
                 vm.prank(reviewer);
@@ -6780,7 +6990,7 @@ contract MockToken is Test, IERC20 {
                 // Trying to create a bounty task should revert
                 vm.prank(creator1);
                 vm.expectRevert(BudgetLib.BudgetExceeded.selector);
-                tm.createTask(1 ether, bytes("task"), bytes32(0), pid, address(bountyToken), 1 ether, false);
+                tm.createTask(1 ether, bytes("task"), bytes32(0), pid, address(bountyToken), 1 ether, false, 0, 0);
             }
 
             function test_DefaultCapZeroAllowsNonBountyTasks() public {
@@ -6789,7 +6999,7 @@ contract MockToken is Test, IERC20 {
 
                 // Non-bounty tasks should work fine
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("task"), bytes32(0), pid, address(0), 0, false);
+                tm.createTask(1 ether, bytes("task"), bytes32(0), pid, address(0), 0, false, 0, 0);
             }
 
             function test_DisableBountyBudgetViaSetConfig() public {
@@ -6803,7 +7013,7 @@ contract MockToken is Test, IERC20 {
 
                 // Create a task (should work)
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("task1"), bytes32(0), pid, address(bountyToken), 2 ether, false);
+                tm.createTask(1 ether, bytes("task1"), bytes32(0), pid, address(bountyToken), 2 ether, false, 0, 0);
 
                 // Disable the budget by setting cap to 0
                 vm.prank(executor);
@@ -6812,7 +7022,7 @@ contract MockToken is Test, IERC20 {
                 // New bounty tasks should now be blocked
                 vm.prank(creator1);
                 vm.expectRevert(BudgetLib.BudgetExceeded.selector);
-                tm.createTask(1 ether, bytes("task2"), bytes32(0), pid, address(bountyToken), 1 ether, false);
+                tm.createTask(1 ether, bytes("task2"), bytes32(0), pid, address(bountyToken), 1 ether, false, 0, 0);
             }
 
             function test_EnableBountyBudgetViaSetConfig() public {
@@ -6822,7 +7032,7 @@ contract MockToken is Test, IERC20 {
                 // Can't create bounty task yet
                 vm.prank(creator1);
                 vm.expectRevert(BudgetLib.BudgetExceeded.selector);
-                tm.createTask(1 ether, bytes("task1"), bytes32(0), pid, address(bountyToken), 1 ether, false);
+                tm.createTask(1 ether, bytes("task1"), bytes32(0), pid, address(bountyToken), 1 ether, false, 0, 0);
 
                 // Enable budget via setConfig
                 vm.prank(executor);
@@ -6830,7 +7040,7 @@ contract MockToken is Test, IERC20 {
 
                 // Now it should work
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("task1"), bytes32(0), pid, address(bountyToken), 2 ether, false);
+                tm.createTask(1 ether, bytes("task1"), bytes32(0), pid, address(bountyToken), 2 ether, false, 0, 0);
             }
 
             // -- unlimited sentinel --
@@ -6843,10 +7053,10 @@ contract MockToken is Test, IERC20 {
 
                 // Can create arbitrarily large bounty tasks
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("task1"), bytes32(0), pid, address(bountyToken), 100 ether, false);
+                tm.createTask(1 ether, bytes("task1"), bytes32(0), pid, address(bountyToken), 100 ether, false, 0, 0);
 
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("task2"), bytes32(0), pid, address(bountyToken), 500 ether, false);
+                tm.createTask(1 ether, bytes("task2"), bytes32(0), pid, address(bountyToken), 500 ether, false, 0, 0);
 
                 bytes memory result = tm.getLensData(9, abi.encode(pid, address(bountyToken)));
                 (uint256 cap, uint256 spent) = abi.decode(result, (uint256, uint256));
@@ -6862,7 +7072,7 @@ contract MockToken is Test, IERC20 {
                 vm.prank(creator1);
                 vm.expectRevert(BudgetLib.BudgetExceeded.selector);
                 tm.createAndAssignTask(
-                    1 ether, bytes("task"), bytes32(0), pid, member1, address(bountyToken), 1 ether, false
+                    1 ether, bytes("task"), bytes32(0), pid, member1, address(bountyToken), 1 ether, false, 0, 0
                 );
             }
 
@@ -6876,7 +7086,7 @@ contract MockToken is Test, IERC20 {
 
                 vm.prank(creator1);
                 tm.createAndAssignTask(
-                    1 ether, bytes("task"), bytes32(0), pid, member1, address(bountyToken), 3 ether, false
+                    1 ether, bytes("task"), bytes32(0), pid, member1, address(bountyToken), 3 ether, false, 0, 0
                 );
 
                 bytes memory result = tm.getLensData(9, abi.encode(pid, address(bountyToken)));
@@ -6958,7 +7168,9 @@ contract MockToken is Test, IERC20 {
                     metadataHash: bytes32(0),
                     bountyToken: address(0),
                     bountyPayout: 0,
-                    requiresApplication: false
+                    requiresApplication: false,
+                    absoluteDeadline: 0,
+                    completionWindow: 0
                 });
             }
 
@@ -7007,7 +7219,7 @@ contract MockToken is Test, IERC20 {
                 // Bind expected ids to a prior task so any reordering bug surfaces
                 // (without the seed, ids and loop indices coincidentally match starting at 0).
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("seed"), bytes32(0), PID, address(0), 0, false);
+                tm.createTask(1 ether, bytes("seed"), bytes32(0), PID, address(0), 0, false, 0, 0);
 
                 TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](3);
                 inputs[0] = _mkInput(1 ether, bytes("title-a"));
@@ -7037,7 +7249,9 @@ contract MockToken is Test, IERC20 {
                     metadataHash: bytes32(0),
                     bountyToken: address(0),
                     bountyPayout: 0,
-                    requiresApplication: true
+                    requiresApplication: true,
+                    absoluteDeadline: 0,
+                    completionWindow: 0
                 });
                 inputs[1] = _mkInput(1 ether, bytes("claimable"));
                 inputs[2] = TaskManager.CreateTaskInput({
@@ -7046,7 +7260,9 @@ contract MockToken is Test, IERC20 {
                     metadataHash: bytes32(0),
                     bountyToken: address(0),
                     bountyPayout: 0,
-                    requiresApplication: true
+                    requiresApplication: true,
+                    absoluteDeadline: 0,
+                    completionWindow: 0
                 });
 
                 vm.prank(creator1);
@@ -7078,7 +7294,9 @@ contract MockToken is Test, IERC20 {
                     metadataHash: bytes32(0),
                     bountyToken: address(bountyToken),
                     bountyPayout: 1 ether,
-                    requiresApplication: false
+                    requiresApplication: false,
+                    absoluteDeadline: 0,
+                    completionWindow: 0
                 });
                 inputs[1] = TaskManager.CreateTaskInput({
                     payout: 1 ether,
@@ -7086,7 +7304,9 @@ contract MockToken is Test, IERC20 {
                     metadataHash: bytes32(0),
                     bountyToken: address(bountyToken),
                     bountyPayout: 2 ether,
-                    requiresApplication: false
+                    requiresApplication: false,
+                    absoluteDeadline: 0,
+                    completionWindow: 0
                 });
 
                 vm.prank(creator1);
@@ -7104,7 +7324,9 @@ contract MockToken is Test, IERC20 {
                     metadataHash: bytes32(0),
                     bountyToken: address(bountyToken),
                     bountyPayout: 2 ether,
-                    requiresApplication: false
+                    requiresApplication: false,
+                    absoluteDeadline: 0,
+                    completionWindow: 0
                 });
                 inputs[1] = _mkInput(1 ether, bytes("plain"));
                 inputs[2] = TaskManager.CreateTaskInput({
@@ -7113,7 +7335,9 @@ contract MockToken is Test, IERC20 {
                     metadataHash: bytes32(0),
                     bountyToken: address(bountyToken),
                     bountyPayout: 1 ether,
-                    requiresApplication: false
+                    requiresApplication: false,
+                    absoluteDeadline: 0,
+                    completionWindow: 0
                 });
 
                 vm.prank(creator1);
@@ -7124,7 +7348,7 @@ contract MockToken is Test, IERC20 {
 
             function test_CreateTasksBatch_IdsContinueAfterPriorCreate() public {
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("first"), bytes32(0), PID, address(0), 0, false);
+                tm.createTask(1 ether, bytes("first"), bytes32(0), PID, address(0), 0, false, 0, 0);
 
                 TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](3);
                 inputs[0] = _mkInput(1 ether, bytes("a"));
@@ -7255,7 +7479,9 @@ contract MockToken is Test, IERC20 {
                     metadataHash: bytes32(0),
                     bountyToken: address(bountyToken),
                     bountyPayout: 4 ether,
-                    requiresApplication: false
+                    requiresApplication: false,
+                    absoluteDeadline: 0,
+                    completionWindow: 0
                 });
                 inputs[1] = TaskManager.CreateTaskInput({
                     payout: 1 ether,
@@ -7263,7 +7489,9 @@ contract MockToken is Test, IERC20 {
                     metadataHash: bytes32(0),
                     bountyToken: address(bountyToken),
                     bountyPayout: 2 ether,
-                    requiresApplication: false
+                    requiresApplication: false,
+                    absoluteDeadline: 0,
+                    completionWindow: 0
                 });
 
                 vm.prank(creator1);
@@ -7282,7 +7510,9 @@ contract MockToken is Test, IERC20 {
                     metadataHash: bytes32(0),
                     bountyToken: address(0),
                     bountyPayout: 1 ether,
-                    requiresApplication: false
+                    requiresApplication: false,
+                    absoluteDeadline: 0,
+                    completionWindow: 0
                 });
 
                 vm.prank(creator1);
@@ -7298,7 +7528,9 @@ contract MockToken is Test, IERC20 {
                     metadataHash: bytes32(0),
                     bountyToken: address(bountyToken),
                     bountyPayout: 0,
-                    requiresApplication: false
+                    requiresApplication: false,
+                    absoluteDeadline: 0,
+                    completionWindow: 0
                 });
 
                 vm.prank(creator1);
@@ -7322,7 +7554,7 @@ contract MockToken is Test, IERC20 {
                 // nextTaskId atomicity: a fresh task after the failed batch must get id 0,
                 // proving the counter never advanced inside the reverted loop.
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("post-revert"), bytes32(0), PID, address(0), 0, false);
+                tm.createTask(1 ether, bytes("post-revert"), bytes32(0), PID, address(0), 0, false, 0, 0);
                 bytes memory result = lens.getStorage(address(tm), TaskManagerLens.StorageKey.TASK_INFO, abi.encode(0));
                 (,,, bytes32 projectId,) = abi.decode(result, (uint256, TaskManager.Status, address, bytes32, bool));
                 assertEq(projectId, PID, "id 0 must be the post-revert task: counter did not advance");
@@ -7591,7 +7823,7 @@ contract MockToken is Test, IERC20 {
             function _createAndClaim(uint256 payout) internal returns (uint256 id) {
                 id = _nextId++;
                 vm.prank(creator1);
-                tm.createTask(payout, bytes("orig"), bytes32(0), PID, address(0), 0, false);
+                tm.createTask(payout, bytes("orig"), bytes32(0), PID, address(0), 0, false, 0, 0);
                 vm.prank(member1);
                 tm.claimTask(id);
             }
@@ -7601,7 +7833,7 @@ contract MockToken is Test, IERC20 {
                 assertEq(_projectSpent(PID), 2 ether);
 
                 vm.prank(editorFull);
-                tm.updateTask(id, 5 ether, bytes("new-title"), bytes32(0), address(0), 0);
+                tm.updateTask(id, 5 ether, bytes("new-title"), bytes32(0), address(0), 0, 0, 0);
 
                 (uint256 payout,,, TaskManager.Status status,) = _taskFields(id);
                 assertEq(payout, 5 ether, "payout should be updated");
@@ -7629,7 +7861,7 @@ contract MockToken is Test, IERC20 {
                 // EDIT_META alone is insufficient for the full updateTask post-claim.
                 vm.prank(editorMeta);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
-                tm.updateTask(id, 5 ether, bytes("new"), bytes32(0), address(0), 0);
+                tm.updateTask(id, 5 ether, bytes("new"), bytes32(0), address(0), 0, 0, 0);
             }
 
             function test_EditFull_CanAlsoCallUpdateTaskMetadata() public {
@@ -7650,7 +7882,7 @@ contract MockToken is Test, IERC20 {
 
                 vm.prank(editorFull);
                 vm.expectRevert(TaskManager.BadStatus.selector);
-                tm.updateTask(id, 3 ether, bytes("x"), bytes32(0), address(0), 0);
+                tm.updateTask(id, 3 ether, bytes("x"), bytes32(0), address(0), 0, 0, 0);
 
                 vm.prank(editorFull);
                 vm.expectRevert(TaskManager.BadStatus.selector);
@@ -7660,13 +7892,13 @@ contract MockToken is Test, IERC20 {
             function test_EditFull_RevertsOnCancelledTask() public {
                 uint256 id = _nextId++;
                 vm.prank(creator1);
-                tm.createTask(2 ether, bytes("c"), bytes32(0), PID, address(0), 0, false);
+                tm.createTask(2 ether, bytes("c"), bytes32(0), PID, address(0), 0, false, 0, 0);
                 vm.prank(creator1);
                 tm.cancelTask(id);
 
                 vm.prank(editorFull);
                 vm.expectRevert(TaskManager.BadStatus.selector);
-                tm.updateTask(id, 3 ether, bytes("x"), bytes32(0), address(0), 0);
+                tm.updateTask(id, 3 ether, bytes("x"), bytes32(0), address(0), 0, 0, 0);
             }
 
             function test_Pm_ImplicitEditFullPostClaim() public {
@@ -7674,7 +7906,7 @@ contract MockToken is Test, IERC20 {
 
                 // creator1 is the project manager (auto-added on createProject). No EDIT_FULL grant.
                 vm.prank(creator1);
-                tm.updateTask(id, 7 ether, bytes("pm-edit"), bytes32(0), address(0), 0);
+                tm.updateTask(id, 7 ether, bytes("pm-edit"), bytes32(0), address(0), 0, 0, 0);
 
                 (uint256 payout,,,,) = _taskFields(id);
                 assertEq(payout, 7 ether);
@@ -7685,7 +7917,7 @@ contract MockToken is Test, IERC20 {
                 uint256 id = _createAndClaim(2 ether);
 
                 vm.prank(executor);
-                tm.updateTask(id, 9 ether, bytes("exec-edit"), bytes32(0), address(0), 0);
+                tm.updateTask(id, 9 ether, bytes("exec-edit"), bytes32(0), address(0), 0, 0, 0);
 
                 (uint256 payout,,,,) = _taskFields(id);
                 assertEq(payout, 9 ether);
@@ -7697,7 +7929,7 @@ contract MockToken is Test, IERC20 {
                 tm.submitTask(id, keccak256("done"));
 
                 vm.prank(editorFull);
-                tm.updateTask(id, 3 ether, bytes("late-bump"), bytes32(0), address(0), 0);
+                tm.updateTask(id, 3 ether, bytes("late-bump"), bytes32(0), address(0), 0, 0, 0);
 
                 (uint256 payout,,, TaskManager.Status status,) = _taskFields(id);
                 assertEq(payout, 3 ether);
@@ -7715,7 +7947,7 @@ contract MockToken is Test, IERC20 {
             function test_EditMeta_CreatorHatWorksPreClaimOnly() public {
                 uint256 id = _nextId++;
                 vm.prank(creator1);
-                tm.createTask(2 ether, bytes("c"), bytes32(0), PID, address(0), 0, false);
+                tm.createTask(2 ether, bytes("c"), bytes32(0), PID, address(0), 0, false, 0, 0);
 
                 // creator2 has CREATE perm via CREATOR_HAT but is NOT the PM of this project.
                 vm.prank(creator2);
@@ -7746,7 +7978,7 @@ contract MockToken is Test, IERC20 {
 
                 uint256 id = _nextId++;
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("b"), bytes32(0), bountyPid, address(tokenA), 2 ether, false);
+                tm.createTask(1 ether, bytes("b"), bytes32(0), bountyPid, address(tokenA), 2 ether, false, 0, 0);
                 vm.prank(creator1);
                 tm.assignTask(id, member1);
 
@@ -7754,7 +7986,7 @@ contract MockToken is Test, IERC20 {
                 _assertBountySpent(bountyPid, address(tokenB), 0);
 
                 vm.prank(editorFull);
-                tm.updateTask(id, 1 ether, bytes("b-swap"), bytes32(0), address(tokenB), 3 ether);
+                tm.updateTask(id, 1 ether, bytes("b-swap"), bytes32(0), address(tokenB), 3 ether, 0, 0);
 
                 _assertBountySpent(bountyPid, address(tokenA), 0);
                 _assertBountySpent(bountyPid, address(tokenB), 3 ether);
@@ -7773,14 +8005,14 @@ contract MockToken is Test, IERC20 {
 
                 uint256 id = _nextId++;
                 vm.prank(creator1);
-                tm.createTask(1 ether, bytes("b"), bytes32(0), bountyPid, address(tokenA), 2 ether, false);
+                tm.createTask(1 ether, bytes("b"), bytes32(0), bountyPid, address(tokenA), 2 ether, false, 0, 0);
                 vm.prank(creator1);
                 tm.assignTask(id, member1);
 
                 // tokenB has no budget on this project (cap = 0 = DISABLED) — swap reverts via BudgetLib.
                 vm.prank(editorFull);
                 vm.expectRevert(BudgetLib.BudgetExceeded.selector);
-                tm.updateTask(id, 1 ether, bytes("b-bad"), bytes32(0), address(tokenB), 1 ether);
+                tm.updateTask(id, 1 ether, bytes("b-bad"), bytes32(0), address(tokenB), 1 ether, 0, 0);
             }
 
             function test_ProjectOverrideRemovesEditFull() public {
@@ -7796,17 +8028,17 @@ contract MockToken is Test, IERC20 {
                 uint256 id = _createAndClaim(2 ether);
                 vm.prank(editorFull);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
-                tm.updateTask(id, 3 ether, bytes("x"), bytes32(0), address(0), 0);
+                tm.updateTask(id, 3 ether, bytes("x"), bytes32(0), address(0), 0, 0, 0);
 
                 // On the other project (no override), the global EDIT_FULL still grants access.
                 uint256 otherId = _nextId++;
                 vm.prank(creator1);
-                tm.createTask(2 ether, bytes("o"), bytes32(0), otherPid, address(0), 0, false);
+                tm.createTask(2 ether, bytes("o"), bytes32(0), otherPid, address(0), 0, false, 0, 0);
                 vm.prank(member1);
                 tm.claimTask(otherId);
 
                 vm.prank(editorFull);
-                tm.updateTask(otherId, 3 ether, bytes("ok"), bytes32(0), address(0), 0);
+                tm.updateTask(otherId, 3 ether, bytes("ok"), bytes32(0), address(0), 0, 0, 0);
             }
 
             function test_EditFull_OnCreateAndAssignTask() public {
@@ -7816,7 +8048,7 @@ contract MockToken is Test, IERC20 {
                 vm.prank(creator1); // creator1 is the PM (and has both CREATE and ASSIGN via creator hat? no — needs explicit)
                 // creator1 is a PM via auto-add on createProject. PMs satisfy the createAndAssignTask
                 // permission gate (hasCreateAndAssign || isPM).
-                tm.createAndAssignTask(2 ether, bytes("ca"), bytes32(0), PID, member1, address(0), 0, false);
+                tm.createAndAssignTask(2 ether, bytes("ca"), bytes32(0), PID, member1, address(0), 0, false, 0, 0);
 
                 (uint256 payoutBefore,,, TaskManager.Status statusBefore,) = _taskFields(id);
                 assertEq(uint256(statusBefore), uint256(TaskManager.Status.CLAIMED));
@@ -7824,7 +8056,7 @@ contract MockToken is Test, IERC20 {
 
                 // EDIT_FULL holder can edit the directly-claimed task.
                 vm.prank(editorFull);
-                tm.updateTask(id, 4 ether, bytes("ca-edited"), bytes32(0), address(0), 0);
+                tm.updateTask(id, 4 ether, bytes("ca-edited"), bytes32(0), address(0), 0, 0, 0);
 
                 (uint256 payoutAfter,,,,) = _taskFields(id);
                 assertEq(payoutAfter, 4 ether);
@@ -7837,7 +8069,7 @@ contract MockToken is Test, IERC20 {
                 uint256 id = _createAndClaim(2 ether);
 
                 vm.prank(editorFull);
-                tm.updateTask(id, 7 ether, bytes("bumped"), bytes32(0), address(0), 0);
+                tm.updateTask(id, 7 ether, bytes("bumped"), bytes32(0), address(0), 0, 0, 0);
 
                 vm.prank(member1);
                 tm.submitTask(id, keccak256("done"));
@@ -8039,7 +8271,7 @@ contract MockToken is Test, IERC20 {
 
                 vm.prank(editorFull);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
-                tm.updateTask(0, 5 ether, bytes("nope"), bytes32(0), address(0), 0);
+                tm.updateTask(0, 5 ether, bytes("nope"), bytes32(0), address(0), 0, 0, 0);
 
                 // But metadata-only succeeds because EDIT_META was the last-written mask.
                 vm.prank(editorFull);
@@ -8112,7 +8344,7 @@ contract MockToken is Test, IERC20 {
 
                 // The bootstrap-granted hat wearer can immediately edit.
                 vm.prank(editorFull);
-                tm.updateTask(0, 5 ether, bytes("bumped"), bytes32(0), address(0), 0);
+                tm.updateTask(0, 5 ether, bytes("bumped"), bytes32(0), address(0), 0, 0, 0);
             }
 
             /* ---------- Edge case 10: multiple bits OR'd into one mask ---------- */
@@ -8181,7 +8413,7 @@ contract MockToken is Test, IERC20 {
 
                 // Editor hat (bootstrapped) can edit the now-CLAIMED task.
                 vm.prank(editorFull);
-                tm.updateTask(0, 2 ether, bytes("post"), bytes32(0), address(0), 0);
+                tm.updateTask(0, 2 ether, bytes("post"), bytes32(0), address(0), 0, 0, 0);
             }
 
             /* ---------- Edge case 12: per-project override still beats bootstrap-granted global ---------- */
@@ -8205,7 +8437,7 @@ contract MockToken is Test, IERC20 {
                 // Editor hat is denied on this project despite the global EDIT_FULL grant.
                 vm.prank(editorFull);
                 vm.expectRevert(TaskManager.Unauthorized.selector);
-                tm.updateTask(0, 5 ether, bytes("nope"), bytes32(0), address(0), 0);
+                tm.updateTask(0, 5 ether, bytes("nope"), bytes32(0), address(0), 0, 0, 0);
             }
 
             /* ---------- Helpers ---------- */
@@ -8231,6 +8463,685 @@ contract MockToken is Test, IERC20 {
                     })
                 );
                 vm.prank(creator1);
-                tm.createTask(2 ether, bytes("t"), bytes32(0), pid, address(0), 0, false);
+                tm.createTask(2 ether, bytes("t"), bytes32(0), pid, address(0), 0, false, 0, 0);
+            }
+        }
+
+        /*────────────────── TaskManager v6: Deadlines & Takeover ──────────────────*/
+        contract TaskManagerDeadlineTest is TaskManagerTestBase {
+            bytes32 DL_ID;
+            address member2 = makeAddr("member2");
+
+            uint32 constant WINDOW = 7 days;
+            uint48 ABS; // T0 + 30 days
+            uint256 T0;
+
+            bytes32 constant TOPIC_DEADLINES_SET = keccak256("TaskDeadlinesSet(uint256,uint48,uint32)");
+            bytes32 constant TOPIC_CLAIM_DEADLINE_SET = keccak256("TaskClaimDeadlineSet(uint256,uint48)");
+            bytes32 constant TOPIC_CLAIM_EXPIRED = keccak256("TaskClaimExpired(uint256,address,address)");
+
+            function setUp() public {
+                vm.warp(1_700_000_000); // realistic base timestamp so `abs <= block.timestamp` checks bite
+                T0 = block.timestamp;
+                ABS = uint48(T0 + 30 days);
+                setUpBase();
+                setHat(member2, MEMBER_HAT);
+                DL_ID = _createDefaultProject("DEADLINES", 0);
+            }
+
+            /*──────── helpers ───────*/
+            // Mirrors the contract's sequential id assignment (fresh setUp ⇒ first task is id 0),
+            // same pattern as TaskManagerEditPermsTest.
+            uint256 _nextId;
+
+            function _mkTask(uint48 absoluteDeadline, uint32 completionWindow) internal returns (uint256 id) {
+                id = _nextId++;
+                vm.prank(creator1);
+                tm.createTask(
+                    1 ether, bytes("dl"), bytes32(0), DL_ID, address(0), 0, false, absoluteDeadline, completionWindow
+                );
+            }
+
+            function _mkAppTask(uint48 absoluteDeadline, uint32 completionWindow) internal returns (uint256 id) {
+                id = _nextId++;
+                vm.prank(creator1);
+                tm.createTask(
+                    1 ether, bytes("dl-app"), bytes32(0), DL_ID, address(0), 0, true, absoluteDeadline, completionWindow
+                );
+            }
+
+            function _deadlines(uint256 id) internal view returns (uint48 abs_, uint32 window_, uint48 cd_) {
+                bytes memory data = lens.getStorage(
+                    address(tm), TaskManagerLens.StorageKey.TASK_DEADLINES, abi.encode(id)
+                );
+                (abs_, window_, cd_) = abi.decode(data, (uint48, uint32, uint48));
+            }
+
+            function _status(uint256 id) internal view returns (TaskManager.Status st, address claimer) {
+                bytes memory data = lens.getStorage(address(tm), TaskManagerLens.StorageKey.TASK_INFO, abi.encode(id));
+                (, st, claimer,,) = abi.decode(data, (uint256, TaskManager.Status, address, bytes32, bool));
+            }
+
+            function _countTopic(Vm.Log[] memory logs, bytes32 topic) internal pure returns (uint256 n) {
+                for (uint256 i; i < logs.length; i++) {
+                    if (logs[i].topics[0] == topic) n++;
+                }
+            }
+
+            /*──────── creation & validation ───────*/
+
+            function test_CreateWithBothDeadlines() public {
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskDeadlinesSet(0, ABS, WINDOW);
+                uint256 id = _mkTask(ABS, WINDOW);
+
+                (uint48 abs_, uint32 window_, uint48 cd_) = _deadlines(id);
+                assertEq(abs_, ABS, "absoluteDeadline stored");
+                assertEq(window_, WINDOW, "completionWindow stored");
+                assertEq(cd_, 0, "claimDeadline unset until claim");
+            }
+
+            function test_CreateWithAbsoluteOnly() public {
+                uint256 id = _mkTask(ABS, 0);
+                (uint48 abs_, uint32 window_, uint48 cd_) = _deadlines(id);
+                assertEq(abs_, ABS);
+                assertEq(window_, 0);
+                assertEq(cd_, 0);
+            }
+
+            function test_CreateWithWindowOnly() public {
+                uint256 id = _mkTask(0, WINDOW);
+                (uint48 abs_, uint32 window_, uint48 cd_) = _deadlines(id);
+                assertEq(abs_, 0);
+                assertEq(window_, WINDOW);
+                assertEq(cd_, 0);
+            }
+
+            function test_CreateWithoutDeadlinesEmitsNoDeadlineEvent() public {
+                vm.recordLogs();
+                uint256 id = _mkTask(0, 0);
+                Vm.Log[] memory logs = vm.getRecordedLogs();
+                assertEq(_countTopic(logs, TOPIC_DEADLINES_SET), 0, "no TaskDeadlinesSet for deadline-less create");
+                assertEq(
+                    _countTopic(logs, TOPIC_CLAIM_DEADLINE_SET), 0, "no TaskClaimDeadlineSet for deadline-less create"
+                );
+                (uint48 abs_, uint32 window_, uint48 cd_) = _deadlines(id);
+                assertEq(abs_, 0);
+                assertEq(window_, 0);
+                assertEq(cd_, 0);
+            }
+
+            function test_CreateBatchMixedDeadlines() public {
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](4);
+                // (abs, window) combos: both / abs-only / window-only / neither
+                uint48[4] memory abss = [ABS, ABS, 0, 0];
+                uint32[4] memory windows = [WINDOW, 0, WINDOW, 0];
+                for (uint256 i; i < 4; i++) {
+                    inputs[i] = TaskManager.CreateTaskInput({
+                        payout: 1 ether,
+                        title: bytes("batch"),
+                        metadataHash: bytes32(0),
+                        bountyToken: address(0),
+                        bountyPayout: 0,
+                        requiresApplication: false,
+                        absoluteDeadline: abss[i],
+                        completionWindow: windows[i]
+                    });
+                }
+                vm.prank(creator1);
+                uint256[] memory ids = tm.createTasksBatch(DL_ID, inputs);
+                for (uint256 i; i < 4; i++) {
+                    (uint48 abs_, uint32 window_, uint48 cd_) = _deadlines(ids[i]);
+                    assertEq(abs_, abss[i], "batch abs");
+                    assertEq(window_, windows[i], "batch window");
+                    assertEq(cd_, 0, "batch cd unset");
+                }
+            }
+
+            function test_CreateBornExpiredReverts() public {
+                uint48 past = uint48(block.timestamp); // `<= now` is rejected
+                vm.prank(creator1);
+                vm.expectRevert(TaskManager.InvalidDeadline.selector);
+                tm.createTask(1 ether, bytes("x"), bytes32(0), DL_ID, address(0), 0, false, past, 0);
+
+                // batch path
+                TaskManager.CreateTaskInput[] memory inputs = new TaskManager.CreateTaskInput[](1);
+                inputs[0] = TaskManager.CreateTaskInput({
+                    payout: 1 ether,
+                    title: bytes("x"),
+                    metadataHash: bytes32(0),
+                    bountyToken: address(0),
+                    bountyPayout: 0,
+                    requiresApplication: false,
+                    absoluteDeadline: uint48(block.timestamp - 1),
+                    completionWindow: 0
+                });
+                vm.prank(creator1);
+                vm.expectRevert(TaskManager.InvalidDeadline.selector);
+                tm.createTasksBatch(DL_ID, inputs);
+
+                // create-and-assign path (executor: PM bypass — pm1's project mask shadows his global CREATE)
+                vm.prank(executor);
+                vm.expectRevert(TaskManager.InvalidDeadline.selector);
+                tm.createAndAssignTask(
+                    1 ether, bytes("x"), bytes32(0), DL_ID, member1, address(0), 0, false, past, WINDOW
+                );
+            }
+
+            function test_CreateAndAssignStartsWindow() public {
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskCreated(0, DL_ID, 1 ether, address(0), 0, false, bytes("caa"), bytes32(0));
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskAssigned(0, member1, executor);
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskDeadlinesSet(0, ABS, WINDOW);
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskClaimDeadlineSet(0, uint48(block.timestamp) + WINDOW);
+                vm.prank(executor);
+                uint256 id = tm.createAndAssignTask(
+                    1 ether, bytes("caa"), bytes32(0), DL_ID, member1, address(0), 0, false, ABS, WINDOW
+                );
+
+                (,, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, uint48(block.timestamp) + WINDOW, "window starts at assignment");
+                (TaskManager.Status st, address claimer) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.CLAIMED));
+                assertEq(claimer, member1);
+            }
+
+            /*──────── claim-window lifecycle ───────*/
+
+            function test_ClaimSetsClaimDeadline() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskClaimDeadlineSet(id, uint48(block.timestamp) + WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                (,, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, uint48(block.timestamp) + WINDOW);
+            }
+
+            function test_ClaimWindowlessLeavesDeadlineZero() public {
+                uint256 id = _mkTask(ABS, 0);
+                vm.recordLogs();
+                vm.prank(member1);
+                tm.claimTask(id);
+                Vm.Log[] memory logs = vm.getRecordedLogs();
+                assertEq(_countTopic(logs, TOPIC_CLAIM_DEADLINE_SET), 0, "windowless claim emits no deadline event");
+                (,, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, 0);
+            }
+
+            function test_AssignSetsClaimDeadline() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(pm1);
+                tm.assignTask(id, member1);
+                (,, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, uint48(block.timestamp) + WINDOW);
+            }
+
+            function test_ApproveApplicationSetsClaimDeadline() public {
+                uint256 id = _mkAppTask(0, WINDOW);
+                vm.prank(member1);
+                tm.applyForTask(id, keccak256("app"));
+                vm.prank(pm1);
+                tm.approveApplication(id, member1);
+                (,, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, uint48(block.timestamp) + WINDOW);
+            }
+
+            function test_RejectResetsWindow() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                uint48 firstDeadline = uint48(block.timestamp) + WINDOW;
+
+                vm.warp(block.timestamp + 3 days);
+                vm.prank(member1);
+                tm.submitTask(id, keccak256("work"));
+
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskClaimDeadlineSet(id, uint48(block.timestamp) + WINDOW);
+                vm.prank(pm1);
+                tm.rejectTask(id, keccak256("redo"));
+
+                (,, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, uint48(block.timestamp) + WINDOW, "fresh window for rework");
+                assertGt(cd_, firstDeadline);
+            }
+
+            function test_RejectWindowlessIsNoop() public {
+                uint256 id = _mkTask(0, 0);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(member1);
+                tm.submitTask(id, keccak256("work"));
+                vm.recordLogs();
+                vm.prank(pm1);
+                tm.rejectTask(id, keccak256("redo"));
+                Vm.Log[] memory logs = vm.getRecordedLogs();
+                assertEq(_countTopic(logs, TOPIC_CLAIM_DEADLINE_SET), 0);
+                (,, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, 0);
+            }
+
+            /*──────── lenient submission ───────*/
+
+            function test_LateSubmitAndCompleteAllowed() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+
+                vm.warp(block.timestamp + WINDOW + 30 days); // way past the claim deadline
+                vm.prank(member1);
+                tm.submitTask(id, keccak256("late-but-fine"));
+
+                vm.prank(pm1);
+                tm.completeTask(id);
+                (TaskManager.Status st,) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.COMPLETED));
+                assertEq(token.balanceOf(member1), 1 ether, "late work still pays");
+            }
+
+            function test_LateSubmitPastAbsoluteAllowed() public {
+                uint256 id = _mkTask(ABS, 0);
+                vm.prank(member1);
+                tm.claimTask(id);
+
+                vm.warp(uint256(ABS) + 1 days);
+                vm.prank(member1);
+                tm.submitTask(id, keccak256("late"));
+                vm.prank(pm1);
+                tm.completeTask(id);
+                (TaskManager.Status st,) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.COMPLETED));
+            }
+
+            /*──────── takeover ───────*/
+
+            function test_ClaimTakeoverAfterWindowExpiry() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                uint48 cd1 = uint48(block.timestamp) + WINDOW;
+
+                vm.warp(uint256(cd1) + 1);
+
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskClaimExpired(id, member1, member2);
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskClaimed(id, member2);
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskClaimDeadlineSet(id, uint48(block.timestamp) + WINDOW);
+                vm.prank(member2);
+                tm.claimTask(id);
+
+                (TaskManager.Status st, address claimer) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.CLAIMED));
+                assertEq(claimer, member2, "claimer switched");
+                (,, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, uint48(block.timestamp) + WINDOW, "fresh window for new claimer");
+
+                // ousted claimer can no longer submit
+                vm.prank(member1);
+                vm.expectRevert(TaskManager.NotClaimer.selector);
+                tm.submitTask(id, keccak256("too-late"));
+            }
+
+            function test_ClaimTakeoverAfterAbsoluteExpiry() public {
+                uint256 id = _mkTask(ABS, 0);
+                vm.prank(member1);
+                tm.claimTask(id);
+
+                vm.warp(uint256(ABS) + 1);
+                vm.prank(member2);
+                tm.claimTask(id);
+                (, address claimer) = _status(id);
+                assertEq(claimer, member2);
+
+                // past the absolute cutoff every claim is born unprotected — chain another takeover
+                vm.prank(member1);
+                tm.claimTask(id);
+                (, claimer) = _status(id);
+                assertEq(claimer, member1);
+            }
+
+            function test_ClaimNotExpiredReverts() public {
+                uint256 id = _mkTask(ABS, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+
+                vm.warp(block.timestamp + WINDOW); // exactly the deadline second: still protected
+                vm.prank(member2);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.claimTask(id);
+            }
+
+            function test_SubmittedNeverTakeoverable() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.warp(block.timestamp + WINDOW + 1); // expire, then submit late (lenient)
+                vm.prank(member1);
+                tm.submitTask(id, keccak256("work"));
+
+                vm.warp(block.timestamp + 365 days);
+                vm.prank(member2);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.claimTask(id);
+                vm.prank(pm1);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.assignTask(id, member2);
+            }
+
+            function test_AssignTakeoverAndSelfRefresh() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(pm1);
+                tm.assignTask(id, member1);
+                uint48 cd1 = uint48(block.timestamp) + WINDOW;
+
+                vm.warp(uint256(cd1) + 1);
+                // reassign to someone else
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskClaimExpired(id, member1, member2);
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskAssigned(id, member2, pm1);
+                vm.prank(pm1);
+                tm.assignTask(id, member2);
+
+                // expire again, re-assign to the SAME claimer = explicit window refresh
+                (,, uint48 cd2) = _deadlines(id);
+                vm.warp(uint256(cd2) + 1);
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskClaimExpired(id, member2, member2);
+                vm.prank(pm1);
+                tm.assignTask(id, member2);
+                (,, uint48 cd3) = _deadlines(id);
+                assertEq(cd3, uint48(block.timestamp) + WINDOW, "refreshed window");
+            }
+
+            function test_AssignTakeoverNeedsAssignPerm() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.warp(block.timestamp + WINDOW + 1);
+                vm.prank(member2); // MEMBER_HAT has CLAIM, not ASSIGN
+                vm.expectRevert(TaskManager.Unauthorized.selector);
+                tm.assignTask(id, member2);
+            }
+
+            function test_RequiresApplicationDirectClaimTakeoverReverts() public {
+                uint256 id = _mkAppTask(0, WINDOW);
+                vm.prank(member1);
+                tm.applyForTask(id, keccak256("app1"));
+                vm.prank(pm1);
+                tm.approveApplication(id, member1);
+
+                vm.warp(block.timestamp + WINDOW + 1);
+                vm.prank(member2);
+                vm.expectRevert(TaskManager.RequiresApplication.selector);
+                tm.claimTask(id);
+            }
+
+            function test_ApplicationTakeoverFlow() public {
+                uint256 id = _mkAppTask(0, WINDOW);
+                vm.prank(member1);
+                tm.applyForTask(id, keccak256("app1"));
+                vm.prank(pm1);
+                tm.approveApplication(id, member1);
+
+                // not expired yet: new applications are rejected
+                vm.prank(member2);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.applyForTask(id, keccak256("app2"));
+
+                vm.warp(block.timestamp + WINDOW + 1);
+
+                // expired: a NEW applicant can apply while the task is still CLAIMED
+                vm.prank(member2);
+                tm.applyForTask(id, keccak256("app2"));
+
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskClaimExpired(id, member1, member2);
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskApplicationApproved(id, member2, pm1);
+                vm.prank(pm1);
+                tm.approveApplication(id, member2);
+                (, address claimer) = _status(id);
+                assertEq(claimer, member2);
+
+                // the ousted claimer's application hash persists — they are re-approvable after expiry
+                vm.warp(block.timestamp + WINDOW + 1);
+                vm.prank(pm1);
+                tm.approveApplication(id, member1);
+                (, claimer) = _status(id);
+                assertEq(claimer, member1);
+            }
+
+            function test_ApproveNonApplicantOnExpiredClaimReverts() public {
+                uint256 id = _mkAppTask(0, WINDOW);
+                vm.prank(member1);
+                tm.applyForTask(id, keccak256("app1"));
+                vm.prank(pm1);
+                tm.approveApplication(id, member1);
+                vm.warp(block.timestamp + WINDOW + 1);
+                vm.prank(pm1);
+                vm.expectRevert(TaskManager.NotApplicant.selector);
+                tm.approveApplication(id, member2);
+            }
+
+            function test_ExpiredClaimerSelfReclaim() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.warp(block.timestamp + WINDOW + 1);
+
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskClaimExpired(id, member1, member1);
+                vm.prank(member1);
+                tm.claimTask(id);
+                (,, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, uint48(block.timestamp) + WINDOW, "self-reclaim refreshes the window");
+            }
+
+            function test_ClaimUnclaimedPastAbsoluteAllowed() public {
+                uint256 id = _mkTask(ABS, 0);
+                vm.warp(uint256(ABS) + 1 days); // expires while UNCLAIMED
+                vm.prank(member1);
+                tm.claimTask(id); // lenient: claiming is allowed, the claim is just born unprotected
+                (, address claimer) = _status(id);
+                assertEq(claimer, member1);
+                vm.prank(member2);
+                tm.claimTask(id); // immediately takeover-able
+                (, claimer) = _status(id);
+                assertEq(claimer, member2);
+            }
+
+            /*──────── updateTask deadline arithmetic ───────*/
+
+            function test_UpdateDeadlinesUnclaimed() public {
+                uint256 id = _mkTask(0, 0);
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskDeadlinesSet(id, ABS, WINDOW);
+                vm.prank(creator1);
+                tm.updateTask(id, 1 ether, bytes("dl"), bytes32(0), address(0), 0, ABS, WINDOW);
+                (uint48 abs_, uint32 window_, uint48 cd_) = _deadlines(id);
+                assertEq(abs_, ABS);
+                assertEq(window_, WINDOW);
+                assertEq(cd_, 0, "no claim, no claim deadline");
+            }
+
+            function test_UpdateWindowWhileClaimedPreservesClaimStart() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                uint48 claimStart = uint48(block.timestamp);
+
+                vm.warp(block.timestamp + 2 days);
+                uint32 newWindow = 14 days;
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskClaimDeadlineSet(id, claimStart + newWindow);
+                vm.prank(executor);
+                tm.updateTask(id, 1 ether, bytes("dl"), bytes32(0), address(0), 0, 0, newWindow);
+
+                (,, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, claimStart + newWindow, "claim start preserved across window edits");
+            }
+
+            function test_UpdateWindowFromZeroWhileClaimed() public {
+                uint256 id = _mkTask(0, 0);
+                vm.prank(member1);
+                tm.claimTask(id); // windowless claim, cd = 0
+                vm.warp(block.timestamp + 5 days);
+
+                vm.prank(executor);
+                tm.updateTask(id, 1 ether, bytes("dl"), bytes32(0), address(0), 0, 0, WINDOW);
+                (,, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, uint48(block.timestamp) + WINDOW, "window starts now when previously windowless");
+            }
+
+            function test_UpdateWindowToZeroClears() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskClaimDeadlineSet(id, 0);
+                vm.prank(executor);
+                tm.updateTask(id, 1 ether, bytes("dl"), bytes32(0), address(0), 0, 0, 0);
+                (,, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, 0, "cleared");
+            }
+
+            function test_UpdatePastAbsoluteUnsticksClaimedTask() public {
+                uint256 id = _mkTask(0, 0); // no deadlines: pre-v6-style task
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.warp(block.timestamp + 90 days); // claimer ghosted; task is stuck CLAIMED
+
+                vm.prank(member2);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.claimTask(id); // still protected — no deadlines configured
+
+                // executor sets the absolute deadline into the past → opens takeover
+                vm.prank(executor);
+                tm.updateTask(id, 1 ether, bytes("dl"), bytes32(0), address(0), 0, uint48(block.timestamp - 1), 0);
+
+                vm.prank(member2);
+                tm.claimTask(id);
+                (, address claimer) = _status(id);
+                assertEq(claimer, member2, "unstuck via past absolute deadline");
+            }
+
+            function test_UpdateSubmittedAdjustsClaimDeadline() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                uint48 claimStart = uint48(block.timestamp);
+                vm.prank(member1);
+                tm.submitTask(id, keccak256("work"));
+
+                uint32 newWindow = 21 days;
+                vm.prank(executor);
+                tm.updateTask(id, 1 ether, bytes("dl"), bytes32(0), address(0), 0, 0, newWindow);
+                (,, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, claimStart + newWindow, "submitted tasks keep arithmetic consistent");
+
+                // a later rejection restarts the window from 'now'
+                vm.warp(block.timestamp + 10 days);
+                vm.prank(pm1);
+                tm.rejectTask(id, keccak256("redo"));
+                (,, cd_) = _deadlines(id);
+                assertEq(cd_, uint48(block.timestamp) + newWindow, "reject overrides with a fresh window");
+            }
+
+            function test_UpdateNoopEmitsNoDeadlineEvents() public {
+                uint256 id = _mkTask(ABS, WINDOW);
+                vm.recordLogs();
+                vm.prank(creator1);
+                tm.updateTask(id, 1 ether, bytes("dl"), bytes32(0), address(0), 0, ABS, WINDOW);
+                Vm.Log[] memory logs = vm.getRecordedLogs();
+                assertEq(_countTopic(logs, TOPIC_DEADLINES_SET), 0, "unchanged values emit nothing");
+                assertEq(_countTopic(logs, TOPIC_CLAIM_DEADLINE_SET), 0);
+            }
+
+            function test_UpdateDeadlinePermissionsMatchPayoutEdits() public {
+                uint256 id = _mkTask(0, 0);
+
+                // outsider: no perms at all
+                vm.prank(outsider);
+                vm.expectRevert(TaskManager.Unauthorized.selector);
+                tm.updateTask(id, 1 ether, bytes("dl"), bytes32(0), address(0), 0, ABS, WINDOW);
+
+                // CREATE-perm holder can set deadlines while UNCLAIMED...
+                // (creator2: wears CREATOR_HAT but is NOT the project's auto-added manager)
+                vm.prank(creator2);
+                tm.updateTask(id, 1 ether, bytes("dl"), bytes32(0), address(0), 0, ABS, WINDOW);
+
+                // ...but not post-claim (no EDIT_FULL)
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(creator2);
+                vm.expectRevert(TaskManager.Unauthorized.selector);
+                tm.updateTask(id, 1 ether, bytes("dl"), bytes32(0), address(0), 0, 0, 0);
+            }
+
+            function test_TerminalTasksRejectDeadlineEdits() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(member1);
+                tm.submitTask(id, keccak256("work"));
+                vm.prank(pm1);
+                tm.completeTask(id);
+
+                vm.prank(executor);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.updateTask(id, 1 ether, bytes("dl"), bytes32(0), address(0), 0, ABS, WINDOW);
+            }
+
+            /*──────── fuzz ───────*/
+
+            function testFuzz_WindowEditPreservesClaimStart(uint32 w1, uint32 w2, uint32 warpBy) public {
+                w1 = uint32(bound(w1, 1, 365 days));
+                w2 = uint32(bound(w2, 1, 365 days));
+                warpBy = uint32(bound(warpBy, 0, 365 days));
+
+                uint256 id = _mkTask(0, w1);
+                vm.prank(member1);
+                tm.claimTask(id);
+                uint48 claimStart = uint48(block.timestamp);
+
+                vm.warp(block.timestamp + warpBy);
+                vm.prank(executor);
+                tm.updateTask(id, 1 ether, bytes("dl"), bytes32(0), address(0), 0, 0, w2);
+
+                (,, uint48 cd_) = _deadlines(id);
+                if (w1 == w2) {
+                    assertEq(cd_, claimStart + w1, "no-op edit keeps deadline");
+                } else {
+                    assertEq(cd_, claimStart + w2, "claim start preserved");
+                }
+            }
+
+            function testFuzz_ExpiryBoundary(uint32 window) public {
+                window = uint32(bound(window, 1, 3650 days));
+                uint256 id = _mkTask(0, window);
+                vm.prank(member1);
+                tm.claimTask(id);
+                uint48 cd = uint48(block.timestamp) + window;
+
+                // exactly at the deadline: still protected
+                vm.warp(cd);
+                vm.prank(member2);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.claimTask(id);
+
+                // one second past: expired
+                vm.warp(uint256(cd) + 1);
+                vm.prank(member2);
+                tm.claimTask(id);
+                (, address claimer) = _status(id);
+                assertEq(claimer, member2);
             }
         }


### PR DESCRIPTION
## What

TaskManager v6 adds **task deadlines** with a **lenient takeover model** — part 1 of a 3-repo feature (contracts → subgraph → frontend).

Three deadline fields per task (all optional, `0` = unset; **append-only — pre-v6 tasks read zeros, no migration**):

| Field | Type | Meaning |
|---|---|---|
| `absoluteDeadline` | `uint48` unix | calendar cutoff; while CLAIMED past it, the claim is open to takeover |
| `completionWindow` | `uint32` sec | per-claim window: submit within N seconds of claiming or the claim opens up |
| `claimDeadline` | `uint48` unix | derived: `claimTime + window`, recomputed at claim/assign/approve/reject |

A fourth, **soft due date** lives only in IPFS task metadata (`dueDate`) — display-only, no contract involvement (frontend/subgraph PRs).

### Lenient enforcement
- `submitTask` is **never** deadline-blocked — late work can be submitted (and paid) until someone actually takes the task over.
- An expired claim is taken over **in one tx** via the normal `claimTask` / `assignTask` / `approveApplication` — emits `TaskClaimExpired(id, previousClaimer, newClaimer)` then the usual lifecycle event; new claimer gets a fresh window. No separate unclaim function.
- `applyForTask` now also accepts applications while CLAIMED-and-expired (otherwise application-gated tasks could only be taken over by the original applicant pool).
- `rejectTask` restarts the window (fresh allowance for rework). SUBMITTED tasks are never takeover-able.
- `updateTask` edits both knobs; window edits preserve the original claim start. **A past `absoluteDeadline` is deliberately accepted on update** — the only unstick lever for abandoned CLAIMED tasks (`cancelTask` is UNCLAIMED-only), incl. all pre-v6 ones. Create paths revert `InvalidDeadline` for non-future values.

### Selector replacements (paymaster + frontend ship in lockstep)
| Function | v5 (dead) | v6 |
|---|---|---|
| createTask | `0x22fa79bc` | `0x4d0265d4` |
| createTasksBatch | `0xc18aa1c9` | `0xf31d148f` |
| createAndAssignTask | `0xaf425951` | `0x98e30e89` |
| updateTask | `0x48db6f65` | `0xb7c288e8` |

New events (existing signatures untouched; ordering documented in `docs/TASK_MANAGER.md` as the subgraph contract): `TaskDeadlinesSet`, `TaskClaimDeadlineSet` (only-on-change), `TaskClaimExpired`.

Also: OrgDeployer `_appendTaskManagerRules` swapped to the v6 strings (count stays 43); Lens decodes the 10-field tuple + new `TASK_DEADLINES` key.

## Testing
- New `TaskManagerDeadlineTest`: 37 cases — create combos + born-expired reverts (all 3 paths), window lifecycle (claim/assign/approve/reject), lenient late submit+complete, takeover happy/sad paths (boundary: deadline second protected, +1s expired), application-flow takeover, self-reclaim refresh, updateTask arithmetic (claim-start preservation, 0→W, W→0, past-absolute unstick, perm parity), fuzz (window-edit invariant + expiry boundary).
- DeployerTest asserts the 4 v6 selectors are auto-whitelisted at deploy + selector-accuracy strings pinned to the real selectors.
- **Full suite: 1419 passed / 0 failed.** `forge fmt` clean.
- Production sizes: TaskManager 20,690 / OrgDeployer 19,389 (margins +3,886 / +5,187).

## Ops scripts — all 7 sims fork-run to PASS under `FOUNDRY_PROFILE=production` (`--skip test`)
- `script/upgrades/UpgradeTaskManagerDeadlines.s.sol` — 3-step cross-chain upgrade. **v6 probed FREE (registry + CREATE2) on Gnosis AND Arbitrum** (predicted impl `0x7833c4670C42dbCe1a7aB1BAB7e7Baf0A982ff57`). DryRuns on **both** chains exercise the live proxies: pre-v6 task zero-state (real Poa tasks on Arbitrum), born-expired revert, window start, expiry boundary, takeover with fresh window, lenient late submit + complete, window-edit arithmetic, deadline-less claims stay protected, executor storage preserved.
- `script/upgrades/UpgradeOrgDeployerDeadlineRules.s.sol` — OrgDeployer **v15** (probed FREE both chains, predicted `0xFa5Bc9343631489094e68a6059E93994C33127A3`).
- `script/fixes/WhitelistTaskDeadlineRules{Poa,Test6Kubi,DecentralPark}ViaGovernance.s.sol` — per-org proposals: **4 v6 selectors allowed + 4 dead v5 selectors disallowed** (griefing hygiene). Sims execute create → vote → warp → announceWinner and assert `getRule` flips on the real fork.

## Broadcast runbook (Hudson)
1. Create + vote the 4 org proposals (Poa/Arbitrum; Test6, KUBI, DecentralPark/Gnosis).
2. After windows: `announceWinner` per org → TaskManager Step1 (Gnosis) → Step2 (Arbitrum + cross-chain) → Step3 verify → OrgDeployer v15 Step1/Step2/Step3.
3. Subgraph deploy + gateway publish, then frontend deploy (sibling PRs). Old-frontend degradation window = minutes between announceWinner and beacon upgrade, ops-controlled.

## Known limitation
`FOUNDRY_PROFILE=production forge build` **with tests** now hits a YulException (stack-too-deep) inside the giant `DeployerTest` contract — optimizer-on inlining pressure; it persists even with all v6-touched functions stubbed, i.e. marginal-budget instability of that compilation unit, not a specific new function (also repros on solc 0.8.30). The CI gate (default profile) is green, src + scripts compile clean under production, and sims run with `--skip test`. Not load-bearing for broadcast artifacts.

## Cross-repo
Binding spec (events, param order `..., absoluteDeadline, completionWindow`, `CreateTaskInput` field names, zero→null indexing semantics) is mirrored by the subgraph PR (poa-box/subgraph-pop) and frontend PR (poa-frontend) — linked once opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)