### PR TITLE
feat(tee-agent): attestation-pinned Hats eligibility for TEE agents

### DIFF
--- a/docs/SIGSTACK_BOT_INTEGRATION.md
+++ b/docs/SIGSTACK_BOT_INTEGRATION.md
@@ -13,6 +13,13 @@ Decentral Park (`script/fixes/CreateAgentRoleDecentralPark.s.sol`). Nothing new
 is needed on-chain; you grant the bot's wallet a permission through normal
 governance.
 
+> **Advanced — bind the hat to the enclave, not the address.**
+> `TEEAgentEligibilityModule` lets governance grant a role to an attested TEE
+> *measurement*, so upgrading the bot's code becomes a governance event and
+> retiring an image de-authorizes it instantly. See
+> [`TEE_AGENT_ELIGIBILITY.md`](TEE_AGENT_ELIGIBILITY.md). The address-grant flow
+> below is the simpler baseline and works without it.
+
 ## 1. Get the bot's wallet address
 
 The bot signs with a key **derived inside its TEE** (dstack `derive_key`) — no

--- a/docs/SIGSTACK_BOT_INTEGRATION.md
+++ b/docs/SIGSTACK_BOT_INTEGRATION.md
@@ -1,0 +1,125 @@
+# Sigstack bot integration
+
+[sigstack-bot](https://github.com/BreadchainCoop/sigstack-bot) is a Signal bot
+that runs inside an Intel TDX TEE and proxies chat to private inference. This doc
+covers the Poa-side setup for the **Poa DAO task tools** added in
+[sigstack-bot#4](https://github.com/BreadchainCoop/sigstack-bot/pull/4): letting
+the bot read an org's projects/tasks and (for authorized operators) create and
+manage tasks on the org's `TaskManager`.
+
+The bot is, from this repo's perspective, just another **agent EOA** that holds a
+TaskManager permission — the same shape as the "Agent role" already used on
+Decentral Park (`script/fixes/CreateAgentRoleDecentralPark.s.sol`). Nothing new
+is needed on-chain; you grant the bot's wallet a permission through normal
+governance.
+
+## 1. Get the bot's wallet address
+
+The bot signs with a key **derived inside its TEE** (dstack `derive_key`) — no
+private key is exported. To read the address:
+
+- start the bot with `TOOLS__POA__ENABLED=true` and look for the log line
+  `Poa wallet address: 0x… (grant this address project-manager rights on-chain)`, or
+- ask the running bot (it exposes a `poa_wallet_info` tool).
+
+Call this address `BOT` below. It is stable for a given TEE image + derivation
+path (`poa-tools/task-manager-wallet`).
+
+## 2. Point the bot at the org
+
+The bot needs the org's chain RPC, the Poa subgraph, and the org's `TaskManager`
+proxy. Find the TaskManager from the subgraph (see `CLAUDE.md` → *Subgraph*):
+
+```bash
+curl -s -X POST 'https://api.studio.thegraph.com/query/73367/poa-gnosis-v-1/version/latest' \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"{ organization(id:\"0x<orgId>\"){ name taskManager{ id } } }"}'
+```
+
+Set on the bot: `TOOLS__POA__RPC_URL`, `TOOLS__POA__SUBGRAPH_URL`,
+`TOOLS__POA__TASK_MANAGER`, `TOOLS__POA__NETWORK_NAME`. (Poa governance orgs are
+on **Arbitrum**; KUBI/Test6/etc. on **Gnosis**.)
+
+## 3. Grant the bot a TaskManager permission
+
+Read tools need **no** on-chain grant. Write tools require the bot wallet to hold
+a permission on the target project. Two options:
+
+### Option A — Project manager (simplest, per project)
+
+One governance call makes `BOT` a manager of project `pid`, bypassing the hat
+system for that project (create/assign/review/edit/cancel):
+
+```solidity
+TaskManager.setConfig(
+    TaskManager.ConfigKey.PROJECT_MANAGER,
+    abi.encode(pid, BOT, true)   // (bytes32 pid, address mgr, bool isManager)
+);
+```
+
+This is executor-gated, so it runs as a proposal executed by the org's Executor
+(same batch shape as the `script/fixes/*ViaGovernance.s.sol` scripts). Revoke by
+passing `false`.
+
+### Option B — Agent role hat (recommended, least privilege)
+
+Mirror `CreateAgentRoleDecentralPark.s.sol`: create an "Agent"/"Bot" role hat,
+grant it a **scoped** TaskPerm mask org-wide, mint the hat to `BOT`, and sponsor
+its gas via PaymasterHub. Example mask — the bot can create and assign tasks and
+edit task metadata, but not touch payouts, reviews, or budgets:
+
+```solidity
+uint8 mask = TaskPerm.CREATE | TaskPerm.ASSIGN | TaskPerm.EDIT_META;
+TaskManager.setConfig(TaskManager.ConfigKey.ROLE_PERM, abi.encode(botHat, mask));
+```
+
+Use `setProjectRolePerm(pid, botHat, mask)` (or `setConfig(PROJECT_ROLE_PERM…)`)
+to scope the grant to a single project instead of the whole org.
+
+**TaskPerm bits** (`src/libs/TaskPerm.sol`):
+
+| Bit | Name | Gates |
+|-----|------|-------|
+| `1<<0` | `CREATE` | createTask, cancelTask, edit while unclaimed |
+| `1<<1` | `CLAIM` | claimTask |
+| `1<<2` | `REVIEW` | completeTask (mints payout), rejectTask |
+| `1<<3` | `ASSIGN` | assignTask, approveApplication |
+| `1<<4` | `SELF_REVIEW` | approve one's own submission |
+| `1<<5` | `BUDGET` | project/bounty cap edits |
+| `1<<6` | `EDIT_META` | edit title/metadata post-claim |
+| `1<<7` | `EDIT_FULL` | edit payout/bounty post-claim |
+
+Grant only what the bot should do. In particular `REVIEW` mints tokens and
+`EDIT_FULL`/`BUDGET` move value — reserve those for humans unless the bot is
+explicitly meant to approve work.
+
+## 4. Fund gas
+
+The bot pays its own gas from `BOT`. Either send it a little native token on the
+org's chain, or sponsor it via `PaymasterHub.setBudget(orgId, botSubjectKey, …)`
+as in step 5 of the Decentral Park agent script.
+
+## 5. Turn on writes (bot side)
+
+On the bot, writes are gated independently of the chain:
+
+- `TOOLS__POA__ENABLE_WRITES=true`
+- `TOOLS__POA__AUTHORIZED_SENDERS=<comma/space-separated Signal numbers>`
+
+Only those senders can invoke write tools, even in group chats. See
+[`docs/poa-integration.md`](https://github.com/BreadchainCoop/sigstack-bot/blob/main/docs/poa-integration.md)
+in the bot repo.
+
+## Security notes
+
+- **Key custody:** the signing key never leaves the TEE. Whoever controls the TEE
+  image/deployment effectively controls `BOT` — treat granting it `REVIEW`/
+  `EDIT_FULL`/`BUDGET` as delegating value movement to that operator.
+- **Two independent gates:** the bot's sender allowlist limits *who can ask*; the
+  on-chain permission limits *what the wallet can do*. Keep both tight; revoke
+  the on-chain grant (Option A `false`, or burn the Agent hat) to cut the bot off
+  regardless of bot config.
+- **Least privilege:** prefer Option B with a project-scoped mask over org-wide
+  project-manager rights.
+- **Auditability:** every write emits the usual `Task*` events, so the subgraph
+  and any monitoring pick up bot actions with `_msgSender() == BOT`.

--- a/docs/TEE_AGENT_ELIGIBILITY.md
+++ b/docs/TEE_AGENT_ELIGIBILITY.md
@@ -1,0 +1,82 @@
+# TEE agent eligibility (attestation-pinned hats)
+
+`TEEAgentEligibilityModule` lets an org grant a Hats Protocol role **to an
+enclave image rather than to an address** — the endgame of the sigstack-bot
+integration. A wallet may wear the agent hat only while it holds a fresh
+attestation binding it to a TEE measurement that governance has explicitly
+allowed. Upgrading the agent's code becomes a governance event; retiring or
+rotating a measurement de-authorizes every wallet on that image instantly.
+
+This closes the loop left open by the base integration
+([`SIGSTACK_BOT_INTEGRATION.md`](SIGSTACK_BOT_INTEGRATION.md)): there, governance
+grants a hat to the bot's address and trusts *off-band* that the running TDX
+quote matches the intended code. Here, the grant is *conditional on the
+measurement*.
+
+## Contracts
+
+| File | Role |
+|------|------|
+| `src/TEEAgentEligibilityModule.sol` | Hats `IHatsEligibility` module; pins a hat to allowed measurements + live bindings. |
+| `src/interfaces/ITEEAttestationVerifier.sol` | Pluggable verifier: raw attestation → `(subject, measurement, expiry)`. |
+| `src/verifiers/TrustedSignerAttestationVerifier.sol` | Ships-today verifier: an off-chain notary runs DCAP and signs the triple. |
+| `test/mocks/MockTEEAttestationVerifier.sol` | Test verifier (no crypto). |
+
+## How it works
+
+1. **Governance allows a measurement.** The org Executor (the module's
+   `governor`) calls `setMeasurementAllowed(hatId, measurement, true)`. The
+   `measurement` identifies the attested enclave image (e.g. a hash of the TDX
+   RTMRs / mrtd of the sigstack-bot build).
+2. **The agent attests.** Anyone (typically the bot) calls
+   `submitAttestation(hatId, attestation)`. The pluggable verifier authenticates
+   the blob and returns `(subject, measurement, expiry)`; if the measurement is
+   allowed and unexpired, the module records a binding `subject → (measurement,
+   expiry)`.
+3. **Hats checks eligibility live.** `getWearerStatus(wearer, hatId)` returns
+   eligible iff the binding is active, unexpired, **and** its measurement is
+   still allowed. So three levers each drop the hat immediately:
+   - measurement retired by governance (`setMeasurementAllowed(..., false)`),
+   - attestation freshness lapses (bindings carry an `expiry`; the agent
+     re-attests periodically),
+   - explicit `revokeBinding(wearer, hatId)` (emergency kill for one wallet).
+
+Wire it into an org exactly like the existing `EligibilityModule`: create the
+agent hat with this module as its eligibility module, then run steps above via
+governance. Combined with a `TaskManager` role grant (see
+[`SIGSTACK_BOT_INTEGRATION.md`](SIGSTACK_BOT_INTEGRATION.md)) and PaymasterHub gas
+sponsorship, the bot is a governance-hired, attestation-gated org member.
+
+## The verifier is the trust seam
+
+`ITEEAttestationVerifier` is deliberately the only trusted component, and it is
+swappable via `setVerifier` without touching the module:
+
+- **`TrustedSignerAttestationVerifier` (today).** An off-chain notary service
+  runs the real DCAP/TDX quote verification and ECDSA-signs the
+  `(subject, measurement, expiry)` triple, bound to the verifier address + chain
+  id (no cross-chain replay). Trust reduces to that signer, which governance can
+  rotate. Honest and deployable now.
+- **On-chain DCAP verification (later).** A verifier that checks the TDX quote
+  and Intel PCS collateral entirely on-chain would make the system trustless. It
+  is a large separate effort; the interface exists so it can be slotted in with a
+  single `setVerifier` call.
+
+## Testing
+
+```sh
+forge test --match-contract TEEAgentEligibilityModuleTest -vv
+```
+
+Covers the happy path, every rejection (disallowed measurement, expiry, verifier
+revert), the three live-revocation levers, verifier swap, and the notary-signer
+verifier end-to-end (valid + forged signature).
+
+## Deployment note
+
+`TEEAgentEligibilityModule` is upgradeable (ERC-7201 namespaced storage, no
+`__gap`, `_disableInitializers()` in the constructor) — deploy behind a proxy and
+call `initialize(governor, verifier)`. A production rollout should pair a
+`BroadcastX`/`SimX` script per the repo's "simulate before declaring done" rule;
+that script is left for the deploying operator since it depends on the target
+org's Executor address and chain.

--- a/src/TEEAgentEligibilityModule.sol
+++ b/src/TEEAgentEligibilityModule.sol
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.20;
+
+import {IHatsEligibility} from "@hats-protocol/src/Interfaces/IHatsEligibility.sol";
+import {Initializable} from "@openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
+import {ITEEAttestationVerifier} from "./interfaces/ITEEAttestationVerifier.sol";
+
+/**
+ * @title TEEAgentEligibilityModule
+ * @notice A Hats Protocol eligibility module that pins a hat to a TEE-attested
+ *         enclave measurement. A wallet may wear the agent hat only while it
+ *         holds a fresh attestation binding it to an enclave *image* that
+ *         governance has explicitly allowed for that hat.
+ *
+ * @dev This makes "the org hires attested software" concrete, and — crucially —
+ *      makes upgrading the agent's code a governance event: a new enclave image
+ *      produces a new `measurement`, which governance must register before the
+ *      new build can wear the hat. Rotating or revoking a measurement instantly
+ *      de-eligibilizes every wallet running that image (Hats calls
+ *      {getWearerStatus} live), so a compromised or retired build loses its hat
+ *      with no per-wallet bookkeeping.
+ *
+ *      Trust in the *attestation itself* is delegated to a pluggable
+ *      {ITEEAttestationVerifier}, so the module is agnostic to how a quote is
+ *      checked (trusted notary today, on-chain DCAP later).
+ *
+ *      Storage uses ERC-7201-style namespaced storage; no `__gap`. Access is
+ *      gated by a `governor` address (the org's Executor), matching the
+ *      project convention of governance-controlled admin rather than OZ
+ *      AccessControl.
+ */
+contract TEEAgentEligibilityModule is Initializable, IHatsEligibility {
+    /*═══════════════════════════════ ERRORS ═══════════════════════════════*/
+
+    /// @notice Caller is not the configured governor.
+    error NotGovernor();
+    /// @notice A required address argument was zero.
+    error ZeroAddress();
+    /// @notice The attested measurement is not allowed for this hat.
+    error MeasurementNotAllowed();
+    /// @notice The attestation names a different subject than expected.
+    error SubjectMismatch();
+    /// @notice The attestation is already expired at submission time.
+    error AttestationExpired();
+    /// @notice No binding exists for the (wearer, hat) pair.
+    error NoBinding();
+
+    /*═══════════════════════════════ EVENTS ═══════════════════════════════*/
+
+    event Initialized(address indexed governor, address indexed verifier);
+    event GovernorTransferred(address indexed oldGovernor, address indexed newGovernor);
+    event VerifierUpdated(address indexed oldVerifier, address indexed newVerifier);
+    event MeasurementAllowed(uint256 indexed hatId, bytes32 indexed measurement, bool allowed);
+    event AttestationAccepted(
+        uint256 indexed hatId, address indexed subject, bytes32 indexed measurement, uint64 expiry
+    );
+    event BindingRevoked(uint256 indexed hatId, address indexed subject);
+
+    /*══════════════════════════════ STRUCTS ═══════════════════════════════*/
+
+    /// @notice A wallet's attestation binding for one hat.
+    struct Binding {
+        bytes32 measurement; // enclave image the wallet attested to
+        uint64 expiry; // attestation freshness cutoff (unix)
+        bool active; // false once revoked
+    }
+
+    /*══════════════════════════════ STORAGE ═══════════════════════════════*/
+
+    /// @custom:storage-location erc7201:poa.teeagenteligibility.storage
+    struct Layout {
+        /// @notice Governance address (the org Executor) that manages measurements.
+        address governor;
+        /// @notice The attestation verifier (swappable for a stronger one).
+        ITEEAttestationVerifier verifier;
+        /// @notice hatId => measurement => allowed.
+        mapping(uint256 => mapping(bytes32 => bool)) allowedMeasurement;
+        /// @notice wearer => hatId => binding.
+        mapping(address => mapping(uint256 => Binding)) bindings;
+    }
+
+    bytes32 private constant _STORAGE_SLOT = keccak256("poa.teeagenteligibility.storage");
+
+    function _layout() private pure returns (Layout storage s) {
+        bytes32 slot = _STORAGE_SLOT;
+        assembly {
+            s.slot := slot
+        }
+    }
+
+    /*═════════════════════════════ MODIFIERS ══════════════════════════════*/
+
+    modifier onlyGovernor() {
+        if (msg.sender != _layout().governor) revert NotGovernor();
+        _;
+    }
+
+    /*═══════════════════════════════ INIT ═════════════════════════════════*/
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Initialize the module.
+     * @param governor_ Governance address (typically the org Executor).
+     * @param verifier_ Attestation verifier implementation.
+     */
+    function initialize(address governor_, address verifier_) external initializer {
+        if (governor_ == address(0) || verifier_ == address(0)) revert ZeroAddress();
+        Layout storage l = _layout();
+        l.governor = governor_;
+        l.verifier = ITEEAttestationVerifier(verifier_);
+        emit Initialized(governor_, verifier_);
+    }
+
+    /*═══════════════════════════ GOVERNANCE ═══════════════════════════════*/
+
+    /// @notice Transfer governance to a new address.
+    function transferGovernor(address newGovernor) external onlyGovernor {
+        if (newGovernor == address(0)) revert ZeroAddress();
+        address old = _layout().governor;
+        _layout().governor = newGovernor;
+        emit GovernorTransferred(old, newGovernor);
+    }
+
+    /// @notice Swap the attestation verifier (e.g. notary → on-chain DCAP).
+    function setVerifier(address newVerifier) external onlyGovernor {
+        if (newVerifier == address(0)) revert ZeroAddress();
+        address old = address(_layout().verifier);
+        _layout().verifier = ITEEAttestationVerifier(newVerifier);
+        emit VerifierUpdated(old, newVerifier);
+    }
+
+    /**
+     * @notice Allow or disallow an enclave `measurement` to wear `hatId`.
+     * @dev This is the governance lever that makes an agent-code upgrade a
+     *      governance action. Disallowing a measurement instantly removes
+     *      eligibility from every wallet attested to it.
+     */
+    function setMeasurementAllowed(uint256 hatId, bytes32 measurement, bool allowed) external onlyGovernor {
+        _layout().allowedMeasurement[hatId][measurement] = allowed;
+        emit MeasurementAllowed(hatId, measurement, allowed);
+    }
+
+    /**
+     * @notice Emergency: revoke a specific wallet's binding for a hat, without
+     *         disallowing the whole measurement.
+     */
+    function revokeBinding(address wearer, uint256 hatId) external onlyGovernor {
+        Binding storage b = _layout().bindings[wearer][hatId];
+        if (!b.active) revert NoBinding();
+        b.active = false;
+        emit BindingRevoked(hatId, wearer);
+    }
+
+    /*═══════════════════════════ ATTESTATION ══════════════════════════════*/
+
+    /**
+     * @notice Submit an attestation binding a wallet to `hatId`. Permissionless:
+     *         the verifier authenticates the attestation, so anyone (typically
+     *         the agent itself) may relay it.
+     * @param hatId       The hat the subject wants to become eligible for.
+     * @param attestation Opaque attestation blob understood by the verifier.
+     * @return subject     The bound wallet.
+     * @return measurement The attested enclave measurement.
+     */
+    function submitAttestation(uint256 hatId, bytes calldata attestation)
+        external
+        returns (address subject, bytes32 measurement)
+    {
+        Layout storage l = _layout();
+        uint64 expiry;
+        (subject, measurement, expiry) = l.verifier.verifyAttestation(attestation);
+
+        if (subject == address(0)) revert ZeroAddress();
+        if (expiry <= block.timestamp) revert AttestationExpired();
+        if (!l.allowedMeasurement[hatId][measurement]) revert MeasurementNotAllowed();
+
+        l.bindings[subject][hatId] = Binding({measurement: measurement, expiry: expiry, active: true});
+        emit AttestationAccepted(hatId, subject, measurement, expiry);
+    }
+
+    /*═══════════════════════ ELIGIBILITY INTERFACE ════════════════════════*/
+
+    /**
+     * @inheritdoc IHatsEligibility
+     * @dev Eligible iff the wearer has an active, unexpired binding whose
+     *      measurement is *still* allowed for the hat. All three conditions are
+     *      checked live, so revoking the measurement, expiry lapsing, or an
+     *      explicit revocation each drop eligibility immediately.
+     */
+    function getWearerStatus(address _wearer, uint256 _hatId)
+        external
+        view
+        override
+        returns (bool eligible, bool standing)
+    {
+        Layout storage l = _layout();
+        Binding storage b = l.bindings[_wearer][_hatId];
+        eligible = b.active && b.expiry > block.timestamp && l.allowedMeasurement[_hatId][b.measurement];
+        // Standing tracks eligibility here; a bad-standing wearer is simply not eligible.
+        standing = eligible;
+    }
+
+    /*════════════════════════════ VIEWS ═══════════════════════════════════*/
+
+    /// @notice Current governor.
+    function governor() external view returns (address) {
+        return _layout().governor;
+    }
+
+    /// @notice Current verifier.
+    function verifier() external view returns (address) {
+        return address(_layout().verifier);
+    }
+
+    /// @notice Whether `measurement` may wear `hatId`.
+    function isMeasurementAllowed(uint256 hatId, bytes32 measurement) external view returns (bool) {
+        return _layout().allowedMeasurement[hatId][measurement];
+    }
+
+    /// @notice The binding recorded for `wearer` on `hatId`.
+    function bindingOf(address wearer, uint256 hatId)
+        external
+        view
+        returns (bytes32 measurement, uint64 expiry, bool active)
+    {
+        Binding storage b = _layout().bindings[wearer][hatId];
+        return (b.measurement, b.expiry, b.active);
+    }
+}

--- a/src/interfaces/ITEEAttestationVerifier.sol
+++ b/src/interfaces/ITEEAttestationVerifier.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.20;
+
+/**
+ * @title ITEEAttestationVerifier
+ * @notice Pluggable verifier that turns a raw TEE attestation into a
+ *         `(subject, measurement, expiry)` triple usable for on-chain
+ *         authorization.
+ *
+ * @dev The verifier is the trust seam of the TEE-agent eligibility system.
+ *      Implementations range in strength:
+ *        - A trusted-notary signer (an off-chain service that itself runs DCAP
+ *          quote verification and signs the result) — cheap, ships today, trust
+ *          reduces to that signer. See `TrustedSignerAttestationVerifier`.
+ *        - Full on-chain DCAP / TDX quote verification — trustless, expensive,
+ *          a separate effort. It can be slotted in later via
+ *          `TEEAgentEligibilityModule.setVerifier` without touching the module.
+ *
+ *      `verifyAttestation` MUST revert if the attestation is invalid, forged,
+ *      or expired so callers can treat any successful return as authoritative.
+ */
+interface ITEEAttestationVerifier {
+    /**
+     * @notice Verify a raw attestation blob.
+     * @param attestation Opaque, implementation-defined attestation bytes.
+     * @return subject      The address the attestation binds (the enclave-derived wallet).
+     * @return measurement  Identifier of the attested enclave image (e.g. a hash of TDX RTMRs/mrtd).
+     * @return expiry       Unix timestamp after which this attestation is no longer valid.
+     */
+    function verifyAttestation(bytes calldata attestation)
+        external
+        view
+        returns (address subject, bytes32 measurement, uint64 expiry);
+}

--- a/src/verifiers/TrustedSignerAttestationVerifier.sol
+++ b/src/verifiers/TrustedSignerAttestationVerifier.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.20;
+
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import {ITEEAttestationVerifier} from "../interfaces/ITEEAttestationVerifier.sol";
+
+/**
+ * @title TrustedSignerAttestationVerifier
+ * @notice A pragmatic {ITEEAttestationVerifier}: an off-chain notary service
+ *         runs the real DCAP/TDX quote verification and signs the resulting
+ *         `(subject, measurement, expiry)` triple. This contract recovers and
+ *         checks that signature.
+ *
+ * @dev Trust reduces to the notary `signer`. This is honest about its
+ *      assumption and ships today; a trustless on-chain DCAP verifier can
+ *      replace it later via `TEEAgentEligibilityModule.setVerifier` without any
+ *      change to the eligibility module. The signed digest is bound to this
+ *      verifier's address and chain id, so a signature cannot be replayed across
+ *      chains or verifier deployments.
+ *
+ *      Attestation encoding (ABI):
+ *        abi.encode(address subject, bytes32 measurement, uint64 expiry, bytes signature)
+ */
+contract TrustedSignerAttestationVerifier is ITEEAttestationVerifier {
+    using ECDSA for bytes32;
+
+    /// @notice Domain tag mixed into the signed digest.
+    bytes32 public constant DOMAIN = keccak256("POA_TEE_ATTESTATION_V1");
+
+    /// @notice Caller is not the governor.
+    error NotGovernor();
+    /// @notice A required address was zero.
+    error ZeroAddress();
+    /// @notice The recovered signer is not the trusted notary.
+    error BadSignature();
+
+    /// @notice Governance address that can rotate the signer.
+    address public governor;
+    /// @notice The trusted notary whose signature authenticates attestations.
+    address public signer;
+
+    event SignerUpdated(address indexed oldSigner, address indexed newSigner);
+    event GovernorTransferred(address indexed oldGovernor, address indexed newGovernor);
+
+    constructor(address governor_, address signer_) {
+        if (governor_ == address(0) || signer_ == address(0)) revert ZeroAddress();
+        governor = governor_;
+        signer = signer_;
+    }
+
+    modifier onlyGovernor() {
+        if (msg.sender != governor) revert NotGovernor();
+        _;
+    }
+
+    /// @notice Rotate the trusted notary signer.
+    function setSigner(address newSigner) external onlyGovernor {
+        if (newSigner == address(0)) revert ZeroAddress();
+        emit SignerUpdated(signer, newSigner);
+        signer = newSigner;
+    }
+
+    /// @notice Transfer governance.
+    function transferGovernor(address newGovernor) external onlyGovernor {
+        if (newGovernor == address(0)) revert ZeroAddress();
+        emit GovernorTransferred(governor, newGovernor);
+        governor = newGovernor;
+    }
+
+    /**
+     * @notice The digest the notary must sign for a given attestation triple,
+     *         bound to this verifier and chain. Exposed so the off-chain signer
+     *         and integration tests can reproduce it exactly.
+     */
+    function digest(address subject, bytes32 measurement, uint64 expiry) public view returns (bytes32) {
+        return keccak256(abi.encode(DOMAIN, block.chainid, address(this), subject, measurement, expiry));
+    }
+
+    /// @inheritdoc ITEEAttestationVerifier
+    function verifyAttestation(bytes calldata attestation)
+        external
+        view
+        override
+        returns (address subject, bytes32 measurement, uint64 expiry)
+    {
+        bytes memory signature;
+        (subject, measurement, expiry, signature) = abi.decode(attestation, (address, bytes32, uint64, bytes));
+
+        bytes32 ethHash = MessageHashUtils.toEthSignedMessageHash(digest(subject, measurement, expiry));
+        address recovered = ethHash.recover(signature);
+        if (recovered != signer) revert BadSignature();
+    }
+}

--- a/test/TEEAgentEligibilityModule.t.sol
+++ b/test/TEEAgentEligibilityModule.t.sol
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import {TEEAgentEligibilityModule} from "../src/TEEAgentEligibilityModule.sol";
+import {TrustedSignerAttestationVerifier} from "../src/verifiers/TrustedSignerAttestationVerifier.sol";
+import {MockTEEAttestationVerifier} from "./mocks/MockTEEAttestationVerifier.sol";
+
+contract TEEAgentEligibilityModuleTest is Test {
+    TEEAgentEligibilityModule internal module;
+    MockTEEAttestationVerifier internal mock;
+
+    address internal governor = address(0x6047);
+    address internal agent = address(0xA9E7);
+    uint256 internal constant HAT = 42;
+    bytes32 internal constant IMAGE_A = keccak256("enclave-image-A");
+    bytes32 internal constant IMAGE_B = keccak256("enclave-image-B");
+
+    function setUp() public {
+        mock = new MockTEEAttestationVerifier();
+        TEEAgentEligibilityModule impl = new TEEAgentEligibilityModule();
+        bytes memory data = abi.encodeCall(TEEAgentEligibilityModule.initialize, (governor, address(mock)));
+        module = TEEAgentEligibilityModule(address(new ERC1967Proxy(address(impl), data)));
+    }
+
+    function _attest(address subject, bytes32 measurement, uint64 expiry) internal view returns (bytes memory) {
+        return abi.encode(subject, measurement, expiry);
+    }
+
+    function _status(address who) internal view returns (bool eligible, bool standing) {
+        return module.getWearerStatus(who, HAT);
+    }
+
+    /*──────────────── init / access ────────────────*/
+
+    function testInitState() public view {
+        assertEq(module.governor(), governor);
+        assertEq(module.verifier(), address(mock));
+    }
+
+    function testImplInitializerDisabled() public {
+        TEEAgentEligibilityModule impl = new TEEAgentEligibilityModule();
+        vm.expectRevert();
+        impl.initialize(governor, address(mock));
+    }
+
+    function testOnlyGovernorGates() public {
+        vm.expectRevert(TEEAgentEligibilityModule.NotGovernor.selector);
+        module.setMeasurementAllowed(HAT, IMAGE_A, true);
+
+        vm.expectRevert(TEEAgentEligibilityModule.NotGovernor.selector);
+        module.setVerifier(address(mock));
+
+        vm.expectRevert(TEEAgentEligibilityModule.NotGovernor.selector);
+        module.transferGovernor(agent);
+    }
+
+    /*──────────────── happy path ────────────────*/
+
+    function testAttestGrantsEligibility() public {
+        vm.prank(governor);
+        module.setMeasurementAllowed(HAT, IMAGE_A, true);
+
+        (bool e0,) = _status(agent);
+        assertFalse(e0, "not eligible before attestation");
+
+        module.submitAttestation(HAT, _attest(agent, IMAGE_A, uint64(block.timestamp + 1 days)));
+
+        (bool eligible, bool standing) = _status(agent);
+        assertTrue(eligible, "eligible after attestation");
+        assertTrue(standing, "standing tracks eligibility");
+
+        (bytes32 m, uint64 exp, bool active) = module.bindingOf(agent, HAT);
+        assertEq(m, IMAGE_A);
+        assertEq(exp, uint64(block.timestamp + 1 days));
+        assertTrue(active);
+    }
+
+    /*──────────────── rejections ────────────────*/
+
+    function testDisallowedMeasurementReverts() public {
+        vm.expectRevert(TEEAgentEligibilityModule.MeasurementNotAllowed.selector);
+        module.submitAttestation(HAT, _attest(agent, IMAGE_A, uint64(block.timestamp + 1 days)));
+    }
+
+    function testExpiredAttestationReverts() public {
+        vm.prank(governor);
+        module.setMeasurementAllowed(HAT, IMAGE_A, true);
+        vm.warp(1000);
+        vm.expectRevert(TEEAgentEligibilityModule.AttestationExpired.selector);
+        module.submitAttestation(HAT, _attest(agent, IMAGE_A, uint64(999)));
+    }
+
+    function testVerifierRevertPropagates() public {
+        vm.prank(governor);
+        module.setMeasurementAllowed(HAT, IMAGE_A, true);
+        mock.setShouldRevert(true);
+        vm.expectRevert(MockTEEAttestationVerifier.MockRejected.selector);
+        module.submitAttestation(HAT, _attest(agent, IMAGE_A, uint64(block.timestamp + 1 days)));
+    }
+
+    /*──────────────── live revocation semantics ────────────────*/
+
+    function testDisallowingMeasurementRevokesLive() public {
+        vm.prank(governor);
+        module.setMeasurementAllowed(HAT, IMAGE_A, true);
+        module.submitAttestation(HAT, _attest(agent, IMAGE_A, uint64(block.timestamp + 1 days)));
+        (bool before,) = _status(agent);
+        assertTrue(before);
+
+        // Governance retires image A (e.g. bumping the agent to image B):
+        // every wallet on A loses the hat immediately, no per-wallet bookkeeping.
+        vm.prank(governor);
+        module.setMeasurementAllowed(HAT, IMAGE_A, false);
+
+        (bool afterFlag,) = _status(agent);
+        assertFalse(afterFlag, "eligibility gone once measurement retired");
+    }
+
+    function testExpiryLapsesEligibility() public {
+        vm.warp(1000);
+        vm.prank(governor);
+        module.setMeasurementAllowed(HAT, IMAGE_A, true);
+        module.submitAttestation(HAT, _attest(agent, IMAGE_A, uint64(1000 + 100)));
+
+        (bool live,) = _status(agent);
+        assertTrue(live);
+
+        vm.warp(1000 + 101);
+        (bool lapsed,) = _status(agent);
+        assertFalse(lapsed, "stale attestation is not eligible");
+    }
+
+    function testRevokeBinding() public {
+        vm.prank(governor);
+        module.setMeasurementAllowed(HAT, IMAGE_A, true);
+        module.submitAttestation(HAT, _attest(agent, IMAGE_A, uint64(block.timestamp + 1 days)));
+
+        vm.prank(governor);
+        module.revokeBinding(agent, HAT);
+        (bool eligible,) = _status(agent);
+        assertFalse(eligible);
+
+        // Re-attesting restores eligibility (image still allowed).
+        module.submitAttestation(HAT, _attest(agent, IMAGE_A, uint64(block.timestamp + 1 days)));
+        (bool eligible2,) = _status(agent);
+        assertTrue(eligible2);
+    }
+
+    function testRevokeUnknownBindingReverts() public {
+        vm.prank(governor);
+        vm.expectRevert(TEEAgentEligibilityModule.NoBinding.selector);
+        module.revokeBinding(agent, HAT);
+    }
+
+    function testSwapVerifier() public {
+        MockTEEAttestationVerifier mock2 = new MockTEEAttestationVerifier();
+        vm.prank(governor);
+        module.setVerifier(address(mock2));
+        assertEq(module.verifier(), address(mock2));
+    }
+
+    /*──────────────── real notary-signer verifier ────────────────*/
+
+    function testTrustedSignerVerifierEndToEnd() public {
+        (address notary, uint256 notaryPk) = makeAddrAndKey("notary");
+        TrustedSignerAttestationVerifier v = new TrustedSignerAttestationVerifier(governor, notary);
+
+        // Point the module at the real verifier and allow image A.
+        vm.startPrank(governor);
+        module.setVerifier(address(v));
+        module.setMeasurementAllowed(HAT, IMAGE_A, true);
+        vm.stopPrank();
+
+        uint64 expiry = uint64(block.timestamp + 1 days);
+        bytes32 dig = v.digest(agent, IMAGE_A, expiry);
+        bytes32 ethHash = MessageHashUtils.toEthSignedMessageHash(dig);
+        (uint8 sv, bytes32 sr, bytes32 ss) = vm.sign(notaryPk, ethHash);
+        bytes memory sig = abi.encodePacked(sr, ss, sv);
+        bytes memory attestation = abi.encode(agent, IMAGE_A, expiry, sig);
+
+        module.submitAttestation(HAT, attestation);
+        (bool eligible,) = _status(agent);
+        assertTrue(eligible, "notary-signed attestation grants eligibility");
+    }
+
+    function testTrustedSignerRejectsForgedSignature() public {
+        (address notary,) = makeAddrAndKey("notary");
+        (, uint256 impostorPk) = makeAddrAndKey("impostor");
+        TrustedSignerAttestationVerifier v = new TrustedSignerAttestationVerifier(governor, notary);
+
+        vm.startPrank(governor);
+        module.setVerifier(address(v));
+        module.setMeasurementAllowed(HAT, IMAGE_A, true);
+        vm.stopPrank();
+
+        uint64 expiry = uint64(block.timestamp + 1 days);
+        bytes32 ethHash = MessageHashUtils.toEthSignedMessageHash(v.digest(agent, IMAGE_A, expiry));
+        (uint8 sv, bytes32 sr, bytes32 ss) = vm.sign(impostorPk, ethHash);
+        bytes memory sig = abi.encodePacked(sr, ss, sv);
+
+        vm.expectRevert(TrustedSignerAttestationVerifier.BadSignature.selector);
+        module.submitAttestation(HAT, abi.encode(agent, IMAGE_A, expiry, sig));
+    }
+}

--- a/test/mocks/MockTEEAttestationVerifier.sol
+++ b/test/mocks/MockTEEAttestationVerifier.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.20;
+
+import {ITEEAttestationVerifier} from "../../src/interfaces/ITEEAttestationVerifier.sol";
+
+/**
+ * @notice Test verifier that trusts the attestation payload verbatim (no crypto).
+ *         The attestation is `abi.encode(address subject, bytes32 measurement,
+ *         uint64 expiry)`. Lets tests exercise the eligibility module's logic in
+ *         isolation from any signature scheme. Set `shouldRevert` to simulate an
+ *         invalid attestation.
+ */
+contract MockTEEAttestationVerifier is ITEEAttestationVerifier {
+    bool public shouldRevert;
+
+    error MockRejected();
+
+    function setShouldRevert(bool v) external {
+        shouldRevert = v;
+    }
+
+    /// @notice Helper to build a mock attestation blob.
+    function encode(address subject, bytes32 measurement, uint64 expiry) external pure returns (bytes memory) {
+        return abi.encode(subject, measurement, expiry);
+    }
+
+    function verifyAttestation(bytes calldata attestation)
+        external
+        view
+        override
+        returns (address subject, bytes32 measurement, uint64 expiry)
+    {
+        if (shouldRevert) revert MockRejected();
+        (subject, measurement, expiry) = abi.decode(attestation, (address, bytes32, uint64));
+    }
+}


### PR DESCRIPTION
Adds the Poa-side support for integrating [sigstack-bot](https://github.com/BreadchainCoop/sigstack-bot) — a TEE Signal bot — as a governance-hireable DAO member. `TEEAgentEligibilityModule` is a Hats `IHatsEligibility` module that grants a role to an attested enclave **measurement** rather than a bare address, so upgrading the bot's code becomes a governance event and retiring/rotating a measurement (or expiry lapse, or explicit revoke) drops the hat live in `getWearerStatus`. Attestation trust is isolated behind a pluggable `ITEEAttestationVerifier` — shipping with a notary-signer verifier (`TrustedSignerAttestationVerifier`) that's deployable today and swappable for on-chain DCAP later without touching the module. Two docs explain the baseline address-grant flow (`SIGSTACK_BOT_INTEGRATION.md`) and this attestation-pinned endgame (`TEE_AGENT_ELIGIBILITY.md`). Fully additive and green: `forge build` clean, `forge fmt` clean, and 14 new tests pass (happy path, every rejection, all three live-revocation levers, verifier swap, notary-signer end-to-end incl. forged-signature rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)