### PR TITLE
feat(TaskManager v7): unclaimTask — release a claimed task back to the pool

### DIFF
--- a/docs/TASK_MANAGER.md
+++ b/docs/TASK_MANAGER.md
@@ -185,6 +185,9 @@ struct Task {
 
 ```
 UNCLAIMED → CLAIMED → SUBMITTED → COMPLETED
+    ↑         │  ↑         │
+    └─────────┘  └─────────┘
+     unclaimTask   rejectTask
     │
     └──→ CANCELLED
 ```
@@ -403,16 +406,16 @@ setConfig(ConfigKey.PROJECT_MANAGER, abi.encode(projectId, oldManager, false)); 
      └──────────────┴──────────────┘                              │
                     │                                             │
                     ▼                                             │
-            ┌───────────────┐                                     │
-            │    CLAIMED    │                                     │
-            └───────┬───────┘                                     │
-                    │                                             │
-                    ▼                                             │
-               submitTask                                         │
-                    │                                             │
-                    ▼                                             │
-            ┌───────────────┐                                     │
-            │   SUBMITTED   │                                     │
+            ┌───────────────┐   unclaimTask                       │
+            │    CLAIMED    │──────────────► back to UNCLAIMED    │
+            └───────┬───────┘   (claimer, or ASSIGN once expired) │
+                    │              ▲                              │
+                    ▼              │ rejectTask                   │
+               submitTask          │ (REVIEW)                     │
+                    │              │                              │
+                    ▼              │                              │
+            ┌───────────────┐      │                              │
+            │   SUBMITTED   │──────┘                              │
             └───────┬───────┘                                     │
                     │                                             │
                     ▼                                             │
@@ -437,9 +440,12 @@ setConfig(ConfigKey.PROJECT_MANAGER, abi.encode(projectId, oldManager, false)); 
 | `UNCLAIMED` | `updateTask` | CREATE permission |
 | `UNCLAIMED` | `cancelTask` | CREATE permission |
 | `CLAIMED` | `submitTask` | Only the claimer |
+| `CLAIMED` | `unclaimTask` — release back to the pool | Only the claimer |
 | `CLAIMED` (claim expired) | `claimTask` / `assignTask` / `approveApplication` — takeover | CLAIM / ASSIGN / ASSIGN |
+| `CLAIMED` (claim expired) | `unclaimTask` — release back to the pool | ASSIGN permission |
 | `CLAIMED` (claim expired, requiresApplication) | `applyForTask` | CLAIM permission |
 | `SUBMITTED` | `completeTask` | REVIEW permission |
+| `SUBMITTED` | `rejectTask` — back to `CLAIMED` for rework | REVIEW permission |
 
 ---
 
@@ -482,6 +488,38 @@ Deadlines never block work — they only remove claim *protection*:
 - Past the `absoluteDeadline`, claims (and takeovers) are still allowed — they are
   simply born unprotected. Reviewers keep full control via `completeTask`.
 
+### Releasing a claim (`unclaimTask`)
+
+A takeover hands the task to a *named* replacement. `unclaimTask` is the same move with
+no replacement: status returns to `UNCLAIMED`, `claimer` is zeroed, `claimDeadline` is
+cleared (`absoluteDeadline` / `completionWindow` are task config and survive), and the
+task is open to anyone eligible again.
+
+- **The claimer may always release**, expired or not, with **no permission check at all**.
+  This is deliberate: `assignTask` / `createAndAssignTask` never check the assignee's
+  mask, and a hat can be revoked after a claim — so gating release on `CLAIM` would trap
+  exactly the people who most need out.
+- **An `ASSIGN` holder (or project manager / executor) may release an expired claim.**
+  Same gate `assignTask`'s takeover uses, so this grants no new authority: whoever can
+  release could already reassign to anyone. A live, unexpired claim stays protected from
+  everyone but its own claimer.
+- **`SUBMITTED` is excluded.** Delivered work must be reviewed first — this is what keeps
+  `completeTask`'s `mint(claimer, …)` from ever seeing `address(0)`, which would brick the
+  task (un-completable, un-submittable, un-cancellable, bounty reserved forever). The route
+  out of `SUBMITTED` is `rejectTask` → `CLAIMED` → `unclaimTask`.
+- **Budgets are untouched.** `spent` tracks what a non-cancelled task has committed, not who
+  holds it. Releasing makes the task `cancelTask`-able again, and `cancelTask` remains the
+  single place a reservation is refunded — so a claim/release cycle can never double-refund.
+- **Applications survive.** Hashes in `taskApplications` are never deleted, so the original
+  pool (including the releaser) stays approvable exactly as after a takeover. The applicant
+  *array* was already emptied at approval time; index `TaskApplicationSubmitted` off-chain
+  for the true pool.
+- **A claimer can refresh their own window** by releasing and immediately re-claiming, which
+  pre-empts a `completionWindow` takeover. This is accepted: v6 already lets an *expired*
+  claimer re-claim to refresh, and the remedy is unchanged — set an `absoluteDeadline` (or
+  push one into the past via `updateTask`), which no amount of re-claiming can refresh.
+  Application-gated tasks are immune: their releaser needs a fresh approval to get back in.
+
 ### Editing deadlines
 
 `updateTask` carries both knobs under its existing permission gates (executor / PM /
@@ -494,7 +532,10 @@ Deadlines never block work — they only remove claim *protection*:
 - A **past `absoluteDeadline` is deliberately accepted on update** (create paths
   revert `InvalidDeadline` for non-future values). This is the admin lever that opens
   an abandoned CLAIMED task to takeover — `cancelTask` is UNCLAIMED-only, so no other
-  remedy exists, including for tasks claimed before v6.
+  remedy exists, including for tasks claimed before v6. A task with **both** deadline
+  fields zero never expires, so this two-step (`updateTask` with a past absolute
+  deadline, then `unclaimTask` or a takeover) is the only way to unstick it. Set a
+  `completionWindow` at creation to avoid needing it.
 
 ### Events (indexer contract)
 
@@ -503,10 +544,12 @@ Deadlines never block work — they only remove claim *protection*:
 | `TaskDeadlinesSet(uint256 indexed id, uint48 absoluteDeadline, uint32 completionWindow)` | At create only when at least one value is non-zero; on `updateTask` whenever either value changes. |
 | `TaskClaimDeadlineSet(uint256 indexed id, uint48 claimDeadline)` | Only when the stored value changes (claim/assign/approve start, reject reset, window-edit adjustment, clear). |
 | `TaskClaimExpired(uint256 indexed id, address indexed previousClaimer, address indexed newClaimer)` | On takeover, always before the lifecycle event (`TaskClaimed` / `TaskAssigned` / `TaskApplicationApproved`) in the same transaction. |
+| `TaskUnclaimed(uint256 indexed id, address indexed previousClaimer, address indexed caller)` | On `unclaimTask`. `caller == previousClaimer` ⇒ voluntary self-release; otherwise an ASSIGN holder released an expired claim. Never accompanied by `TaskClaimExpired` — no new claimer is named. |
 
 Intra-tx ordering guarantees: `TaskCreated` → `TaskDeadlinesSet?` →
 `TaskClaimDeadlineSet?` (create paths); `TaskClaimExpired` → lifecycle event →
-`TaskClaimDeadlineSet?` (takeovers).
+`TaskClaimDeadlineSet?` (takeovers); `TaskUnclaimed` → `TaskClaimDeadlineSet(id, 0)?`
+(release).
 
 ---
 
@@ -801,10 +844,12 @@ struct Layout {
 | `createTask` | Create new task in project | CREATE permission for project |
 | `updateTask` | Modify unclaimed task details | CREATE permission for project |
 | `cancelTask` | Cancel unclaimed task, reclaim budget | CREATE permission for project |
-| `claimTask` | Self-assign open task | CLAIM permission for project |
+| `claimTask` | Self-assign open task (or take over an expired claim) | CLAIM permission for project |
 | `assignTask` | Assign task to specific address | ASSIGN permission for project |
+| `unclaimTask` | Release a claimed task back to the pool | Task claimer always; ASSIGN once the claim has expired |
 | `submitTask` | Submit completed work | Task claimer only |
 | `completeTask` | Approve submission, trigger payout | REVIEW permission for project |
+| `rejectTask` | Send a submission back for rework | REVIEW permission for project |
 | `createAndAssignTask` | Create and assign atomically | CREATE + ASSIGN permissions |
 
 #### Application System
@@ -842,9 +887,16 @@ event TaskUpdated(uint256 indexed id, uint256 payout, address bountyToken,
                   uint256 bountyPayout, bytes title, bytes32 metadataHash);
 event TaskClaimed(uint256 indexed id, address indexed claimer);
 event TaskAssigned(uint256 indexed id, address indexed assignee, address indexed assigner);
+event TaskUnclaimed(uint256 indexed id, address indexed previousClaimer, address indexed caller);
 event TaskSubmitted(uint256 indexed id, bytes32 submissionHash);
 event TaskCompleted(uint256 indexed id, address indexed completer);
 event TaskCancelled(uint256 indexed id, address indexed canceller);
+event TaskRejected(uint256 indexed id, address indexed rejector, bytes32 rejectionHash);
+
+// Deadlines & takeover (v6)
+event TaskDeadlinesSet(uint256 indexed id, uint48 absoluteDeadline, uint32 completionWindow);
+event TaskClaimDeadlineSet(uint256 indexed id, uint48 claimDeadline);
+event TaskClaimExpired(uint256 indexed id, address indexed previousClaimer, address indexed newClaimer);
 
 // Application system
 event TaskApplicationSubmitted(uint256 indexed id, address indexed applicant, bytes32 applicationHash);
@@ -860,9 +912,9 @@ event ExecutorUpdated(address newExecutor);
 | Error | Cause |
 |-------|-------|
 | `NotFound` | Task or project doesn't exist |
-| `BadStatus` | Invalid operation for current task status |
+| `BadStatus` | Invalid operation for current task status (also: releasing a claim that is still protected) |
 | `NotCreator` | Caller lacks creator hat or executor role |
-| `NotClaimer` | Only task claimer can submit |
+| `NotClaimer` | Caller is not the task's current claimer |
 | `NotExecutor` | Only executor can call this config function |
 | `Unauthorized` | Caller lacks required permission |
 | `NotApplicant` | Address hasn't applied for this task |

--- a/script/fixes/WhitelistUnclaimTaskRulesViaGovernance.s.sol
+++ b/script/fixes/WhitelistUnclaimTaskRulesViaGovernance.s.sol
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import {IExecutor} from "../../src/Executor.sol";
+import {HybridVoting} from "../../src/HybridVoting.sol";
+
+/*
+ * ============================================================================
+ * Live orgs — paymaster rule for the TaskManager v7 unclaimTask selector,
+ * via governance (proposal + creator vote per org)
+ * ============================================================================
+ *
+ * TaskManager v7 added unclaimTask(uint256) = 0x6103955a (release a claimed task
+ * back to the pool). OrgDeployer v18 puts it in the default rule batch, but that is
+ * forward-only: already-deployed orgs keep the rules they were bootstrapped with, so
+ * without this their passkey/smart-account users hit AA validation failure (not a
+ * contract revert) when they try to release a task.
+ *
+ * Per org, one proposal whose single Executor call is:
+ *   paymaster.setRulesBatch(orgId, [TM], [0x6103955a], [true], [0])
+ *
+ * Purely additive — unlike the v5->v6 deadline migration, v7 replaced no selectors,
+ * so there is nothing to disallow in the same batch.
+ *
+ * Gas hint stays 0 deliberately: the hint is a CAP, not a budget, and the deployed
+ * PaymasterHub unpacks v0.7 accountGasLimits reversed (docs/PAYMASTERHUB_GAS_UNPACK_BUG.md),
+ * so a non-zero hint caps the WRONG gas field and yields AA33 GasTooHigh.
+ *
+ * Prerequisite: the org's chain must already be running TaskManager v7, or the rule
+ * points at a selector the beacon does not implement. Verified live 2026-08-01:
+ * Gnosis and Arbitrum are both on v7 (0xcfAe1DAdF1A48b363aAD3BbB8f94f67bb3785988).
+ *
+ * Usage:
+ *   # Sims (run first — CLAUDE.md requires PASS before broadcast)
+ *   FOUNDRY_PROFILE=production forge script \
+ *     script/fixes/WhitelistUnclaimTaskRulesViaGovernance.s.sol:SimWhitelistUnclaimTest6 \
+ *     --fork-url gnosis -vvv
+ *   ... :SimWhitelistUnclaimKubi          --fork-url gnosis   -vvv
+ *   ... :SimWhitelistUnclaimDecentralPark --fork-url gnosis   -vvv
+ *   ... :SimWhitelistUnclaimPoa           --fork-url arbitrum -vvv
+ *
+ *   # Broadcasts (each creates its org's proposal AND votes)
+ *   source .env && FOUNDRY_PROFILE=production forge script \
+ *     script/fixes/WhitelistUnclaimTaskRulesViaGovernance.s.sol:BroadcastWhitelistUnclaimTest6 \
+ *     --rpc-url gnosis --broadcast --slow
+ *   ... :BroadcastWhitelistUnclaimKubi          --rpc-url gnosis   --broadcast --slow
+ *   ... :BroadcastWhitelistUnclaimDecentralPark --rpc-url gnosis   --broadcast --slow
+ *   ... :BroadcastWhitelistUnclaimPoa           --rpc-url arbitrum --broadcast --slow
+ *
+ * After the voting window closes, execute with an EXPLICIT gas limit — announceWinner
+ * wraps the batch in try/catch, so estimation prices only the cheap caught-failure path
+ * and the call silently no-ops (see CLAUDE.md):
+ *   cast send <HV> 'announceWinner(uint256)' <id> --gas-limit 3000000 --rpc-url <chain>
+ *
+ * Optional env override:
+ *   PROPOSAL_DURATION — voting window in minutes (default 10 = HybridVoting min)
+ * ============================================================================
+ */
+
+// PaymasterHubs.
+address constant GNOSIS_PAYMASTER_HUB = 0xdEf1038C297493c0b5f82F0CDB49e929B53B4108;
+address constant ARB_PAYMASTER_HUB = 0xD6659bCaFAdCB9CC2F57B7aE923c7F1Ca4438a11;
+
+// Test6 (Gnosis).
+bytes32 constant TEST6_ORG = 0x263b2b29f392647f0fb8ddbb26f099e812ab4ba2777e5e07b906277164181f6b;
+address constant TEST6_TM = 0x3d93f0D090356D25E7a1614F0F8764b103ca99bc;
+address constant TEST6_HV = 0xF642DdE77848dC195c8089F4042A311Ed650d7a6;
+
+// KUBI (Gnosis).
+bytes32 constant KUBI_ORG = 0xc0f2765d555e21bfad5c6b05accef86a5758e0dee3e9a5b4ee3c3f3069c2102e;
+address constant KUBI_TM = 0xF57024fC77915Fce8f2608afdd027941bCEE3336;
+address constant KUBI_HV = 0x13CBd5eD47bF177968B24D84516a75879c23971E;
+
+// Decentral Park (Gnosis).
+bytes32 constant DECENTRAL_PARK_ORG = 0x3721271eb827a52a5adf676136d302efe19c34e72f08e080b07b225eecf27d78;
+address constant DECENTRAL_PARK_TM = 0x2D9d397A842B8D691ea2A232062CbC8eF8eBbdB7;
+address constant DECENTRAL_PARK_HV = 0x1B80CA1EF7F274E141658A666fc12277957bF7A1;
+
+// Poa (Arbitrum).
+bytes32 constant POA_ORG = 0xa71879ef0e38b15fe7080196c0102f859e0ca8e7b8c0703ec8df03c66befd069;
+address constant POA_TM = 0x681f29751724D2bED331d3EB35e0C9B1C57aF9F0;
+address constant POA_HV = 0x34aa1bD79a3A5eb5d2B208eb4f091ccF6B1081d5;
+
+// TaskManager v7 selector (cast sig "unclaimTask(uint256)").
+bytes4 constant SEL_UNCLAIM_TASK = 0x6103955a;
+
+// Hudson — verified creator-hat wearer on every org's HybridVoting (see the deadline twins).
+address constant HUDSON = 0xA6F4D9f44Dd980b7168D829d5f74c2b00a46b2c9;
+
+uint32 constant DEFAULT_PROPOSAL_DURATION_MINUTES = 10;
+
+interface IPaymasterHubMinimal {
+    // Field order matches PaymasterHub.sol's Rule struct exactly: (uint32 maxCallGasHint, bool allowed).
+    struct Rule {
+        uint32 maxCallGasHint;
+        bool allowed;
+    }
+
+    function setRulesBatch(
+        bytes32 orgId,
+        address[] calldata targets,
+        bytes4[] calldata selectors,
+        bool[] calldata allowed,
+        uint32[] calldata maxCallGasHints
+    ) external;
+
+    function getRule(bytes32 orgId, address target, bytes4 selector) external view returns (Rule memory);
+}
+
+interface IHatsMinimal {
+    function balanceOf(address user, uint256 hatId) external view returns (uint256);
+}
+
+interface ITaskManagerLensMinimal {
+    function getLensData(uint8 t, bytes calldata d) external view returns (bytes memory);
+}
+
+abstract contract WhitelistUnclaimBase is Script {
+    function _hub() internal pure virtual returns (address);
+
+    function _resolveDuration() internal view returns (uint32) {
+        return uint32(vm.envOr("PROPOSAL_DURATION", uint256(DEFAULT_PROPOSAL_DURATION_MINUTES)));
+    }
+
+    function _resolveKey() internal view returns (uint256 key) {
+        key = vm.envOr("PRIVATE_KEY", uint256(0));
+        if (key == 0) key = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    }
+
+    function _buildBatch(bytes32 orgId, address tm) internal pure returns (IExecutor.Call[] memory batch) {
+        address[] memory targets = new address[](1);
+        bytes4[] memory selectors = new bytes4[](1);
+        bool[] memory allowed = new bool[](1);
+        uint32[] memory hints = new uint32[](1);
+
+        targets[0] = tm;
+        selectors[0] = SEL_UNCLAIM_TASK;
+        allowed[0] = true;
+        // hints[0] stays 0 — see the header note on the accountGasLimits unpack bug.
+
+        batch = new IExecutor.Call[](1);
+        batch[0] = IExecutor.Call({
+            target: _hub(),
+            value: 0,
+            data: abi.encodeCall(IPaymasterHubMinimal.setRulesBatch, (orgId, targets, selectors, allowed, hints))
+        });
+    }
+
+    function _ruleAllowed(bytes32 orgId, address tm, bytes4 selector) internal view returns (bool) {
+        return IPaymasterHubMinimal(_hub()).getRule(orgId, tm, selector).allowed;
+    }
+
+    function _ballot() internal pure returns (uint8[] memory idxs, uint8[] memory weights) {
+        idxs = new uint8[](1);
+        weights = new uint8[](1);
+        idxs[0] = 0;
+        weights[0] = 100;
+    }
+
+    /// @dev Guards against whitelisting a selector the org's beacon cannot serve. A live v7
+    ///      impl reverts BadStatus() on task id 0 (not CLAIMED); a pre-v7 impl reverts with
+    ///      EMPTY data (no such function), which is what this distinguishes.
+    function _requireV7(address tm) internal view {
+        (bool ok, bytes memory ret) = tm.staticcall(abi.encodeWithSelector(SEL_UNCLAIM_TASK, uint256(0)));
+        require(!ok, "unclaimTask(0) unexpectedly succeeded");
+        require(ret.length >= 4, "TaskManager is not v7 (unclaimTask missing) - upgrade the beacon first");
+    }
+
+    function _printPreview(string memory name, bytes32 orgId, address tm) internal view {
+        console.log("\n=== v7 unclaimTask paymaster rule preview:", name, "===");
+        console.log("  PaymasterHub:        ", _hub());
+        console.log("  TaskManager (target):", tm);
+        console.log("  unclaimTask allowed now:", _ruleAllowed(orgId, tm, SEL_UNCLAIM_TASK));
+        console.log("  -> will be allowed (additive; nothing is disallowed)");
+    }
+
+    /// @dev Full sim (real Hats, prank Hudson): create -> vote -> warp -> announceWinner -> assert.
+    function _simFlow(string memory name, bytes32 orgId, address tm, address hv) internal {
+        _requireV7(tm);
+        _printPreview(name, orgId, tm);
+        require(!_ruleAllowed(orgId, tm, SEL_UNCLAIM_TASK), "Sim: unclaimTask already allowed (nothing to prove)");
+
+        IExecutor.Call[][] memory batches = new IExecutor.Call[][](1);
+        batches[0] = _buildBatch(orgId, tm);
+
+        uint32 minutesDuration = 10;
+        vm.prank(HUDSON);
+        HybridVoting(hv)
+            .createProposal(
+                bytes("Paymaster rule for TaskManager v7 unclaimTask (sim)"),
+                bytes32(0),
+                minutesDuration,
+                1,
+                batches,
+                new uint256[](0)
+            );
+        uint256 proposalId = HybridVoting(hv).proposalsCount() - 1;
+        console.log("  Proposal id:", proposalId);
+
+        (uint8[] memory idxs, uint8[] memory weights) = _ballot();
+        vm.prank(HUDSON);
+        HybridVoting(hv).vote(proposalId, idxs, weights);
+
+        vm.warp(vm.getBlockTimestamp() + uint256(minutesDuration) * 60 + 10);
+        (uint256 winner, bool valid) = HybridVoting(hv).announceWinner(proposalId);
+        require(valid, "Sim: proposal did not pass with the creator's single vote");
+        console.log("  Winner option:", winner, " valid:", valid);
+
+        require(_ruleAllowed(orgId, tm, SEL_UNCLAIM_TASK), "Sim: unclaimTask still not allowed after execution");
+        console.log("PASS:", name, "unclaimTask 0x6103955a is now sponsored.");
+    }
+
+    /// @dev Broadcast: create the proposal AND cast the creator's vote, in one signed session.
+    function _broadcastCreateAndVote(uint256 key, string memory name, bytes32 orgId, address tm, address hv) internal {
+        address sender = vm.addr(key);
+        uint32 minutesDuration = _resolveDuration();
+
+        _requireV7(tm);
+
+        console.log("\n=== Broadcasting", name, "v7 unclaimTask rule proposal + vote ===");
+        console.log("  Sender:       ", sender);
+        console.log("  HybridVoting: ", hv);
+        console.log("  Duration:     ", minutesDuration, "minutes");
+        _printPreview(name, orgId, tm);
+
+        // Sanity: sender must wear a creator hat or createProposal reverts.
+        IHatsMinimal hats = IHatsMinimal(abi.decode(ITaskManagerLensMinimal(tm).getLensData(3, ""), (address)));
+        uint256[] memory creatorHats = HybridVoting(hv).creatorHats();
+        bool isCreator = false;
+        for (uint256 i; i < creatorHats.length; ++i) {
+            if (hats.balanceOf(sender, creatorHats[i]) > 0) {
+                isCreator = true;
+                break;
+            }
+        }
+        require(isCreator, "Sender wears no creator hat on this org's HybridVoting");
+
+        IExecutor.Call[][] memory batches = new IExecutor.Call[][](1);
+        batches[0] = _buildBatch(orgId, tm);
+
+        (uint8[] memory idxs, uint8[] memory weights) = _ballot();
+
+        vm.startBroadcast(key);
+        HybridVoting(hv)
+            .createProposal(
+                bytes("Paymaster rule for TaskManager v7 unclaimTask"),
+                bytes32(0),
+                minutesDuration,
+                1,
+                batches,
+                new uint256[](0)
+            );
+        uint256 proposalId = HybridVoting(hv).proposalsCount() - 1;
+        HybridVoting(hv).vote(proposalId, idxs, weights);
+        vm.stopBroadcast();
+
+        console.log("  Proposal ID:", proposalId, "(vote cast)");
+        console.log("  After the window expires, execute it with an EXPLICIT gas limit:");
+        console.log("    cast send <HV> 'announceWinner(uint256)' <id> --gas-limit 3000000");
+    }
+}
+
+abstract contract WhitelistUnclaimGnosisBase is WhitelistUnclaimBase {
+    function _hub() internal pure override returns (address) {
+        return GNOSIS_PAYMASTER_HUB;
+    }
+}
+
+abstract contract WhitelistUnclaimArbitrumBase is WhitelistUnclaimBase {
+    function _hub() internal pure override returns (address) {
+        return ARB_PAYMASTER_HUB;
+    }
+}
+
+contract SimWhitelistUnclaimTest6 is WhitelistUnclaimGnosisBase {
+    function run() public {
+        _simFlow("Test6", TEST6_ORG, TEST6_TM, TEST6_HV);
+    }
+}
+
+contract BroadcastWhitelistUnclaimTest6 is WhitelistUnclaimGnosisBase {
+    function run() public {
+        _broadcastCreateAndVote(_resolveKey(), "Test6", TEST6_ORG, TEST6_TM, TEST6_HV);
+    }
+}
+
+contract SimWhitelistUnclaimKubi is WhitelistUnclaimGnosisBase {
+    function run() public {
+        _simFlow("KUBI", KUBI_ORG, KUBI_TM, KUBI_HV);
+    }
+}
+
+contract BroadcastWhitelistUnclaimKubi is WhitelistUnclaimGnosisBase {
+    function run() public {
+        _broadcastCreateAndVote(_resolveKey(), "KUBI", KUBI_ORG, KUBI_TM, KUBI_HV);
+    }
+}
+
+contract SimWhitelistUnclaimDecentralPark is WhitelistUnclaimGnosisBase {
+    function run() public {
+        _simFlow("Decentral Park", DECENTRAL_PARK_ORG, DECENTRAL_PARK_TM, DECENTRAL_PARK_HV);
+    }
+}
+
+contract BroadcastWhitelistUnclaimDecentralPark is WhitelistUnclaimGnosisBase {
+    function run() public {
+        _broadcastCreateAndVote(
+            _resolveKey(), "Decentral Park", DECENTRAL_PARK_ORG, DECENTRAL_PARK_TM, DECENTRAL_PARK_HV
+        );
+    }
+}
+
+contract SimWhitelistUnclaimPoa is WhitelistUnclaimArbitrumBase {
+    function run() public {
+        _simFlow("Poa", POA_ORG, POA_TM, POA_HV);
+    }
+}
+
+contract BroadcastWhitelistUnclaimPoa is WhitelistUnclaimArbitrumBase {
+    function run() public {
+        _broadcastCreateAndVote(_resolveKey(), "Poa", POA_ORG, POA_TM, POA_HV);
+    }
+}

--- a/script/upgrades/UpgradeOrgDeployerUnclaimRule.s.sol
+++ b/script/upgrades/UpgradeOrgDeployerUnclaimRule.s.sol
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import {OrgDeployer} from "../../src/OrgDeployer.sol";
+import {PoaManagerHub} from "../../src/crosschain/PoaManagerHub.sol";
+import {PoaManager} from "../../src/PoaManager.sol";
+import {DeterministicDeployer} from "../../src/crosschain/DeterministicDeployer.sol";
+
+/*
+ * ============================================================================
+ * OrgDeployer v18 — unclaimTask in the default paymaster whitelist
+ * ============================================================================
+ *
+ * TaskManager v7 adds unclaimTask(uint256) = 0x6103955a. It was not in the default
+ * ruleset deployFullOrg emits, so a new org's passkey/smart accounts could not call
+ * it with gas sponsorship. This adds it to _appendTaskManagerRules (TaskManager rule
+ * count 16 -> 17, base count 43 -> 44).
+ *
+ *   Live impl: v17 (0xab8124C986Cf056dA23184913FA73352c8695615, both chains)
+ *   This PR:   v18
+ *
+ * Version selection (CLAUDE.md recipe, both surfaces, both chains, 2026-07-31):
+ *   Gnosis   registry count=15; v16/v17 TAKEN (registry+CREATE2); v18 FREE on both.
+ *   Arbitrum registry count=16; v17 TAKEN (registry+CREATE2); v18 FREE on both.
+ *   Predicted v18 impl (identical on both chains): 0xE328c6093e53cBafea8d4461e9bd4345786decC9
+ *
+ * Forward-only: existing orgs already have their rules and are unaffected by an
+ * OrgDeployer upgrade. They need the separate per-org governance batch to add the
+ * new selector. Sequence this AFTER TaskManager v7 so a new org never gets a rule
+ * pointing at a selector its impl does not implement.
+ *
+ * Sim first (CLAUDE.md requires PASS before broadcast):
+ *   FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeOrgDeployerUnclaimRule.s.sol:SimulateOrgDeployerUnclaimRuleUpgrade \
+ *     --fork-url arbitrum -vvv
+ *
+ * Broadcast:
+ *   source .env && FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeOrgDeployerUnclaimRule.s.sol:Step1_DeployImplOnGnosis \
+ *     --rpc-url gnosis --broadcast --slow
+ *   source .env && FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeOrgDeployerUnclaimRule.s.sol:Step2_UpgradeFromArbitrum \
+ *     --rpc-url arbitrum --broadcast --slow
+ *   forge script script/upgrades/UpgradeOrgDeployerUnclaimRule.s.sol:Step3_Verify --rpc-url gnosis
+ * ============================================================================
+ */
+
+address constant DD = 0x4aC8B5ebEb9D8C3dE3180ddF381D552d59e8835a;
+address constant HUB = 0xB72840B343654eAfb2CFf7acC4Fc6b59E6c3CC71;
+address constant GNOSIS_POA_MANAGER = 0x794fD39e75140ee1545B1B022E5486B7c863789b;
+uint256 constant HYPERLANE_FEE = 0.005 ether;
+// Hudson — owner of PoaManagerHub + DeterministicDeployer (pranked in the sim).
+address constant HUDSON_ADMIN = 0xA6F4D9f44Dd980b7168D829d5f74c2b00a46b2c9;
+string constant VERSION = "v18";
+
+// The selector this upgrade adds (cast sig "unclaimTask(uint256)"); documented for the
+// per-org governance batches that back-fill it on already-deployed orgs.
+bytes4 constant SEL_UNCLAIM_TASK = 0x6103955a;
+
+contract Step1_DeployImplOnGnosis is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+
+        bytes32 salt = dd.computeSalt("OrgDeployer", VERSION);
+        address predicted = dd.computeAddress(salt);
+        console.log("\n=== Step 1: Deploy OrgDeployer v18 on Gnosis ===");
+        console.log("Predicted:", predicted);
+
+        if (predicted.code.length > 0) {
+            console.log("Already deployed. Skipping.");
+            return;
+        }
+
+        vm.startBroadcast(deployerKey);
+        address deployed = dd.deploy(salt, type(OrgDeployer).creationCode);
+        vm.stopBroadcast();
+
+        require(deployed == predicted, "Address mismatch");
+        console.log("Deployed:", deployed);
+        console.log("\nNext: Run Step2_UpgradeFromArbitrum on Arbitrum");
+    }
+}
+
+contract Step2_UpgradeFromArbitrum is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        address deployer = vm.addr(deployerKey);
+
+        PoaManagerHub hub = PoaManagerHub(payable(HUB));
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+
+        console.log("\n=== Step 2: Upgrade OrgDeployer to v18 from Arbitrum ===");
+        require(hub.owner() == deployer, "Deployer must own Hub");
+        require(!hub.paused(), "Hub is paused");
+
+        bytes32 salt = dd.computeSalt("OrgDeployer", VERSION);
+        address impl = dd.computeAddress(salt);
+        console.log("OrgDeployer v18 impl:", impl);
+
+        vm.startBroadcast(deployerKey);
+
+        if (impl.code.length == 0) {
+            address deployed = dd.deploy(salt, type(OrgDeployer).creationCode);
+            require(deployed == impl, "Address mismatch on Arbitrum");
+            console.log("Deployed on Arbitrum");
+        } else {
+            console.log("Already deployed on Arbitrum");
+        }
+
+        hub.upgradeBeaconCrossChain{value: HYPERLANE_FEE}("OrgDeployer", impl, VERSION);
+        console.log("Beacon upgrade dispatched (Arbitrum local + Gnosis cross-chain)");
+
+        vm.stopBroadcast();
+
+        address pm = address(hub.poaManager());
+        address current = PoaManager(pm).getCurrentImplementationById(keccak256("OrgDeployer"));
+        require(current == impl, "Arbitrum impl not upgraded");
+        console.log("Arbitrum upgrade: PASS");
+        console.log("\nWait ~5 min for Hyperlane relay, then run Step3_Verify on Gnosis");
+    }
+}
+
+contract Step3_Verify is Script {
+    function run() public view {
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+        address expected = dd.computeAddress(dd.computeSalt("OrgDeployer", VERSION));
+        address current = PoaManager(GNOSIS_POA_MANAGER).getCurrentImplementationById(keccak256("OrgDeployer"));
+
+        console.log("\n=== Verify Gnosis OrgDeployer Upgrade ===");
+        console.log("Expected:", expected);
+        console.log("Current: ", current);
+        if (current == expected) {
+            console.log("PASS: OrgDeployer v18 live on Gnosis");
+            console.log("New orgs now auto-whitelist unclaimTask(uint256) 0x6103955a");
+        } else {
+            console.log("WAITING: Hyperlane message not yet relayed.");
+        }
+    }
+}
+
+/**
+ * @title SimulateOrgDeployerUnclaimRuleUpgrade
+ * @notice Fork-sims the upgrade end-to-end on Arbitrum: deploys v18 via DD (prank
+ *         Hudson — no env needed), calls upgradeBeaconCrossChain, and verifies the
+ *         Arbitrum beacon impl switched to bytecode identical to this branch's build.
+ *         Gnosis relay isn't fork-simulatable; Step3 verifies it after broadcast.
+ *
+ *         Behavior verification (the rule really lands in the default batch) is
+ *         covered by test/DeployerTest.t.sol — testDeployFullOrgWithPaymasterAutoWhitelist
+ *         and testDeployFullOrgAutoWhitelistNoEducation both assert
+ *         getRule(orgId, taskManager, unclaimTask).allowed (education on and off, since
+ *         educationEnabled changes the rule-array sizing), and testPaymasterSelectorAccuracy
+ *         pins the signature string to the real selector.
+ */
+contract SimulateOrgDeployerUnclaimRuleUpgrade is Script {
+    function run() public {
+        PoaManagerHub hub = PoaManagerHub(payable(HUB));
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+        address pm = address(hub.poaManager());
+
+        console.log("\n=== SIM: OrgDeployer v18 upgrade (Arbitrum fork) ===");
+        console.log("Adds TaskManager unclaimTask(uint256) 0x6103955a to the default rule batch");
+
+        address before = PoaManager(pm).getCurrentImplementationById(keccak256("OrgDeployer"));
+        console.log("Current impl:", before);
+
+        bytes32 salt = dd.computeSalt("OrgDeployer", VERSION);
+        address predicted = dd.computeAddress(salt);
+        console.log("Predicted v18:", predicted);
+        require(before != predicted, "Sim: v18 already live (nothing to upgrade)");
+
+        vm.deal(HUDSON_ADMIN, 1 ether);
+        vm.startPrank(HUDSON_ADMIN);
+
+        if (predicted.code.length == 0) {
+            address deployed = dd.deploy(salt, type(OrgDeployer).creationCode);
+            require(deployed == predicted, "Address mismatch");
+            console.log("v18 deployed at:", deployed);
+        }
+
+        hub.upgradeBeaconCrossChain{value: HYPERLANE_FEE}("OrgDeployer", predicted, VERSION);
+
+        vm.stopPrank();
+
+        address after_ = PoaManager(pm).getCurrentImplementationById(keccak256("OrgDeployer"));
+        console.log("New impl:", after_);
+        require(after_ == predicted, "Upgrade failed");
+        require(after_.code.length > 0, "Impl has no code");
+        console.log("New impl codesize:", after_.code.length, "bytes");
+
+        // The impl on the fork must be byte-identical to this branch's build — that is what
+        // ties the deploy to the code DeployerTest verified behaviorally.
+        //
+        // Do NOT "improve" this into a grep for SEL_UNCLAIM_TASK in the bytecode: the rule
+        // selectors are keccak-of-string-literal constants that the optimizer folds and then
+        // materializes arithmetically, so most of them (including this one) never appear as a
+        // literal 4-byte sequence. Verified on this build: 9 of the 12 TaskManager rule
+        // selectors are absent from the runtime code even though every rule is emitted.
+        // (The grep IS valid on TaskManager itself, where selectors are dispatch-table entries.)
+        require(keccak256(after_.code) == keccak256(type(OrgDeployer).runtimeCode), "Sim: impl != this branch's build");
+        console.log("Impl bytecode matches this branch's OrgDeployer build");
+
+        console.log("\nArbitrum upgrade simulation: PASS");
+        console.log(
+            "Behavior: DeployerTest.testDeployFullOrgWithPaymasterAutoWhitelist (+NoEducation) assert the rule auto-sets."
+        );
+    }
+}

--- a/script/upgrades/UpgradeTaskManagerUnclaim.s.sol
+++ b/script/upgrades/UpgradeTaskManagerUnclaim.s.sol
@@ -1,0 +1,462 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import {TaskManager} from "../../src/TaskManager.sol";
+import {PoaManagerHub} from "../../src/crosschain/PoaManagerHub.sol";
+import {PoaManager} from "../../src/PoaManager.sol";
+import {DeterministicDeployer} from "../../src/crosschain/DeterministicDeployer.sol";
+
+/*
+ * ============================================================================
+ * TaskManager v7 — unclaimTask (release a claimed task back to the pool)
+ * ============================================================================
+ *
+ * ADDITIVE ONLY. New external `unclaimTask(uint256)` (0x6103955a) + new event
+ * TaskUnclaimed(uint256 indexed,address indexed,address indexed). No Layout change,
+ * no Task field, no Status member, no existing selector touched — v6 callers are
+ * unaffected and the frontend/subgraph can ship after this lands.
+ *
+ * Semantics: CLAIMED -> UNCLAIMED, claimer zeroed, claimDeadline cleared.
+ *   - the claimer may always release (no permission check);
+ *   - anyone else needs ASSIGN on the project AND an expired claim (assignTask's
+ *     takeover gate with no replacement claimer named).
+ * SUBMITTED is excluded; budgets and application hashes are untouched.
+ *
+ *   Live impl: v6 (0x7833c4670C42dbCe1a7aB1BAB7e7Baf0A982ff57, both chains)
+ *   This PR:   v7
+ *
+ * Version selection (CLAUDE.md recipe, both surfaces, both chains, 2026-07-31):
+ *   Gnosis   registry count=5; v6 TAKEN (registry+CREATE2); v7 FREE on both.
+ *   Arbitrum registry count=5; v6 TAKEN (registry+CREATE2); v7 FREE on both.
+ *   Predicted v7 impl (identical on both chains): 0xcfAe1DAdF1A48b363aAD3BbB8f94f67bb3785988
+ *
+ * Existing orgs also need the paymaster rule for the new selector (separate
+ * per-org governance batch); OrgDeployer v18 covers NEW orgs.
+ *
+ * Sim first (CLAUDE.md requires PASS before broadcast):
+ *   FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeTaskManagerUnclaim.s.sol:DryRun_GnosisUpgrade --fork-url gnosis -vvv
+ *   FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeTaskManagerUnclaim.s.sol:DryRun_ArbitrumUpgrade --fork-url arbitrum -vvv
+ *
+ * Broadcast:
+ *   source .env && FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeTaskManagerUnclaim.s.sol:Step1_DeployImplOnGnosis \
+ *     --rpc-url gnosis --broadcast --slow
+ *   source .env && FOUNDRY_PROFILE=production forge script \
+ *     script/upgrades/UpgradeTaskManagerUnclaim.s.sol:Step2_UpgradeFromArbitrum \
+ *     --rpc-url arbitrum --broadcast --slow
+ *   forge script script/upgrades/UpgradeTaskManagerUnclaim.s.sol:Step3_VerifyGnosis --rpc-url gnosis
+ * ============================================================================
+ */
+
+address constant DD = 0x4aC8B5ebEb9D8C3dE3180ddF381D552d59e8835a;
+address constant HUB = 0xB72840B343654eAfb2CFf7acC4Fc6b59E6c3CC71;
+address constant GNOSIS_POA_MANAGER = 0x794fD39e75140ee1545B1B022E5486B7c863789b;
+address constant ARBITRUM_POA_MANAGER = 0xFF585Fae4A944cD173B19158C6FC5E08980b0815;
+uint256 constant HYPERLANE_FEE = 0.005 ether;
+// Hudson — owner of PoaManagerHub (Arbitrum), PoaManagerSatellite (Gnosis), DeterministicDeployer.
+address constant HUDSON_ADMIN = 0xA6F4D9f44Dd980b7168D829d5f74c2b00a46b2c9;
+// PoaManagerSatellite on Gnosis — owner of the Gnosis PoaManager; the real caller post-relay.
+address constant GNOSIS_SATELLITE = 0x4Ad70029a9247D369a5bEA92f90840B9ee58eD06;
+string constant VERSION = "v7";
+
+contract Step1_DeployImplOnGnosis is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+
+        bytes32 salt = dd.computeSalt("TaskManager", VERSION);
+        address predicted = dd.computeAddress(salt);
+        console.log("\n=== Step 1: Deploy TaskManager v7 impl on Gnosis ===");
+        console.log("Predicted:", predicted);
+
+        if (predicted.code.length > 0) {
+            console.log("Already deployed. Skipping.");
+            return;
+        }
+
+        vm.startBroadcast(deployerKey);
+        address deployed = dd.deploy(salt, type(TaskManager).creationCode);
+        vm.stopBroadcast();
+
+        require(deployed == predicted, "Address mismatch");
+        console.log("Deployed:", deployed);
+        console.log("\nNext: Run Step2_UpgradeFromArbitrum on Arbitrum");
+    }
+}
+
+contract Step2_UpgradeFromArbitrum is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        address deployer = vm.addr(deployerKey);
+
+        PoaManagerHub hub = PoaManagerHub(payable(HUB));
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+
+        require(hub.owner() == deployer, "Deployer must own Hub");
+        require(!hub.paused(), "Hub is paused");
+
+        bytes32 salt = dd.computeSalt("TaskManager", VERSION);
+        address predicted = dd.computeAddress(salt);
+        console.log("\n=== Step 2: Upgrade TaskManager to v7 from Arbitrum ===");
+        console.log("DD impl address:", predicted);
+
+        vm.startBroadcast(deployerKey);
+
+        if (predicted.code.length == 0) {
+            dd.deploy(salt, type(TaskManager).creationCode);
+            console.log("Deployed on Arbitrum");
+        } else {
+            console.log("Already deployed on Arbitrum");
+        }
+
+        hub.upgradeBeaconCrossChain{value: HYPERLANE_FEE}("TaskManager", predicted, VERSION);
+        console.log("Beacon upgraded cross-chain");
+
+        vm.stopBroadcast();
+        console.log("\nWait ~5 min for Hyperlane relay, then run Step3 on Gnosis.");
+    }
+}
+
+contract Step3_VerifyGnosis is Script {
+    function run() public view {
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+        address expectedImpl = dd.computeAddress(dd.computeSalt("TaskManager", VERSION));
+        address currentImpl = PoaManager(GNOSIS_POA_MANAGER).getCurrentImplementationById(keccak256("TaskManager"));
+
+        console.log("\n=== Step 3: Verify Gnosis TaskManager v7 Upgrade ===");
+        console.log("Expected impl:", expectedImpl);
+        console.log("Current impl: ", currentImpl);
+
+        if (currentImpl == expectedImpl) {
+            console.log("PASS: TaskManager upgraded to v7 on Gnosis");
+            console.log("  unclaimTask(uint256) 0x6103955a is live");
+            console.log("  NOTE: existing orgs still need the paymaster rule for that selector.");
+        } else {
+            console.log("WAITING: Hyperlane message not yet relayed.");
+        }
+    }
+}
+
+interface IOrgRegistry {
+    function orgIds(uint256 index) external view returns (bytes32);
+    function proxyOf(bytes32 orgId, bytes32 typeId) external view returns (address);
+}
+
+/**
+ * @title UnclaimDryRunBase
+ * @notice Fork-sim: deploy v7 via DD (prank Hudson), upgrade the chain's beacon, then
+ *         exercise unclaimTask against a LIVE TaskManager proxy.
+ *
+ *         Asserts: DD address match; beacon switch; unclaimTask selector present in the
+ *         impl bytecode; storage preserved; then on the live proxy — self-release clears
+ *         status/claimer/claimDeadline, budgets unchanged, re-claim works, a live claim
+ *         is protected from a third party, an expired one is releasable by ASSIGN, a
+ *         SUBMITTED task is never releasable, and cancelTask refunds exactly once.
+ */
+abstract contract UnclaimDryRunBase is Script {
+    address constant ORG_REGISTRY = 0x3744b372abc41589226313F2bB1dB3aCAa22A854;
+
+    function _poaManager() internal pure virtual returns (address);
+    function _upgradeBeacon(address newImpl) internal virtual;
+    function _chainName() internal pure virtual returns (string memory);
+    function _liveProxy() internal view virtual returns (address);
+
+    function run() public {
+        console.log("\n=== DRY RUN: TaskManager v7 (unclaimTask) on", _chainName(), "fork ===\n");
+
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+        PoaManager pm = PoaManager(_poaManager());
+
+        address implBefore = pm.getCurrentImplementationById(keccak256("TaskManager"));
+        console.log("Impl before:", implBefore);
+
+        bytes32 salt = dd.computeSalt("TaskManager", VERSION);
+        address predicted = dd.computeAddress(salt);
+        console.log("DD predicted impl:", predicted);
+        require(implBefore != predicted, "DryRun: v7 already live (nothing to upgrade)");
+
+        address deployed;
+        if (predicted.code.length == 0) {
+            vm.prank(HUDSON_ADMIN);
+            deployed = dd.deploy(salt, type(TaskManager).creationCode);
+        } else {
+            console.log("Already deployed at predicted (skipping deploy)");
+            deployed = predicted;
+        }
+        require(deployed == predicted, "DryRun: DD address mismatch");
+        require(deployed.code.length > 0, "DryRun: impl code missing");
+        console.log("Deployed impl:", deployed);
+
+        _upgradeBeacon(deployed);
+        address implAfter = pm.getCurrentImplementationById(keccak256("TaskManager"));
+        require(implAfter == deployed, "DryRun: beacon upgrade did not stick");
+        console.log("Impl after :", implAfter);
+
+        require(_hasSelector(deployed, TaskManager.unclaimTask.selector), "DryRun: unclaimTask selector missing");
+        console.log("unclaimTask selector present in impl bytecode");
+
+        _exerciseLiveProxy();
+
+        console.log("\n=== ALL DRY-RUN CHECKS PASSED ===");
+        console.log("Safe to broadcast Step1/Step2/Step3 against mainnet.");
+    }
+
+    function _exerciseLiveProxy() internal {
+        address proxy = _liveProxy();
+        require(proxy != address(0), "DryRun: no TaskManager proxy to exercise");
+        TaskManager tm = TaskManager(proxy);
+
+        console.log("\n--- Live-proxy exercise ---");
+        console.log("TaskManager proxy:", proxy);
+
+        // Storage preservation across the impl swap.
+        address executor = abi.decode(tm.getLensData(4, ""), (address));
+        require(executor != address(0), "DryRun: executor unset post-upgrade (storage drift?)");
+        console.log("Executor (preserved):", executor);
+
+        bytes32 pid = _freshProject(tm, executor);
+        uint32 window = 3 days;
+        address workerA = makeAddr("dryrun-worker-a");
+
+        _checkSelfRelease(tm, proxy, pid, executor, window, workerA);
+        _checkThirdPartyRelease(tm, proxy, pid, executor, window, workerA);
+        _checkSubmittedNeverReleasable(tm, proxy, pid, executor, window, workerA);
+        _checkCancelAfterRelease(tm, proxy, pid, executor, window, workerA);
+    }
+
+    function _freshProject(TaskManager tm, address executor) internal returns (bytes32 pid) {
+        TaskManager.BootstrapProjectConfig memory cfg = TaskManager.BootstrapProjectConfig({
+            title: bytes("dryrun-unclaim"),
+            metadataHash: bytes32(0),
+            cap: 0,
+            managers: new address[](0),
+            createHats: new uint256[](0),
+            claimHats: new uint256[](0),
+            reviewHats: new uint256[](0),
+            assignHats: new uint256[](0),
+            bountyTokens: new address[](0),
+            bountyCaps: new uint256[](0)
+        });
+        vm.prank(executor);
+        pid = tm.createProject(cfg);
+        console.log("Test project pid:", vm.toString(pid));
+    }
+
+    /// @dev The assignee holds no hat at all, so this also proves the release is identity-gated.
+    function _checkSelfRelease(
+        TaskManager tm,
+        address proxy,
+        bytes32 pid,
+        address executor,
+        uint32 window,
+        address worker
+    ) internal {
+        uint256 id = _nextAvailableTaskId(proxy);
+        uint128 spentBefore = _projectSpent(tm, pid);
+
+        vm.prank(executor);
+        tm.createTask(1 ether, bytes("self-release"), bytes32(0), pid, address(0), 0, false, 0, window);
+        vm.prank(executor);
+        tm.assignTask(id, worker);
+
+        (address claimer,, uint48 cd,,) = _readTask(tm, id);
+        require(claimer == worker, "DryRun: assignee wrong");
+        require(cd == uint48(vm.getBlockTimestamp()) + window, "DryRun: window not started");
+
+        vm.prank(worker);
+        tm.unclaimTask(id);
+
+        (address claimerAfter, TaskManager.Status st, uint48 cdAfter, uint48 abs_, uint32 win_) = _readTask(tm, id);
+        require(st == TaskManager.Status.UNCLAIMED, "DryRun: status not UNCLAIMED after release");
+        require(claimerAfter == address(0), "DryRun: claimer not cleared");
+        require(cdAfter == 0, "DryRun: claimDeadline not cleared");
+        require(abs_ == 0 && win_ == window, "DryRun: task deadline config must survive the release");
+        require(_projectSpent(tm, pid) == spentBefore + 1 ether, "DryRun: release must not refund the budget");
+        console.log("Self-release OK (status/claimer/claimDeadline cleared, budget held)");
+
+        // ...and the task is genuinely back in the pool.
+        vm.prank(executor);
+        tm.assignTask(id, worker);
+        (address reclaimed,, uint48 cdNew,,) = _readTask(tm, id);
+        require(reclaimed == worker, "DryRun: released task not re-assignable");
+        require(cdNew == uint48(vm.getBlockTimestamp()) + window, "DryRun: re-assign did not restart the window");
+        console.log("Re-assignment after release OK (fresh window)");
+    }
+
+    function _checkThirdPartyRelease(
+        TaskManager tm,
+        address proxy,
+        bytes32 pid,
+        address executor,
+        uint32 window,
+        address worker
+    ) internal {
+        uint256 id = _nextAvailableTaskId(proxy);
+        vm.prank(executor);
+        tm.createTask(1 ether, bytes("third-party"), bytes32(0), pid, address(0), 0, false, 0, window);
+        vm.prank(executor);
+        tm.assignTask(id, worker);
+        (,, uint48 cd,,) = _readTask(tm, id);
+
+        // Protected right up to and including the deadline second.
+        vm.warp(uint256(cd));
+        vm.prank(executor); // executor carries the PM bypass, i.e. ASSIGN
+        (bool okEarly,) = proxy.call(abi.encodeCall(TaskManager.unclaimTask, (id)));
+        require(!okEarly, "DryRun: a live claim must not be releasable by a third party");
+
+        // A stranger is rejected even after expiry.
+        vm.warp(uint256(cd) + 1);
+        vm.prank(makeAddr("dryrun-stranger"));
+        (bool okStranger,) = proxy.call(abi.encodeCall(TaskManager.unclaimTask, (id)));
+        require(!okStranger, "DryRun: no-permission caller must not release");
+
+        vm.prank(executor);
+        tm.unclaimTask(id);
+        (address claimerAfter, TaskManager.Status st,,,) = _readTask(tm, id);
+        require(st == TaskManager.Status.UNCLAIMED && claimerAfter == address(0), "DryRun: expired release failed");
+        console.log("Third-party release OK (protected while live, ASSIGN-only, works once expired)");
+    }
+
+    function _checkSubmittedNeverReleasable(
+        TaskManager tm,
+        address proxy,
+        bytes32 pid,
+        address executor,
+        uint32 window,
+        address worker
+    ) internal {
+        uint256 id = _nextAvailableTaskId(proxy);
+        vm.prank(executor);
+        tm.createTask(1 ether, bytes("submitted"), bytes32(0), pid, address(0), 0, false, 0, window);
+        vm.prank(executor);
+        tm.assignTask(id, worker);
+        vm.prank(worker);
+        tm.submitTask(id, keccak256("dryrun-work"));
+
+        vm.warp(vm.getBlockTimestamp() + 365 days);
+        vm.prank(worker);
+        (bool okClaimer,) = proxy.call(abi.encodeCall(TaskManager.unclaimTask, (id)));
+        require(!okClaimer, "DryRun: SUBMITTED must not be releasable by the claimer");
+        vm.prank(executor);
+        (bool okExec,) = proxy.call(abi.encodeCall(TaskManager.unclaimTask, (id)));
+        require(!okExec, "DryRun: SUBMITTED must not be releasable by an ASSIGN holder");
+
+        // rejectTask is the sanctioned route back to CLAIMED, and then it releases.
+        vm.prank(executor);
+        tm.rejectTask(id, keccak256("dryrun-redo"));
+        vm.prank(worker);
+        tm.unclaimTask(id);
+        (, TaskManager.Status st,,,) = _readTask(tm, id);
+        require(st == TaskManager.Status.UNCLAIMED, "DryRun: reject-then-release failed");
+        console.log("SUBMITTED guard OK (blocked, releasable only after rejectTask)");
+    }
+
+    function _checkCancelAfterRelease(
+        TaskManager tm,
+        address proxy,
+        bytes32 pid,
+        address executor,
+        uint32 window,
+        address worker
+    ) internal {
+        uint128 spentBefore = _projectSpent(tm, pid);
+        uint256 id = _nextAvailableTaskId(proxy);
+
+        vm.prank(executor);
+        tm.createTask(1 ether, bytes("cancel-after"), bytes32(0), pid, address(0), 0, false, 0, window);
+        vm.prank(executor);
+        tm.assignTask(id, worker);
+        vm.prank(worker);
+        tm.unclaimTask(id);
+        vm.prank(executor);
+        tm.cancelTask(id);
+
+        (, TaskManager.Status st,,,) = _readTask(tm, id);
+        require(st == TaskManager.Status.CANCELLED, "DryRun: cancel after release failed");
+        require(_projectSpent(tm, pid) == spentBefore, "DryRun: cancel must refund exactly once");
+        console.log("cancelTask after release OK (reservation refunded exactly once)");
+    }
+
+    function _hasSelector(address impl, bytes4 sel) internal view returns (bool) {
+        bytes memory code = impl.code;
+        for (uint256 i; i + 4 <= code.length; ++i) {
+            if (code[i] == sel[0] && code[i + 1] == sel[1] && code[i + 2] == sel[2] && code[i + 3] == sel[3]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function _projectSpent(TaskManager tm, bytes32 pid) internal view returns (uint128 spent) {
+        (, spent,) = abi.decode(tm.getLensData(2, abi.encode(pid)), (uint128, uint128, bool));
+    }
+
+    /// @dev Finds the next unused task id by probing the lens.
+    function _nextAvailableTaskId(address proxy) internal view returns (uint256) {
+        for (uint256 i; i < 1_000_000; ++i) {
+            (bool ok,) =
+                proxy.staticcall(abi.encodeWithSelector(TaskManager.getLensData.selector, uint8(1), abi.encode(i)));
+            if (!ok) return i;
+        }
+        revert("DryRun: nextAvailableTaskId search exhausted");
+    }
+
+    function _readTask(TaskManager tm, uint256 id)
+        internal
+        view
+        returns (address claimer, TaskManager.Status status, uint48 claimDeadline, uint48 absDeadline, uint32 window)
+    {
+        bytes memory data = tm.getLensData(1, abi.encode(id));
+        (,, claimer,,, status,, absDeadline, window, claimDeadline) = abi.decode(
+            data, (bytes32, uint96, address, uint96, bool, TaskManager.Status, address, uint48, uint32, uint48)
+        );
+    }
+}
+
+/// @notice v7 dry run on a Gnosis fork (beacon upgraded by pranking the Satellite).
+contract DryRun_GnosisUpgrade is UnclaimDryRunBase {
+    function _poaManager() internal pure override returns (address) {
+        return GNOSIS_POA_MANAGER;
+    }
+
+    function _chainName() internal pure override returns (string memory) {
+        return "Gnosis";
+    }
+
+    function _upgradeBeacon(address newImpl) internal override {
+        vm.prank(GNOSIS_SATELLITE);
+        PoaManager(GNOSIS_POA_MANAGER).upgradeBeacon("TaskManager", newImpl, VERSION);
+    }
+
+    function _liveProxy() internal view override returns (address) {
+        IOrgRegistry reg = IOrgRegistry(ORG_REGISTRY);
+        return reg.proxyOf(reg.orgIds(0), keccak256("TaskManager"));
+    }
+}
+
+/// @notice v7 dry run on an Arbitrum fork (beacon upgraded through the Hub exactly like Step2).
+contract DryRun_ArbitrumUpgrade is UnclaimDryRunBase {
+    function _poaManager() internal pure override returns (address) {
+        return ARBITRUM_POA_MANAGER;
+    }
+
+    function _chainName() internal pure override returns (string memory) {
+        return "Arbitrum";
+    }
+
+    function _upgradeBeacon(address newImpl) internal override {
+        vm.deal(HUDSON_ADMIN, 1 ether);
+        vm.prank(HUDSON_ADMIN);
+        PoaManagerHub(payable(HUB)).upgradeBeaconCrossChain{value: HYPERLANE_FEE}("TaskManager", newImpl, VERSION);
+    }
+
+    function _liveProxy() internal pure override returns (address) {
+        // Poa's TaskManager on Arbitrum — verified constant (the Arbitrum OrgRegistry
+        // instance holds no registrations to resolve from).
+        return 0x681f29751724D2bED331d3EB35e0C9B1C57aF9F0;
+    }
+}

--- a/src/OrgDeployer.sol
+++ b/src/OrgDeployer.sol
@@ -1012,8 +1012,8 @@ contract OrgDeployer is Initializable {
         pure
         returns (address[] memory targets, bytes4[] memory selectors, bool[] memory allowed, uint32[] memory gasHints)
     {
-        // Count: QuickJoin(6) + TaskManager(16) + HybridVoting(3) + DDVoting(3) + PaymentManager(5) + EligibilityModule(5) + ParticipationToken(3) + Registry(2) + EducationHub(0 or 4) + ZkEmailInvites(0 or 4)
-        uint256 count = 43;
+        // Count: QuickJoin(6) + TaskManager(17) + HybridVoting(3) + DDVoting(3) + PaymentManager(5) + EligibilityModule(5) + ParticipationToken(3) + Registry(2) + EducationHub(0 or 4) + ZkEmailInvites(0 or 4)
+        uint256 count = 44;
         if (educationEnabled) count += 4;
         bool zkEmailEnabled = result.zkEmailInvites != address(0);
         if (zkEmailEnabled) count += 4;
@@ -1156,6 +1156,10 @@ contract OrgDeployer is Initializable {
         i++;
         targets[i] = tm;
         selectors[i] = bytes4(keccak256("claimTask(uint256)"));
+        i++;
+        // TaskManager v7: voluntary claim release (and ASSIGN release of an expired claim).
+        targets[i] = tm;
+        selectors[i] = bytes4(keccak256("unclaimTask(uint256)"));
         i++;
         targets[i] = tm;
         selectors[i] = bytes4(keccak256("submitTask(uint256,bytes32)"));

--- a/src/TaskManager.sol
+++ b/src/TaskManager.sol
@@ -256,6 +256,10 @@ contract TaskManager is Initializable, ContextUpgradeable {
     /// @dev Always followed in the same tx by the lifecycle event recording the new claim
     ///      (`TaskClaimed`, `TaskAssigned`, or `TaskApplicationApproved`).
     event TaskClaimExpired(uint256 indexed id, address indexed previousClaimer, address indexed newClaimer);
+    /// @notice A CLAIMED task was released back to the pool; `previousClaimer` is cleared.
+    /// @dev `caller == previousClaimer` is a self-release; otherwise an ASSIGN holder released an
+    ///      expired claim. Followed by `TaskClaimDeadlineSet(id, 0)` if a window was running.
+    event TaskUnclaimed(uint256 indexed id, address indexed previousClaimer, address indexed caller);
     /// @notice The executor address was set or changed.
     event ExecutorUpdated(address newExecutor);
 
@@ -810,6 +814,8 @@ contract TaskManager is Initializable, ContextUpgradeable {
      *      claim proceeds as normal with a fresh completion window. The expired claimer may
      *      re-claim their own task to refresh the window. SUBMITTED tasks are never
      *      takeover-able: delivered work must be reviewed (completed or rejected) first.
+     *
+     *      Giving a claim back voluntarily (no replacement claimer) is {unclaimTask}.
      * @param id Task ID.
      */
     function claimTask(uint256 id) external {
@@ -858,6 +864,40 @@ contract TaskManager is Initializable, ContextUpgradeable {
         t.claimer = assignee;
         emit TaskAssigned(id, assignee, _msgSender());
         _startClaimWindow(id, t);
+    }
+
+    /**
+     * @notice Release a CLAIMED task back to the pool: status returns to UNCLAIMED with no claimer.
+     * @dev Permission: the claimer may always release (no mask check — an assignee never needs
+     *      CLAIM, and hats get revoked mid-claim, so gating it would trap the very people this
+     *      frees). Anyone else needs ASSIGN on the project (PM / executor bypass included) AND an
+     *      expired claim — {assignTask}'s takeover gate with no new claimer named, so it grants no
+     *      authority that did not already exist. Deadline-less tasks never expire; unstick those
+     *      the documented way (`updateTask` with a past `absoluteDeadline`, then this).
+     *
+     *      CLAIMED only. SUBMITTED would let `completeTask` mint to `address(0)` (PT reverts),
+     *      bricking the task — use `rejectTask` first. Budgets, application hashes and the
+     *      applicant list are untouched: `spent` tracks task existence, and `cancelTask` (now
+     *      reachable again) stays the only refund path. Note a claimer can release and re-claim to
+     *      refresh their window; `absoluteDeadline` is the knob no re-claim can reset.
+     * @param id Task ID.
+     */
+    function unclaimTask(uint256 id) external {
+        Layout storage l = _layout();
+        Task storage t = _task(l, id);
+        if (t.status != Status.CLAIMED) revert BadStatus();
+
+        address prev = t.claimer;
+        address s = _msgSender();
+        if (s != prev) {
+            _requireCanAssign(t.projectId);
+            if (!_claimExpired(t)) revert BadStatus();
+        }
+
+        t.status = Status.UNCLAIMED;
+        t.claimer = address(0);
+        emit TaskUnclaimed(id, prev, s);
+        _clearClaimWindow(id, t);
     }
 
     /**
@@ -934,7 +974,10 @@ contract TaskManager is Initializable, ContextUpgradeable {
 
     /**
      * @notice Cancel an UNCLAIMED task and roll back its PT/bounty budget reservations.
-     * @dev Permission: CREATE on the task's project. Pending applications are cleared.
+     * @dev Permission: CREATE on the task's project. The applicant list is cleared. Reachable
+     *      for a task that was previously claimed once it has been released via {unclaimTask} —
+     *      the reservation was never refunded while it was held, so this stays the one and only
+     *      place a task's budget is given back.
      * @param id Task ID.
      */
     function cancelTask(uint256 id) external {
@@ -958,7 +1001,8 @@ contract TaskManager is Initializable, ContextUpgradeable {
         t.status = Status.CANCELLED;
         t.claimer = address(0);
 
-        // Clear all applications - zero out the mapping and delete applicants array
+        // Drop the applicant list. The per-applicant hashes in `taskApplications` are left in
+        // place (they are never deleted anywhere) — the task is terminal, so nothing reads them.
         delete l.taskApplicants[id];
 
         emit TaskCancelled(id, _msgSender());
@@ -1198,6 +1242,19 @@ contract TaskManager is Initializable, ContextUpgradeable {
         if (newClaimDeadline != t.claimDeadline) {
             t.claimDeadline = newClaimDeadline;
             emit TaskClaimDeadlineSet(id, newClaimDeadline);
+        }
+    }
+
+    /**
+     * @dev Clear the per-claim window when a task returns to the pool ({unclaimTask}), emit-on-
+     *      change like {_startClaimWindow}. Not that helper: it would set `now + completionWindow`
+     *      on a claimer-less task. Task-level deadline config is untouched and re-derived on the
+     *      next claim.
+     */
+    function _clearClaimWindow(uint256 id, Task storage t) internal {
+        if (t.claimDeadline != 0) {
+            t.claimDeadline = 0;
+            emit TaskClaimDeadlineSet(id, 0);
         }
     }
 

--- a/test/DeployerTest.t.sol
+++ b/test/DeployerTest.t.sol
@@ -5917,6 +5917,10 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         rule = paymasterHub.getRule(orgId, result.taskManager, bytes4(keccak256("claimTask(uint256)")));
         assertTrue(rule.allowed, "TaskManager claimTask should be whitelisted");
 
+        // Check TaskManager unclaimTask(uint256) is whitelisted (v7 claim release)
+        rule = paymasterHub.getRule(orgId, result.taskManager, bytes4(keccak256("unclaimTask(uint256)")));
+        assertTrue(rule.allowed, "TaskManager unclaimTask should be whitelisted");
+
         // Check TaskManager setFolders is whitelisted (v4 bootstrap)
         rule = paymasterHub.getRule(orgId, result.taskManager, bytes4(keccak256("setFolders(bytes32,bytes32)")));
         assertTrue(rule.allowed, "TaskManager setFolders should be whitelisted (v4 bootstrap)");
@@ -6273,6 +6277,11 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         rule = paymasterHub.getRule(orgId, result.taskManager, bytes4(keccak256("claimTask(uint256)")));
         assertTrue(rule.allowed, "TaskManager should be whitelisted");
 
+        // v7 claim release — asserted on this branch too: educationEnabled=false is a
+        // distinct rule-array sizing path from the education-enabled test above.
+        rule = paymasterHub.getRule(orgId, result.taskManager, bytes4(keccak256("unclaimTask(uint256)")));
+        assertTrue(rule.allowed, "TaskManager unclaimTask should be whitelisted without education");
+
         rule = paymasterHub.getRule(orgId, result.hybridVoting, bytes4(keccak256("vote(uint256,uint8[],uint8[])")));
         assertTrue(rule.allowed, "HybridVoting should be whitelisted");
 
@@ -6394,7 +6403,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             "registerAndQuickJoinWithPasskey selector mismatch"
         );
 
-        // ── TaskManager (12) ──
+        // ── TaskManager (13) ──
         assertEq(
             bytes4(keccak256("createTask(uint256,bytes,bytes32,bytes32,address,uint256,bool,uint48,uint32)")),
             TaskManager.createTask.selector,
@@ -6406,6 +6415,9 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             "createTasksBatch selector mismatch"
         );
         assertEq(bytes4(keccak256("claimTask(uint256)")), TaskManager.claimTask.selector, "claimTask selector mismatch");
+        assertEq(
+            bytes4(keccak256("unclaimTask(uint256)")), TaskManager.unclaimTask.selector, "unclaimTask selector mismatch"
+        );
         assertEq(
             bytes4(keccak256("submitTask(uint256,bytes32)")),
             TaskManager.submitTask.selector,

--- a/test/TaskManager.t.sol
+++ b/test/TaskManager.t.sol
@@ -9145,3 +9145,1269 @@ contract MockToken is Test, IERC20 {
                 assertEq(claimer, member2);
             }
         }
+
+        /*═══════════════════════════════════════════════════════════════════════════════
+         *  unclaimTask — release a CLAIMED task back to the pool.
+         *  Route A: the claimer, always, ungated. Route B: ASSIGN/PM/executor, once expired.
+         *═══════════════════════════════════════════════════════════════════════════════*/
+        contract TaskManagerUnclaimTest is TaskManagerTestBase {
+            bytes32 UC_ID; // default project (creator1 is auto-manager)
+            bytes32 BOUNTY_ID; // project with a funded bounty budget
+            MockERC20 bountyToken;
+
+            address member2 = makeAddr("member2");
+
+            uint32 constant WINDOW = 7 days;
+            uint48 ABS; // T0 + 30 days
+            uint256 T0;
+
+            bytes32 constant TOPIC_UNCLAIMED = keccak256("TaskUnclaimed(uint256,address,address)");
+            bytes32 constant TOPIC_CLAIM_DEADLINE_SET = keccak256("TaskClaimDeadlineSet(uint256,uint48)");
+            bytes32 constant TOPIC_CLAIM_EXPIRED = keccak256("TaskClaimExpired(uint256,address,address)");
+            bytes32 constant TOPIC_DEADLINES_SET = keccak256("TaskDeadlinesSet(uint256,uint48,uint32)");
+
+            function setUp() public {
+                vm.warp(1_700_000_000); // realistic base timestamp so absolute-deadline checks bite
+                T0 = block.timestamp;
+                ABS = uint48(T0 + 30 days);
+                setUpBase();
+                setHat(member2, MEMBER_HAT);
+                UC_ID = _createDefaultProject("UNCLAIM", 0);
+
+                bountyToken = new MockERC20();
+                bountyToken.mint(address(tm), 1000 ether);
+                address[] memory tokens = new address[](1);
+                tokens[0] = address(bountyToken);
+                uint256[] memory caps = new uint256[](1);
+                caps[0] = 100 ether;
+                BOUNTY_ID = _createProjectWithBountyBudget("UNCLAIM_BOUNTY", 0, tokens, caps);
+            }
+
+            /*──────── helpers ───────*/
+            // Task ids are global and sequential; mirror the counter like TaskManagerDeadlineTest.
+            uint256 _nextId;
+
+            function _mkTask(uint48 absoluteDeadline, uint32 completionWindow) internal returns (uint256 id) {
+                id = _nextId++;
+                vm.prank(creator1);
+                tm.createTask(
+                    1 ether, bytes("uc"), bytes32(0), UC_ID, address(0), 0, false, absoluteDeadline, completionWindow
+                );
+            }
+
+            function _mkAppTask(uint48 absoluteDeadline, uint32 completionWindow) internal returns (uint256 id) {
+                id = _nextId++;
+                vm.prank(creator1);
+                tm.createTask(
+                    1 ether, bytes("uc-app"), bytes32(0), UC_ID, address(0), 0, true, absoluteDeadline, completionWindow
+                );
+            }
+
+            function _mkBountyTask(uint256 bountyPayout, uint32 completionWindow) internal returns (uint256 id) {
+                id = _nextId++;
+                vm.prank(creator1);
+                tm.createTask(
+                    1 ether,
+                    bytes("uc-bounty"),
+                    bytes32(0),
+                    BOUNTY_ID,
+                    address(bountyToken),
+                    bountyPayout,
+                    false,
+                    0,
+                    completionWindow
+                );
+            }
+
+            /// @dev Claim by `who` and warp one second past whichever deadline the claim has.
+            ///      Reverts loudly on a deadline-less task rather than silently warping to t=1.
+            function _claimAndExpire(uint256 id, address who) internal {
+                vm.prank(who);
+                tm.claimTask(id);
+                (uint48 abs_,, uint48 cd) = _deadlines(id);
+                uint48 expiry = cd != 0 ? cd : abs_;
+                require(expiry != 0, "_claimAndExpire: task has no deadline and can never expire");
+                vm.warp(uint256(expiry) + 1);
+            }
+
+            /// @dev Read the i-th 32-byte word of an ABI-encoded static tuple.
+            function _word(bytes memory b, uint256 i) internal pure returns (bytes32 w) {
+                assembly {
+                    w := mload(add(add(b, 32), mul(i, 32)))
+                }
+            }
+
+            function _deadlines(uint256 id) internal view returns (uint48 abs_, uint32 window_, uint48 cd_) {
+                bytes memory data = lens.getStorage(
+                    address(tm), TaskManagerLens.StorageKey.TASK_DEADLINES, abi.encode(id)
+                );
+                (abs_, window_, cd_) = abi.decode(data, (uint48, uint32, uint48));
+            }
+
+            function _status(uint256 id) internal view returns (TaskManager.Status st, address claimer) {
+                bytes memory data = lens.getStorage(address(tm), TaskManagerLens.StorageKey.TASK_INFO, abi.encode(id));
+                (, st, claimer,,) = abi.decode(data, (uint256, TaskManager.Status, address, bytes32, bool));
+            }
+
+            function _projectSpent(bytes32 pid) internal view returns (uint128 spent) {
+                bytes memory data = lens.getStorage(
+                    address(tm), TaskManagerLens.StorageKey.PROJECT_INFO, abi.encode(pid)
+                );
+                (, spent,) = abi.decode(data, (uint128, uint128, bool));
+            }
+
+            function _bountySpent(bytes32 pid, address tok) internal view returns (uint128 spent) {
+                bytes memory data =
+                    lens.getStorage(address(tm), TaskManagerLens.StorageKey.BOUNTY_BUDGET, abi.encode(pid, tok));
+                (, spent) = abi.decode(data, (uint128, uint128));
+            }
+
+            function _applicantCount(uint256 id) internal view returns (uint256 n) {
+                bytes memory data =
+                    lens.getStorage(address(tm), TaskManagerLens.StorageKey.TASK_APPLICANT_COUNT, abi.encode(id));
+                n = abi.decode(data, (uint256));
+            }
+
+            function _application(uint256 id, address who) internal view returns (bytes32 h) {
+                bytes memory data =
+                    lens.getStorage(address(tm), TaskManagerLens.StorageKey.TASK_APPLICATION, abi.encode(id, who));
+                h = abi.decode(data, (bytes32));
+            }
+
+            function _countTopic(Vm.Log[] memory logs, bytes32 topic) internal pure returns (uint256 n) {
+                for (uint256 i; i < logs.length; i++) {
+                    if (logs[i].topics[0] == topic) n++;
+                }
+            }
+
+            /*──────── self-release: state & events ───────*/
+
+            function test_SelfUnclaimSetsUnclaimedAndClearsClaimer() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                (TaskManager.Status st, address claimer) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.UNCLAIMED), "back to UNCLAIMED");
+                assertEq(claimer, address(0), "claimer cleared");
+            }
+
+            function test_SelfUnclaimClearsClaimDeadlineOnly() public {
+                uint256 id = _mkTask(ABS, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                (,, uint48 cdWhileClaimed) = _deadlines(id);
+                assertEq(cdWhileClaimed, uint48(block.timestamp) + WINDOW, "precondition: window running");
+
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                (uint48 abs_, uint32 window_, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, 0, "claim deadline cleared");
+                assertEq(abs_, ABS, "absoluteDeadline is task config - untouched");
+                assertEq(window_, WINDOW, "completionWindow is task config - untouched");
+            }
+
+            function test_SelfUnclaimEmitsEventsInOrder() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskUnclaimed(id, member1, member1);
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskClaimDeadlineSet(id, 0);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+            }
+
+            function test_WindowlessUnclaimEmitsNoDeadlineEvent() public {
+                uint256 id = _mkTask(0, 0);
+                vm.prank(member1);
+                tm.claimTask(id);
+
+                vm.recordLogs();
+                vm.prank(member1);
+                tm.unclaimTask(id);
+                Vm.Log[] memory logs = vm.getRecordedLogs();
+                assertEq(_countTopic(logs, TOPIC_UNCLAIMED), 1, "release event still fires");
+                assertEq(_countTopic(logs, TOPIC_CLAIM_DEADLINE_SET), 0, "nothing to clear, nothing emitted");
+            }
+
+            function test_UnclaimEmitsNoClaimExpiredEvent() public {
+                // self-release of a live claim...
+                uint256 a = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(a);
+                vm.recordLogs();
+                vm.prank(member1);
+                tm.unclaimTask(a);
+                assertEq(_countTopic(vm.getRecordedLogs(), TOPIC_CLAIM_EXPIRED), 0, "self-release is not a takeover");
+
+                // ...and third-party release of an expired one
+                uint256 b = _mkTask(0, WINDOW);
+                _claimAndExpire(b, member1);
+                vm.recordLogs();
+                vm.prank(pm1);
+                tm.unclaimTask(b);
+                assertEq(
+                    _countTopic(vm.getRecordedLogs(), TOPIC_CLAIM_EXPIRED),
+                    0,
+                    "release names no new claimer, so no TaskClaimExpired"
+                );
+            }
+
+            function test_SelfUnclaimOfExpiredClaimAllowed() public {
+                uint256 id = _mkTask(0, WINDOW);
+                _claimAndExpire(id, member1);
+
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskUnclaimed(id, member1, member1);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+                (TaskManager.Status st,) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.UNCLAIMED));
+            }
+
+            function test_UnclaimByAssigneeWithoutClaimPermission() public {
+                // assignTask never checks the assignee's mask: `outsider` holds no hat at all.
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(pm1);
+                tm.assignTask(id, outsider);
+
+                vm.prank(outsider);
+                tm.unclaimTask(id); // route A is identity-gated, not permission-gated
+                (TaskManager.Status st, address claimer) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.UNCLAIMED));
+                assertEq(claimer, address(0));
+            }
+
+            function test_UnclaimAfterCreateAndAssign() public {
+                _nextId++; // createAndAssignTask consumes the next id
+                vm.prank(executor);
+                uint256 id =
+                    tm.createAndAssignTask(
+                    1 ether, bytes("caa"), bytes32(0), UC_ID, member1, address(0), 0, false, 0, WINDOW
+                );
+
+                vm.prank(member1);
+                tm.unclaimTask(id);
+                (TaskManager.Status st, address claimer) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.UNCLAIMED));
+                assertEq(claimer, address(0));
+                (,, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, 0, "assignment window cleared");
+            }
+
+            function test_UnclaimAfterRejectAllowed() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(member1);
+                tm.submitTask(id, keccak256("work"));
+                vm.prank(pm1);
+                tm.rejectTask(id, keccak256("redo")); // back to CLAIMED with member1 still on it
+
+                vm.prank(member1);
+                tm.unclaimTask(id); // "I don't want to rework this"
+                (TaskManager.Status st, address claimer) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.UNCLAIMED));
+                assertEq(claimer, address(0));
+            }
+
+            function test_ClaimerWithRevokedPermissionCanStillUnclaim() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+
+                // strip CLAIM from MEMBER_HAT, project override first then the global mask
+                vm.prank(creator1);
+                tm.setProjectRolePerm(UC_ID, MEMBER_HAT, 0);
+                vm.prank(executor);
+                tm.setConfig(TaskManager.ConfigKey.ROLE_PERM, abi.encode(MEMBER_HAT, uint8(0)));
+
+                uint256 fresh = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                vm.expectRevert(TaskManager.Unauthorized.selector);
+                tm.claimTask(fresh); // precondition: member1 really has lost CLAIM
+
+                vm.prank(member1);
+                tm.unclaimTask(id); // ...but is never trapped holding what they already claimed
+                (TaskManager.Status st, address claimer) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.UNCLAIMED));
+                assertEq(claimer, address(0));
+            }
+
+            /*──────── third-party release (ASSIGN + expired) ───────*/
+
+            function test_ThirdPartyUnclaimOfExpiredClaimByAssignHolder() public {
+                uint256 id = _mkTask(0, WINDOW);
+                _claimAndExpire(id, member1);
+
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskUnclaimed(id, member1, pm1);
+                vm.prank(pm1); // PM_HAT holds ASSIGN on this project
+                tm.unclaimTask(id);
+                (TaskManager.Status st, address claimer) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.UNCLAIMED));
+                assertEq(claimer, address(0));
+            }
+
+            function test_ThirdPartyUnclaimOfExpiredClaimByExecutor() public {
+                uint256 id = _mkTask(0, WINDOW);
+                _claimAndExpire(id, member1);
+                vm.prank(executor);
+                tm.unclaimTask(id);
+                (, address claimer) = _status(id);
+                assertEq(claimer, address(0));
+            }
+
+            function test_ThirdPartyUnclaimOfExpiredClaimByProjectManager() public {
+                uint256 id = _mkTask(0, WINDOW);
+                _claimAndExpire(id, member1);
+                vm.prank(creator1); // auto-added manager of UC_ID; holds no ASSIGN mask
+                tm.unclaimTask(id);
+                (, address claimer) = _status(id);
+                assertEq(claimer, address(0));
+            }
+
+            function test_ThirdPartyUnclaimAfterAbsoluteExpiryOnly() public {
+                uint256 id = _mkTask(ABS, 0); // no per-claim window: only the calendar cutoff
+                vm.prank(member1);
+                tm.claimTask(id);
+
+                vm.warp(uint256(ABS) + 1);
+                vm.prank(pm1);
+                tm.unclaimTask(id);
+                (, address claimer) = _status(id);
+                assertEq(claimer, address(0));
+            }
+
+            function test_PmCannotUnclaimLiveClaim() public {
+                uint256 id = _mkTask(ABS, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(pm1);
+                vm.expectRevert(TaskManager.BadStatus.selector); // authorized, but the claim is protected
+                tm.unclaimTask(id);
+                (, address claimer) = _status(id);
+                assertEq(claimer, member1, "claim untouched");
+            }
+
+            function test_ExecutorCannotUnclaimLiveClaim() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(executor);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.unclaimTask(id);
+            }
+
+            function test_UnclaimAtExactDeadlineSecondReverts() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.warp(block.timestamp + WINDOW); // the deadline second itself is still protected
+                vm.prank(pm1);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.unclaimTask(id);
+
+                vm.warp(block.timestamp + 1);
+                vm.prank(pm1);
+                tm.unclaimTask(id);
+                (, address claimer) = _status(id);
+                assertEq(claimer, address(0));
+            }
+
+            function test_ClaimOnlyMemberCannotUnclaimOthersExpiredClaim() public {
+                uint256 id = _mkTask(0, WINDOW);
+                _claimAndExpire(id, member1);
+                vm.prank(member2); // MEMBER_HAT has CLAIM, not ASSIGN
+                vm.expectRevert(TaskManager.Unauthorized.selector);
+                tm.unclaimTask(id);
+            }
+
+            function test_OutsiderCannotUnclaim() public {
+                uint256 live = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(live);
+                vm.prank(outsider);
+                vm.expectRevert(TaskManager.Unauthorized.selector);
+                tm.unclaimTask(live);
+
+                uint256 expired = _mkTask(0, WINDOW);
+                _claimAndExpire(expired, member1);
+                vm.prank(outsider);
+                vm.expectRevert(TaskManager.Unauthorized.selector);
+                tm.unclaimTask(expired);
+            }
+
+            function test_UnclaimNoDeadlinesByAssignHolderReverts() public {
+                uint256 id = _mkTask(0, 0); // pre-v6-shaped task: never expires
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.warp(block.timestamp + 365 days);
+                vm.prank(pm1);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.unclaimTask(id);
+            }
+
+            function test_TwoTxAdminLeverUnsticksDeadlinelessTask() public {
+                uint256 id = _mkTask(0, 0);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.warp(block.timestamp + 90 days); // claimer ghosted
+
+                // leg 1: open the claim to takeover with a past absolute deadline
+                vm.prank(executor);
+                tm.updateTask(id, 1 ether, bytes("uc"), bytes32(0), address(0), 0, uint48(block.timestamp - 1), 0);
+                // leg 2: release to the pool instead of naming a replacement
+                vm.prank(pm1);
+                tm.unclaimTask(id);
+
+                (TaskManager.Status st, address claimer) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.UNCLAIMED));
+                assertEq(claimer, address(0));
+            }
+
+            /*──────── status gate & bounds ───────*/
+
+            function test_UnclaimUnclaimedReverts() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.unclaimTask(id);
+            }
+
+            function test_UnclaimSubmittedReverts() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(member1);
+                tm.submitTask(id, keccak256("work"));
+
+                // delivered work must be reviewed first — nobody can pull the claimer out from under it
+                vm.prank(member1);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.unclaimTask(id);
+                vm.prank(pm1);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.unclaimTask(id);
+                vm.prank(executor);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.unclaimTask(id);
+
+                // ...even long after every deadline has passed
+                vm.warp(block.timestamp + 365 days);
+                vm.prank(pm1);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.unclaimTask(id);
+            }
+
+            function test_UnclaimCompletedReverts() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(member1);
+                tm.submitTask(id, keccak256("work"));
+                vm.prank(pm1);
+                tm.completeTask(id);
+
+                vm.prank(member1);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.unclaimTask(id);
+            }
+
+            function test_UnclaimCancelledReverts() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(creator1);
+                tm.cancelTask(id);
+                vm.prank(member1);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.unclaimTask(id);
+            }
+
+            function test_UnclaimUnknownIdReverts() public {
+                vm.prank(member1);
+                vm.expectRevert(TaskManager.NotFound.selector);
+                tm.unclaimTask(_nextId); // one past the last created id
+            }
+
+            function test_DoubleUnclaimReverts() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+                vm.prank(member1);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.unclaimTask(id);
+            }
+
+            /*──────── budget non-effects ───────*/
+
+            function test_UnclaimDoesNotChangeProjectSpent() public {
+                uint256 id = _mkTask(0, WINDOW);
+                uint128 spentBefore = _projectSpent(UC_ID);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+                assertEq(_projectSpent(UC_ID), spentBefore, "release does not refund the PT reservation");
+                (TaskManager.Status st,) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.UNCLAIMED), "anchor: the release really happened");
+            }
+
+            function test_UnclaimDoesNotChangeBountySpent() public {
+                uint256 id = _mkBountyTask(2 ether, WINDOW);
+                uint128 ptBefore = _projectSpent(BOUNTY_ID);
+                uint128 bountyBefore = _bountySpent(BOUNTY_ID, address(bountyToken));
+                assertEq(bountyBefore, 2 ether, "precondition: bounty reserved at creation");
+
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                assertEq(_projectSpent(BOUNTY_ID), ptBefore, "PT reservation held");
+                assertEq(_bountySpent(BOUNTY_ID, address(bountyToken)), bountyBefore, "bounty reservation held");
+                assertEq(bountyToken.balanceOf(address(tm)), 1000 ether, "no tokens moved");
+                assertEq(bountyToken.balanceOf(member1), 0, "the releaser is not paid out");
+                (TaskManager.Status st,) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.UNCLAIMED), "anchor: the release really happened");
+            }
+
+            function test_CancelAfterUnclaimRefundsExactlyOnce() public {
+                uint128 ptBefore = _projectSpent(BOUNTY_ID);
+                uint128 bountyBefore = _bountySpent(BOUNTY_ID, address(bountyToken));
+
+                uint256 id = _mkBountyTask(2 ether, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                // a task that reached CLAIMED is cancellable again once released
+                vm.prank(creator1);
+                tm.cancelTask(id);
+
+                assertEq(_projectSpent(BOUNTY_ID), ptBefore, "PT refunded exactly once");
+                assertEq(_bountySpent(BOUNTY_ID, address(bountyToken)), bountyBefore, "bounty refunded exactly once");
+                (TaskManager.Status st, address claimer) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.CANCELLED));
+                assertEq(claimer, address(0));
+            }
+
+            function test_UpdateTaskAfterUnclaimRebasesSpent() public {
+                uint128 spentBefore = _projectSpent(UC_ID);
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                vm.prank(creator1);
+                tm.updateTask(id, 3 ether, bytes("uc"), bytes32(0), address(0), 0, 0, WINDOW);
+                assertEq(_projectSpent(UC_ID), spentBefore + 3 ether, "spent rebased, no underflow");
+            }
+
+            /*──────── re-claim / takeover interaction ───────*/
+
+            function test_ReclaimBySameMemberAfterUnclaim() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.warp(block.timestamp + 2 days);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                vm.prank(member1);
+                tm.claimTask(id);
+                (,, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, uint48(block.timestamp) + WINDOW, "fresh window on re-claim");
+                (, address claimer) = _status(id);
+                assertEq(claimer, member1);
+            }
+
+            function test_ReclaimByDifferentMemberAfterUnclaim() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                vm.recordLogs();
+                vm.prank(member2);
+                tm.claimTask(id);
+                assertEq(
+                    _countTopic(vm.getRecordedLogs(), TOPIC_CLAIM_EXPIRED), 0, "plain UNCLAIMED claim, not a takeover"
+                );
+                (, address claimer) = _status(id);
+                assertEq(claimer, member2);
+            }
+
+            function test_AssignAfterUnclaim() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskAssigned(id, member2, pm1);
+                vm.prank(pm1);
+                tm.assignTask(id, member2);
+                (,, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, uint48(block.timestamp) + WINDOW, "fresh window on assignment");
+            }
+
+            function test_ExClaimerCannotSubmitAfterUnclaim() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                vm.prank(member1);
+                vm.expectRevert(TaskManager.BadStatus.selector); // UNCLAIMED: nothing to submit
+                tm.submitTask(id, keccak256("work"));
+
+                vm.prank(member2);
+                tm.claimTask(id);
+                vm.prank(member1);
+                vm.expectRevert(TaskManager.NotClaimer.selector);
+                tm.submitTask(id, keccak256("work"));
+            }
+
+            function test_ExClaimerCannotUnclaimAfterTakeover() public {
+                uint256 id = _mkTask(0, WINDOW);
+                _claimAndExpire(id, member1);
+                vm.prank(member2);
+                tm.claimTask(id); // takeover
+
+                vm.prank(member1); // CLAIM only, and no longer the claimer
+                vm.expectRevert(TaskManager.Unauthorized.selector);
+                tm.unclaimTask(id);
+                (, address claimer) = _status(id);
+                assertEq(claimer, member2, "takeover stands");
+            }
+
+            function test_UnclaimRaceWithTakeover() public {
+                // claimer's release lands first: the taker still gets the task, via the UNCLAIMED branch
+                uint256 a = _mkTask(0, WINDOW);
+                _claimAndExpire(a, member1);
+                vm.prank(member1);
+                tm.unclaimTask(a);
+                vm.prank(member2);
+                tm.claimTask(a);
+                (, address claimer) = _status(a);
+                assertEq(claimer, member2);
+
+                // taker lands first: the stale release reverts instead of evicting the new claimer
+                uint256 b = _mkTask(0, WINDOW);
+                _claimAndExpire(b, member1);
+                vm.prank(member2);
+                tm.claimTask(b);
+                vm.prank(member1);
+                vm.expectRevert(TaskManager.Unauthorized.selector);
+                tm.unclaimTask(b);
+                (, claimer) = _status(b);
+                assertEq(claimer, member2);
+            }
+
+            function test_UnclaimPastAbsoluteLeavesNextClaimUnprotected() public {
+                uint256 id = _mkTask(ABS, 0);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.warp(uint256(ABS) + 1);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                // past the cutoff every claim is born expired — same as the pre-existing lenient model
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(member2);
+                tm.claimTask(id); // immediately takeover-able
+                (, address claimer) = _status(id);
+                assertEq(claimer, member2);
+            }
+
+            /*──────── deadline arithmetic after release ───────*/
+
+            function test_UpdateWindowAfterUnclaimSkipsInFlightBranch() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                vm.recordLogs();
+                vm.prank(creator1);
+                tm.updateTask(id, 1 ether, bytes("uc"), bytes32(0), address(0), 0, 0, 21 days);
+                Vm.Log[] memory logs = vm.getRecordedLogs();
+                assertEq(_countTopic(logs, TOPIC_DEADLINES_SET), 1, "config change is emitted");
+                assertEq(_countTopic(logs, TOPIC_CLAIM_DEADLINE_SET), 0, "no claimer, so no in-flight window to adjust");
+                (,, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, 0);
+            }
+
+            function test_UnclaimThenReclaimEmitsFreshClaimDeadline() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskClaimDeadlineSet(id, uint48(block.timestamp) + WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id); // the clear-on-release is what keeps this from being swallowed
+            }
+
+            /*──────── application system ───────*/
+
+            function test_UnclaimApplicationTaskKeepsHashes() public {
+                uint256 id = _mkAppTask(0, WINDOW);
+                vm.prank(member1);
+                tm.applyForTask(id, keccak256("app1"));
+                vm.prank(member2);
+                tm.applyForTask(id, keccak256("app2"));
+                vm.prank(pm1);
+                tm.approveApplication(id, member1);
+
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                assertEq(_application(id, member1), keccak256("app1"), "releaser stays approvable");
+                assertEq(_application(id, member2), keccak256("app2"), "other applicants stay approvable");
+                assertEq(_applicantCount(id), 0, "applicant array was already emptied at approval time");
+                (TaskManager.Status st, address claimer) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.UNCLAIMED), "anchor: the release really happened");
+                assertEq(claimer, address(0));
+            }
+
+            function test_ApproveOriginalApplicantAfterUnclaim() public {
+                uint256 id = _mkAppTask(0, WINDOW);
+                vm.prank(member1);
+                tm.applyForTask(id, keccak256("app1"));
+                vm.prank(pm1);
+                tm.approveApplication(id, member1);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                // UNCLAIMED branch: no expiry needed to re-approve
+                vm.prank(pm1);
+                tm.approveApplication(id, member1);
+                (TaskManager.Status st, address claimer) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.CLAIMED));
+                assertEq(claimer, member1);
+            }
+
+            function test_ApproveOtherOriginalApplicantAfterUnclaim() public {
+                uint256 id = _mkAppTask(0, WINDOW);
+                vm.prank(member1);
+                tm.applyForTask(id, keccak256("app1"));
+                vm.prank(member2);
+                tm.applyForTask(id, keccak256("app2"));
+                vm.prank(pm1);
+                tm.approveApplication(id, member1);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                vm.prank(pm1);
+                tm.approveApplication(id, member2);
+                (, address claimer) = _status(id);
+                assertEq(claimer, member2);
+            }
+
+            function test_NewApplicantCanApplyAfterUnclaim() public {
+                uint256 id = _mkAppTask(0, WINDOW);
+                vm.prank(member1);
+                tm.applyForTask(id, keccak256("app1"));
+                vm.prank(pm1);
+                tm.approveApplication(id, member1);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                vm.prank(member2); // never applied before
+                tm.applyForTask(id, keccak256("app2"));
+                assertEq(_application(id, member2), keccak256("app2"));
+                assertEq(_applicantCount(id), 1, "fresh applicant list rebuilds from the release");
+            }
+
+            function test_OriginalApplicantCannotReapplyAfterUnclaim() public {
+                uint256 id = _mkAppTask(0, WINDOW);
+                vm.prank(member1);
+                tm.applyForTask(id, keccak256("app1"));
+                vm.prank(pm1);
+                tm.approveApplication(id, member1);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                vm.prank(member1);
+                vm.expectRevert(TaskManager.AlreadyApplied.selector); // harmless: still approvable
+                tm.applyForTask(id, keccak256("app1-again"));
+            }
+
+            function test_DirectClaimStillRevertsAfterUnclaimOfApplicationTask() public {
+                uint256 id = _mkAppTask(0, WINDOW);
+                vm.prank(member1);
+                tm.applyForTask(id, keccak256("app1"));
+                vm.prank(pm1);
+                tm.approveApplication(id, member1);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                vm.prank(member2);
+                vm.expectRevert(TaskManager.RequiresApplication.selector);
+                tm.claimTask(id);
+            }
+
+            function test_UnclaimKeepsApplicantsFiledDuringExpiredWindow() public {
+                // A non-vacuous applicant list: applications filed while the claim was expired are
+                // still queued at release time and must survive it (cancelTask deletes them; this
+                // must not).
+                uint256 id = _mkAppTask(0, WINDOW);
+                vm.prank(member1);
+                tm.applyForTask(id, keccak256("app1"));
+                vm.prank(pm1);
+                tm.approveApplication(id, member1); // empties the array
+                (,, uint48 cd) = _deadlines(id);
+                vm.warp(uint256(cd) + 1);
+
+                vm.prank(member2);
+                tm.applyForTask(id, keccak256("app2")); // allowed while CLAIMED-and-expired
+                assertEq(_applicantCount(id), 1, "precondition: a live applicant is queued");
+
+                vm.prank(pm1);
+                tm.unclaimTask(id);
+
+                assertEq(_applicantCount(id), 1, "queued applicants survive the release");
+                assertEq(_application(id, member2), keccak256("app2"));
+                vm.prank(pm1);
+                tm.approveApplication(id, member2);
+                (, address claimer) = _status(id);
+                assertEq(claimer, member2);
+            }
+
+            function test_UnclaimApplicationTaskByAssignHolderAfterExpiry() public {
+                uint256 id = _mkAppTask(0, WINDOW);
+                vm.prank(member1);
+                tm.applyForTask(id, keccak256("app1"));
+                vm.prank(pm1);
+                tm.approveApplication(id, member1);
+                (,, uint48 cd) = _deadlines(id);
+                vm.warp(uint256(cd) + 1);
+
+                vm.prank(pm1);
+                tm.unclaimTask(id);
+                (TaskManager.Status st, address claimer) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.UNCLAIMED));
+                assertEq(claimer, address(0));
+            }
+
+            /*──────── edit-permission consequence ───────*/
+
+            function test_CreateHatRegainsUnclaimedEditPathAfterRelease() public {
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+
+                // creator2 wears CREATOR_HAT (project CREATE) but is not a manager: no post-claim edits
+                vm.prank(creator2);
+                vm.expectRevert(TaskManager.Unauthorized.selector);
+                tm.updateTask(id, 2 ether, bytes("uc"), bytes32(0), address(0), 0, 0, WINDOW);
+
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                vm.prank(creator2);
+                tm.updateTask(id, 2 ether, bytes("uc"), bytes32(0), address(0), 0, 0, WINDOW);
+                assertEq(_projectSpent(UC_ID), 2 ether, "the task is genuinely unclaimed again");
+            }
+
+            /*──────── fuzz ───────*/
+
+            function testFuzz_UnclaimAlwaysClearsClaimState(uint32 window, uint32 warpBy) public {
+                window = uint32(bound(window, 0, 3650 days));
+                warpBy = uint32(bound(warpBy, 0, 3650 days));
+
+                uint256 id = _mkTask(0, window);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.warp(block.timestamp + warpBy);
+
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                (TaskManager.Status st, address claimer) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.UNCLAIMED));
+                assertEq(claimer, address(0));
+                (, uint32 window_, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, 0, "claim deadline always cleared");
+                assertEq(window_, window, "task config preserved");
+            }
+
+            function testFuzz_UnclaimNeverChangesSpent(uint96 payout, uint32 window) public {
+                payout = uint96(bound(payout, 1, 1e24));
+                window = uint32(bound(window, 0, 3650 days));
+
+                uint256 id = _nextId++;
+                vm.prank(creator1);
+                tm.createTask(payout, bytes("uc"), bytes32(0), UC_ID, address(0), 0, false, 0, window);
+                uint128 spentAtCreate = _projectSpent(UC_ID);
+
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+                assertEq(_projectSpent(UC_ID), spentAtCreate, "budget is keyed to existence, not to who holds it");
+                (TaskManager.Status st, address claimer) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.UNCLAIMED), "anchor: the release really happened");
+                assertEq(claimer, address(0));
+            }
+
+            function testFuzz_ThirdPartyUnclaimBoundary(uint32 window) public {
+                window = uint32(bound(window, 1, 3650 days));
+                uint256 id = _mkTask(0, window);
+                vm.prank(member1);
+                tm.claimTask(id);
+                uint48 cd = uint48(block.timestamp) + window;
+
+                vm.warp(cd); // protected up to and including the deadline second
+                vm.prank(pm1);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.unclaimTask(id);
+
+                vm.warp(uint256(cd) + 1);
+                vm.prank(pm1);
+                tm.unclaimTask(id);
+                (, address claimer) = _status(id);
+                assertEq(claimer, address(0));
+            }
+
+            /*──────── permission-bit precision ───────*/
+
+            function test_ReleaseRequiresTheAssignBitSpecifically() public {
+                // pm1's project mask is REVIEW|ASSIGN, so it cannot tell the two bits apart.
+                // Build an actor that provably holds REVIEW (and everything else) but NOT ASSIGN.
+                uint256 reviewerHat = 7;
+                address reviewer = makeAddr("reviewerOnly");
+                setHat(reviewer, reviewerHat);
+                vm.prank(creator1);
+                tm.setProjectRolePerm(UC_ID, reviewerHat, 0xFF & ~TaskPerm.ASSIGN);
+
+                // proof the actor really wields REVIEW on this project
+                uint256 warmup = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(warmup);
+                vm.prank(member1);
+                tm.submitTask(warmup, keccak256("work"));
+                vm.prank(reviewer);
+                tm.rejectTask(warmup, keccak256("redo")); // REVIEW-gated: succeeds
+
+                uint256 id = _mkTask(0, WINDOW);
+                _claimAndExpire(id, member1);
+                vm.prank(reviewer);
+                vm.expectRevert(TaskManager.Unauthorized.selector); // every bit but ASSIGN is not enough
+                tm.unclaimTask(id);
+
+                // grant exactly the missing bit -> the same call now succeeds
+                vm.prank(creator1);
+                tm.setProjectRolePerm(UC_ID, reviewerHat, 0xFF);
+                vm.prank(reviewer);
+                tm.unclaimTask(id);
+                (, address claimer) = _status(id);
+                assertEq(claimer, address(0));
+            }
+
+            function test_ClaimerHoldingAssignReleasesLiveClaim() public {
+                // The caller is simultaneously the claimer AND an ASSIGN holder, on an UNEXPIRED
+                // claim: route A must win. Guards the natural "check permission first" rewrite,
+                // which would trap exactly the PM/executor assignees this feature exists to free.
+                uint256 a = _mkTask(0, WINDOW);
+                vm.prank(creator1);
+                tm.assignTask(a, pm1); // creator1 is the project manager
+                vm.prank(pm1);
+                tm.unclaimTask(a);
+                (, address claimerA) = _status(a);
+                assertEq(claimerA, address(0), "ASSIGN-holding claimer releases their own live claim");
+
+                uint256 b = _mkTask(0, WINDOW);
+                vm.prank(pm1);
+                tm.assignTask(b, executor);
+                vm.prank(executor);
+                tm.unclaimTask(b);
+                (, address claimerB) = _status(b);
+                assertEq(claimerB, address(0), "executor releases their own live claim");
+
+                uint256 c = _mkTask(0, WINDOW);
+                vm.prank(pm1);
+                tm.assignTask(c, creator1);
+                vm.prank(creator1);
+                tm.unclaimTask(c);
+                (, address claimerC) = _status(c);
+                assertEq(claimerC, address(0), "project manager releases their own live claim");
+            }
+
+            function test_ReleaseAuthorityIsScopedToTaskProject() public {
+                // A second project whose only manager is creator2.
+                vm.prank(creator2);
+                bytes32 p2 = tm.createProject(
+                    TaskManager.BootstrapProjectConfig({
+                        title: "SECOND",
+                        metadataHash: bytes32(0),
+                        cap: 0,
+                        managers: new address[](0),
+                        createHats: _hatArr(CREATOR_HAT),
+                        claimHats: _hatArr(MEMBER_HAT),
+                        reviewHats: _hatArr(PM_HAT),
+                        assignHats: new uint256[](0), // nobody gets ASSIGN by hat here
+                        bountyTokens: new address[](0),
+                        bountyCaps: new uint256[](0)
+                    })
+                );
+
+                uint256 id = _nextId++;
+                vm.prank(creator2);
+                tm.createTask(1 ether, bytes("p2"), bytes32(0), p2, address(0), 0, false, 0, WINDOW);
+                _claimAndExpire(id, member1);
+
+                // creator1 manages UC_ID, not p2 — authority must not leak across projects
+                vm.prank(creator1);
+                vm.expectRevert(TaskManager.Unauthorized.selector);
+                tm.unclaimTask(id);
+                (, address claimer) = _status(id);
+                assertEq(claimer, member1, "claim untouched");
+
+                vm.prank(creator2); // p2's own manager
+                tm.unclaimTask(id);
+                (, claimer) = _status(id);
+                assertEq(claimer, address(0));
+            }
+
+            function test_ProjectOverrideWithoutAssignBlocksRelease() public {
+                // pm1 keeps the global CREATE|REVIEW|ASSIGN mask but loses ASSIGN on UC_ID only.
+                vm.prank(creator1);
+                tm.setProjectRolePerm(UC_ID, PM_HAT, TaskPerm.REVIEW);
+
+                uint256 id = _mkTask(0, WINDOW);
+                _claimAndExpire(id, member1);
+                vm.prank(pm1);
+                vm.expectRevert(TaskManager.Unauthorized.selector); // project override beats the global mask
+                tm.unclaimTask(id);
+            }
+
+            /*──────── third-party release: full effects ───────*/
+
+            function test_ThirdPartyUnclaimClearsClaimDeadline() public {
+                uint256 id = _mkTask(0, WINDOW);
+                _claimAndExpire(id, member1);
+
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskUnclaimed(id, member1, pm1);
+                vm.expectEmit(true, true, true, true);
+                emit TaskManager.TaskClaimDeadlineSet(id, 0);
+                vm.prank(pm1);
+                tm.unclaimTask(id);
+
+                (,, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, 0, "route B clears the window too");
+            }
+
+            function test_ThirdPartyUnclaimWhenEitherDeadlineAlonePasses() public {
+                // Both knobs set (the normal production shape): the claim window lapsing is enough,
+                // even though the calendar cutoff is still in the future.
+                uint256 a = _mkTask(ABS, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(a);
+                vm.warp(block.timestamp + WINDOW + 1);
+                assertLt(block.timestamp, uint256(ABS), "precondition: absolute deadline still ahead");
+                vm.prank(pm1);
+                tm.unclaimTask(a);
+                (, address claimerA) = _status(a);
+                assertEq(claimerA, address(0), "claim-window expiry alone suffices");
+
+                // ...and symmetrically, the calendar cutoff passing is enough while the window runs.
+                uint48 soon = uint48(block.timestamp + 1 days);
+                uint256 b = _mkTask(soon, 3650 days);
+                vm.prank(member1);
+                tm.claimTask(b);
+                (,, uint48 cd) = _deadlines(b);
+                vm.warp(uint256(soon) + 1);
+                assertGt(uint256(cd), block.timestamp, "precondition: claim window still running");
+                vm.prank(pm1);
+                tm.unclaimTask(b);
+                (, address claimerB) = _status(b);
+                assertEq(claimerB, address(0), "absolute expiry alone suffices");
+            }
+
+            function test_TaskUnclaimedTopicLayout() public {
+                // expectEmit cannot see indexedness; the subgraph ABI can. Pin the topic layout.
+                uint256 id = _mkTask(0, WINDOW);
+                _claimAndExpire(id, member1);
+
+                vm.recordLogs();
+                vm.prank(pm1);
+                tm.unclaimTask(id);
+                Vm.Log[] memory logs = vm.getRecordedLogs();
+
+                bool seen;
+                for (uint256 i; i < logs.length; i++) {
+                    if (logs[i].topics[0] != TOPIC_UNCLAIMED) continue;
+                    seen = true;
+                    assertEq(logs[i].topics.length, 4, "id, previousClaimer and caller are all indexed");
+                    assertEq(uint256(logs[i].topics[1]), id);
+                    assertEq(address(uint160(uint256(logs[i].topics[2]))), member1);
+                    assertEq(address(uint160(uint256(logs[i].topics[3]))), pm1);
+                    assertEq(logs[i].data.length, 0, "no unindexed payload");
+                }
+                assertTrue(seen, "TaskUnclaimed emitted");
+            }
+
+            /*──────── org-level interactions ───────*/
+
+            function test_ClaimerCanReleaseAfterProjectDeleted() public {
+                // deleteProject has no live-task guard, so a claimer can be left holding a task
+                // whose project is gone — the trapped-claimer case route A must survive.
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(creator1);
+                tm.deleteProject(UC_ID);
+
+                vm.prank(member1);
+                tm.unclaimTask(id);
+                (TaskManager.Status st, address claimer) = _status(id);
+                assertEq(uint8(st), uint8(TaskManager.Status.UNCLAIMED));
+                assertEq(claimer, address(0));
+            }
+
+            function test_SelfReleaseWorksWhenHatsReverts() public {
+                // Route A must make no Hats call at all: a bricked eligibility/toggle module
+                // (Hats reverting) is exactly when a contributor needs to hand work back.
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+
+                vm.mockCallRevert(address(hats), bytes(""), bytes("boom"));
+                vm.prank(member2);
+                vm.expectRevert(); // sanity: permission-gated paths really are broken now
+                tm.claimTask(id);
+
+                vm.prank(member1);
+                tm.unclaimTask(id);
+                vm.clearMockedCalls();
+
+                (, address claimer) = _status(id);
+                assertEq(claimer, address(0));
+            }
+
+            function test_ExecutorRotationMovesReleaseAuthority() public {
+                address newExec = makeAddr("newExecutor");
+                uint256 id = _mkTask(0, WINDOW);
+                _claimAndExpire(id, member1);
+
+                vm.prank(executor);
+                tm.setConfig(TaskManager.ConfigKey.EXECUTOR, abi.encode(newExec));
+
+                vm.prank(executor); // the old executor is nobody now
+                vm.expectRevert(TaskManager.Unauthorized.selector);
+                tm.unclaimTask(id);
+
+                vm.prank(newExec);
+                tm.unclaimTask(id);
+                (, address claimer) = _status(id);
+                assertEq(claimer, address(0));
+            }
+
+            function test_CompleteAfterReleasePaysNewClaimerOnly() public {
+                uint256 id = _mkBountyTask(2 ether, WINDOW);
+                uint128 ptBefore = _projectSpent(BOUNTY_ID);
+                uint128 bountyBefore = _bountySpent(BOUNTY_ID, address(bountyToken));
+
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+
+                vm.prank(member2);
+                tm.claimTask(id);
+                vm.prank(member2);
+                tm.submitTask(id, keccak256("work"));
+                vm.prank(pm1);
+                tm.completeTask(id);
+
+                assertEq(token.balanceOf(member2), 1 ether, "the finisher is paid the PT");
+                assertEq(token.balanceOf(member1), 0, "the releaser gets nothing");
+                assertEq(bountyToken.balanceOf(member2), 2 ether, "the finisher is paid the bounty");
+                assertEq(bountyToken.balanceOf(member1), 0, "no partial credit on release");
+                assertEq(bountyToken.balanceOf(address(tm)), 998 ether, "exactly one bounty transfer");
+                assertEq(_projectSpent(BOUNTY_ID), ptBefore, "reservations untouched by the whole cycle");
+                assertEq(_bountySpent(BOUNTY_ID, address(bountyToken)), bountyBefore);
+            }
+
+            function test_LensFullInfoOnlyClaimFieldsChange() public {
+                uint256 id = _mkBountyTask(2 ether, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+
+                bytes memory before = lens.getStorage(
+                    address(tm), TaskManagerLens.StorageKey.TASK_FULL_INFO, abi.encode(id)
+                );
+                vm.prank(member1);
+                tm.unclaimTask(id);
+                bytes memory after_ = lens.getStorage(
+                    address(tm), TaskManagerLens.StorageKey.TASK_FULL_INFO, abi.encode(id)
+                );
+
+                // 0 payout, 1 bountyPayout, 2 bountyToken, 3 status, 4 claimer,
+                // 5 projectId, 6 requiresApplication, 7 absoluteDeadline, 8 completionWindow, 9 claimDeadline
+                uint256[7] memory untouched = [uint256(0), 1, 2, 5, 6, 7, 8];
+                for (uint256 i; i < untouched.length; i++) {
+                    assertEq(_word(after_, untouched[i]), _word(before, untouched[i]), "field must not change");
+                }
+                assertEq(uint256(_word(after_, 3)), uint256(TaskManager.Status.UNCLAIMED), "status");
+                assertEq(uint256(_word(after_, 4)), 0, "claimer");
+                assertEq(uint256(_word(after_, 9)), 0, "claimDeadline");
+                assertTrue(_word(before, 4) != bytes32(0), "precondition: was claimed");
+            }
+
+            /*──────── documented consequence: the window can be refreshed by the claimer ───────*/
+
+            function test_ReleaseAndReclaimRefreshesProtection() public {
+                // A claimer can pre-empt takeover by releasing and immediately re-claiming.
+                // This is accepted (v6 already lets an expired claimer re-claim to refresh);
+                // absoluteDeadline is the lever that defeats it.
+                uint256 id = _mkTask(0, WINDOW);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.warp(block.timestamp + WINDOW - 1); // one second before losing protection
+
+                vm.prank(member1);
+                tm.unclaimTask(id);
+                vm.prank(member1);
+                tm.claimTask(id);
+
+                (,, uint48 cd_) = _deadlines(id);
+                assertEq(cd_, uint48(block.timestamp) + WINDOW, "protection refreshed");
+                vm.prank(pm1);
+                vm.expectRevert(TaskManager.BadStatus.selector);
+                tm.unclaimTask(id);
+
+                // ...but a past absoluteDeadline makes every re-claim born unprotected
+                vm.prank(executor);
+                tm.updateTask(id, 1 ether, bytes("uc"), bytes32(0), address(0), 0, uint48(block.timestamp - 1), WINDOW);
+                vm.prank(member1);
+                tm.unclaimTask(id);
+                vm.prank(member1);
+                tm.claimTask(id);
+                vm.prank(pm1);
+                tm.unclaimTask(id); // still releasable: absolute expiry cannot be refreshed
+                (, address claimer) = _status(id);
+                assertEq(claimer, address(0));
+            }
+        }


### PR DESCRIPTION
Adds `unclaimTask(uint256)` (`0x6103955a`) and a `TaskUnclaimed(id, previousClaimer, caller)` event: a CLAIMED task returns to UNCLAIMED with no claimer, where the claimer may **always** release (ungated on purpose — `assignTask`/`createAndAssignTask` never check the assignee's mask and hats get revoked mid-claim, so gating on CLAIM would trap exactly the people this frees), while anyone else needs ASSIGN **and** an already-expired claim, which is `assignTask`'s takeover gate with no replacement named and therefore grants no new authority. SUBMITTED is excluded because a zeroed claimer would let `completeTask` mint to `address(0)` and brick the task (un-completable, un-submittable, un-cancellable), so the route out is `rejectTask` → `unclaimTask`; budgets and application hashes are deliberately untouched, keeping `cancelTask` the single refund path so a claim/release cycle can never double-refund. The change is additive only — no Layout, Task, or Status change and no existing selector touched — plus OrgDeployer v18 wiring so newly deployed orgs auto-whitelist the selector for gas sponsorship (TaskManager rules 16→17, base count 43→44).

Also included: a new `TaskManagerUnclaimTest` with 65 cases (3 fuzz) covering the permission matrix, every revert path, event ordering, budget non-effects, application interactions and takeover races; `DeployerTest` assertions for the new rule with education both on and off (distinct rule-array sizing paths) plus selector accuracy, both mutation-checked by removing the rule and confirming they fail; `docs/TASK_MANAGER.md` updates to the state diagram, actions table and event contract; and both upgrade scripts, whose fork sims all PASS under `FOUNDRY_PROFILE=production` (v7/v18 probed FREE on registry **and** CREATE2 across Gnosis and Arbitrum, with the TaskManager dry runs exercising a live proxy end-to-end on both chains). Full suite: **1882 passed**.

Broadcast TaskManager v7 **before** OrgDeployer v18, or a newly deployed org gets a paymaster rule for a selector its beacon does not yet implement; already-live orgs need a separate per-org governance batch (not in this PR), and the indexer side is poa-box/subgraph-pop#201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)