### PR TITLE
fix(paymaster): auto-whitelist the real ZkEmailInvites claim selectors (#188)

### DIFF
--- a/script/upgrades/UpgradeOrgDeployerZkEmailRules.s.sol
+++ b/script/upgrades/UpgradeOrgDeployerZkEmailRules.s.sol
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.21;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+
+import {OrgDeployer, ITaskManagerBootstrap} from "../../src/OrgDeployer.sol";
+import {ModulesFactory} from "../../src/factories/ModulesFactory.sol";
+import {RoleConfigStructs} from "../../src/libs/RoleConfigStructs.sol";
+import {IHybridVotingInit} from "../../src/libs/ModuleDeploymentLib.sol";
+import {PaymasterHub} from "../../src/PaymasterHub.sol";
+import {PoaManager} from "../../src/PoaManager.sol";
+import {DeterministicDeployer} from "../../src/crosschain/DeterministicDeployer.sol";
+import {ZkEmailInvites} from "../../src/ZkEmailInvites.sol";
+
+/*
+ * ============================================================================
+ * OrgDeployer v19 — real ZkEmailInvites claim selectors in the auto-whitelist (issue #188)
+ * ============================================================================
+ *
+ * `_appendZkEmailInvitesRules` derived its four selectors by hashing PRE-Blocker-2
+ * signature strings whose `ZkEmailProof` tuple ended in `string`. The live struct ends in
+ * `bytes32 fromDomainHash`, so every one of those four selectors was wrong:
+ *
+ *   stale 0xc8864f92 / 0x50b2f726 / 0xcc1866ac / 0xebd847f2   (no function answers these)
+ *   live  0x24b5e3ba / 0x8c149bab / 0x6108482e / 0x998dc9d6
+ *
+ * Any org deployed with `autoWhitelistContracts: true` + zk-email enabled therefore got four
+ * dead paymaster rules and ZERO sponsorship on the real claim entrypoints — gasless zk-email
+ * claims fail rule validation. v19 replaces the strings with compiler-derived
+ * `ZkEmailInvites.<fn>.selector`, so they can never drift from the ABI again.
+ *
+ *   Live impl: v18 (0xE328c6093e53cBafea8d4461e9bd4345786decC9, both chains)
+ *   This PR:   v19
+ *
+ * Version selection (CLAUDE.md two-surface probe, both chains, 2026-08-04):
+ *   Gnosis   registry count=16; v16/v17/v18 TAKEN (registry+CREATE2); v19 FREE on both surfaces.
+ *   Arbitrum registry count=17; v16/v17/v18 TAKEN (registry+CREATE2); v19 FREE on both surfaces.
+ *   Predicted v19 impl (identical on both chains): 0x90BAe532D26100a2106c3b16bEA1Ad27D2286b3A
+ *
+ * Forward-only. No live org needs a governance back-fill: `_appendZkEmailInvitesRules` has never
+ * run on-chain (both existing ZkEmailInvites modules — Test6 and KUBI on Gnosis — are retrofits
+ * whose rules were set by their own scripts, and Test6's ceremony already wrote the correct
+ * selectors). But the zk infra IS wired on both chains (OrgDeployer layout +10/+11/+12 all
+ * non-zero) and the ZkEmailInvites beacon IS registered on both, so the bug is armed for the very
+ * next `deployFullOrgWithZkEmail` — land this BEFORE broadcasting script/org/DeployComfiestHouse.
+ *
+ * Uses the fee-free upgrade path (CLAUDE.md: prefer the destination chain over a Hyperlane
+ * dispatch) — Satellite.upgradeBeaconDirect on Gnosis, Hub.upgradeBeaconLocal on Arbitrum. No
+ * 0.005 ETH fee, no 5-minute relay, and both sides are fork-simulatable.
+ *
+ * RUN ORDER (all FOUNDRY_PROFILE=production)
+ *   0. SimZkEmailRulesGnosis   --fork-url gnosis    (must PASS)
+ *      SimZkEmailRulesArbitrum --fork-url arbitrum  (must PASS)
+ *   1. Step1_UpgradeGnosis   --rpc-url gnosis   --broadcast --slow
+ *   2. Step2_UpgradeArbitrum --rpc-url arbitrum --broadcast --slow
+ *   3. Step3_Verify --fork-url gnosis ; Step3_Verify --fork-url arbitrum
+ * ============================================================================
+ */
+
+address constant DD = 0x4aC8B5ebEb9D8C3dE3180ddF381D552d59e8835a;
+address constant HUB = 0xB72840B343654eAfb2CFf7acC4Fc6b59E6c3CC71; // PoaManagerHub (Arbitrum)
+address constant GNOSIS_SATELLITE = 0x4Ad70029a9247D369a5bEA92f90840B9ee58eD06; // owner = Hudson
+address constant HUDSON = 0xA6F4D9f44Dd980b7168D829d5f74c2b00a46b2c9;
+address constant ORG_DEPLOYER = 0x1Ad59E785E3aec1c53069f78bEcC24EcFE6a5d1c; // same both chains (CREATE3)
+
+address constant GNOSIS_POA_MANAGER = 0x794fD39e75140ee1545B1B022E5486B7c863789b;
+address constant GNOSIS_ACCOUNT_REGISTRY = 0x55F72CEB09cBC1fAAED734b6505b99b0a1DFA1cA;
+address constant GNOSIS_PAYMASTER_HUB = 0xdEf1038C297493c0b5f82F0CDB49e929B53B4108;
+
+address constant ARB_POA_MANAGER = 0xFF585Fae4A944cD173B19158C6FC5E08980b0815;
+address constant ARB_ACCOUNT_REGISTRY = 0x01A13c92321E9CA2C02577b92A4F8d2FDC4d8513;
+address constant ARB_PAYMASTER_HUB = 0xD6659bCaFAdCB9CC2F57B7aE923c7F1Ca4438a11;
+
+string constant VERSION = "v19";
+
+/// @dev The four PRE-Blocker-2 selectors v18 and earlier wrote. Kept ONLY so the sim can prove
+///      they are gone; never register these.
+bytes4 constant STALE_CLAIM_DOMAIN = 0xc8864f92;
+bytes4 constant STALE_CLAIM_EMAIL = 0x50b2f726;
+bytes4 constant STALE_REG_CLAIM_DOMAIN = 0xcc1866ac;
+bytes4 constant STALE_REG_CLAIM_EMAIL = 0xebd847f2;
+
+interface ISatelliteZk {
+    function upgradeBeaconDirect(string calldata typeName, address newImpl, string calldata version) external;
+    function owner() external view returns (address);
+}
+
+interface IHubZk {
+    function upgradeBeaconLocal(string calldata typeName, address newImpl, string calldata version) external;
+    function owner() external view returns (address);
+    function paused() external view returns (bool);
+}
+
+abstract contract ZkEmailRulesBase is Script {
+    /* ── deploy ── */
+
+    function _predicted(DeterministicDeployer dd) internal view returns (address) {
+        return dd.computeAddress(dd.computeSalt("OrgDeployer", VERSION));
+    }
+
+    /// @dev Idempotent CREATE3 deploy — skips a slot that already holds code. The two-surface probe
+    ///      in the header confirmed v19 is free on both chains; a takeover between probe and
+    ///      broadcast surfaces as the bytecode check below failing.
+    function _deployImpl(DeterministicDeployer dd) internal returns (address impl) {
+        impl = _predicted(dd);
+        if (impl.code.length > 0) {
+            console.log("OrgDeployer", VERSION, "already deployed:", impl);
+        } else {
+            address deployed = dd.deploy(dd.computeSalt("OrgDeployer", VERSION), type(OrgDeployer).creationCode);
+            require(deployed == impl, "DD address mismatch");
+            console.log("OrgDeployer", VERSION, "deployed:", deployed);
+        }
+        require(
+            keccak256(impl.code) == keccak256(type(OrgDeployer).runtimeCode), "impl != this branch's OrgDeployer build"
+        );
+    }
+
+    /* ── behavioural before/after on a real fork ── */
+
+    /// @dev Deploys a throwaway org through the LIVE OrgDeployer proxy with
+    ///      `autoWhitelistContracts: true` + zk-email enabled, then reports which claim selectors
+    ///      the paymaster actually ended up sponsoring. This is the whole point of the sim: the
+    ///      selectors are keccak-of-string-literal constants that the optimizer folds and
+    ///      materialises arithmetically, so grepping the impl bytecode for them proves nothing —
+    ///      only a real deploy shows which rules land.
+    function _deployFixtureAndReadRules(bytes32 orgId, address accountRegistry, address paymasterHub)
+        internal
+        returns (bool[4] memory liveAllowed, uint32[4] memory liveHints, bool[4] memory staleAllowed)
+    {
+        vm.prank(HUDSON);
+        OrgDeployer.DeploymentResult memory r = OrgDeployer(ORG_DEPLOYER)
+            .deployFullOrgWithZkEmail(
+                _fixtureParams(orgId, accountRegistry),
+                ModulesFactory.ZkEmailConfig({enabled: true, initialRoot: bytes32(0), initialCid: bytes32(0)})
+            );
+        require(r.zkEmailInvites != address(0), "sim: zk module not deployed (infra/beacon missing on this chain)");
+
+        PaymasterHub hub = PaymasterHub(payable(paymasterHub));
+        bytes4[4] memory live = [
+            ZkEmailInvites.claimRoleByDomain.selector,
+            ZkEmailInvites.claimRoleByEmail.selector,
+            ZkEmailInvites.registerAndClaimByDomainWithPasskey.selector,
+            ZkEmailInvites.registerAndClaimByEmailWithPasskey.selector
+        ];
+        bytes4[4] memory stale = [STALE_CLAIM_DOMAIN, STALE_CLAIM_EMAIL, STALE_REG_CLAIM_DOMAIN, STALE_REG_CLAIM_EMAIL];
+
+        for (uint256 i; i < 4; i++) {
+            PaymasterHub.Rule memory ruleLive = hub.getRule(orgId, r.zkEmailInvites, live[i]);
+            liveAllowed[i] = ruleLive.allowed;
+            liveHints[i] = ruleLive.maxCallGasHint;
+            staleAllowed[i] = hub.getRule(orgId, r.zkEmailInvites, stale[i]).allowed;
+        }
+    }
+
+    /// @dev The v18 (pre-fix) expectation: dead rules registered, real entrypoints unsponsored.
+    function _requireBuggyRules(bytes32 orgId, address accountRegistry, address paymasterHub) internal {
+        (bool[4] memory liveAllowed,, bool[4] memory staleAllowed) =
+            _deployFixtureAndReadRules(orgId, accountRegistry, paymasterHub);
+        for (uint256 i; i < 4; i++) {
+            require(!liveAllowed[i], "BEFORE: live selector already sponsored - is v19 already deployed?");
+            require(staleAllowed[i], "BEFORE: expected the stale selector to be whitelisted on the old impl");
+        }
+        console.log("BEFORE (v18): 4/4 stale selectors sponsored, 0/4 real claim entrypoints sponsored");
+    }
+
+    /// @dev The v19 expectation: real entrypoints sponsored with their gas hints, no dead rules.
+    function _requireFixedRules(bytes32 orgId, address accountRegistry, address paymasterHub) internal {
+        (bool[4] memory liveAllowed, uint32[4] memory liveHints, bool[4] memory staleAllowed) =
+            _deployFixtureAndReadRules(orgId, accountRegistry, paymasterHub);
+        uint32[4] memory expectedHints = [uint32(800_000), 800_000, 1_200_000, 1_200_000];
+        for (uint256 i; i < 4; i++) {
+            require(liveAllowed[i], "AFTER: real claim selector not sponsored");
+            require(liveHints[i] == expectedHints[i], "AFTER: gas hint mismatch");
+            require(!staleAllowed[i], "AFTER: stale selector still whitelisted");
+        }
+        console.log("AFTER  (v19): 4/4 real claim entrypoints sponsored (800k/800k/1.2M/1.2M), 0/4 stale");
+    }
+
+    /* ── fixture org ── */
+
+    function _fixtureParams(bytes32 orgId, address accountRegistry)
+        internal
+        pure
+        returns (OrgDeployer.DeploymentParams memory)
+    {
+        return OrgDeployer.DeploymentParams({
+            orgId: orgId,
+            orgName: "ZkRules Fixture",
+            metadataHash: bytes32(0),
+            registryAddr: accountRegistry,
+            deployerAddress: HUDSON,
+            deployerUsername: "",
+            regDeadline: 0,
+            regNonce: 0,
+            regSignature: "",
+            autoUpgrade: true,
+            hybridThresholdPct: 50,
+            ddThresholdPct: 50,
+            hybridClasses: _fixtureClasses(),
+            ddInitialTargets: new address[](0),
+            roles: _fixtureRoles(),
+            roleAssignments: _fixtureAssignments(),
+            metadataAdminRoleIndex: type(uint256).max,
+            passkeyEnabled: false,
+            educationHubConfig: ModulesFactory.EducationHubConfig({enabled: false}),
+            bootstrap: OrgDeployer.BootstrapConfig({
+                projects: new ITaskManagerBootstrap.BootstrapProjectConfig[](0),
+                tasks: new ITaskManagerBootstrap.BootstrapTaskConfig[](0)
+            }),
+            // The knob under test: auto-whitelist writes the default rule batch, zk-email rules included.
+            paymasterConfig: OrgDeployer.PaymasterConfig({
+                operatorRoleIndex: type(uint256).max,
+                autoWhitelistContracts: true,
+                maxFeePerGas: 0,
+                maxPriorityFeePerGas: 0,
+                maxCallGas: 0,
+                maxVerificationGas: 0,
+                maxPreVerificationGas: 0,
+                defaultBudgetCapPerEpoch: 0,
+                defaultBudgetEpochLen: 0
+            }),
+            taskManagerPerms: OrgDeployer.TaskManagerPermConfig({roleIndices: new uint256[](0), masks: new uint8[](0)}),
+            hybridQuorum: 2,
+            ddQuorum: 2,
+            tokenName: "ZkRules Shares",
+            tokenSymbol: "ZKRF"
+        });
+    }
+
+    function _fixtureRoles() private pure returns (RoleConfigStructs.RoleConfig[] memory roles) {
+        roles = new RoleConfigStructs.RoleConfig[](1);
+        roles[0] = RoleConfigStructs.RoleConfig({
+            name: "MEMBER",
+            image: "",
+            metadataCID: bytes32(0),
+            canVote: true,
+            vouching: RoleConfigStructs.RoleVouchingConfig({
+                enabled: false, quorum: 0, voucherRoleIndex: 0, combineWithHierarchy: false
+            }),
+            defaults: RoleConfigStructs.RoleEligibilityDefaults({eligible: true, standing: true}),
+            hierarchy: RoleConfigStructs.RoleHierarchyConfig({adminRoleIndex: type(uint256).max}),
+            distribution: RoleConfigStructs.RoleDistributionConfig({
+                mintToDeployer: true, additionalWearers: new address[](0)
+            }),
+            hatConfig: RoleConfigStructs.HatConfig({maxSupply: 0, mutableHat: true})
+        });
+    }
+
+    function _fixtureAssignments() private pure returns (OrgDeployer.RoleAssignments memory) {
+        return OrgDeployer.RoleAssignments({
+            quickJoinRolesBitmap: 1,
+            tokenMemberRolesBitmap: 1,
+            tokenApproverRolesBitmap: 1,
+            taskCreatorRolesBitmap: 1,
+            educationCreatorRolesBitmap: 0,
+            educationMemberRolesBitmap: 0,
+            hybridProposalCreatorRolesBitmap: 1,
+            ddVotingRolesBitmap: 1,
+            ddCreatorRolesBitmap: 1
+        });
+    }
+
+    function _fixtureClasses() private pure returns (IHybridVotingInit.ClassConfig[] memory classes) {
+        classes = new IHybridVotingInit.ClassConfig[](1);
+        classes[0] = IHybridVotingInit.ClassConfig({
+            strategy: IHybridVotingInit.ClassStrategy.DIRECT,
+            slicePct: 100,
+            quadratic: false,
+            minBalance: 0,
+            asset: address(0),
+            hatIds: new uint256[](0)
+        });
+    }
+
+    /* ── shared verify ── */
+
+    function _alreadyLive(address poaManager, address impl) internal view returns (bool live) {
+        live = PoaManager(poaManager).getCurrentImplementationById(keccak256("OrgDeployer")) == impl;
+        if (live) console.log("Beacon already points at", impl, "- skipping upgrade call");
+    }
+
+    function _requireLive(address poaManager) internal view {
+        address expected = _predicted(DeterministicDeployer(DD));
+        address current = PoaManager(poaManager).getCurrentImplementationById(keccak256("OrgDeployer"));
+        console.log("Expected:", expected);
+        console.log("Current: ", current);
+        require(current == expected, "OrgDeployer v19 not live on this chain");
+    }
+}
+
+/*═══════════════════════════ SIMS (must PASS before broadcast) ═══════════════════════════*/
+
+contract SimZkEmailRulesGnosis is ZkEmailRulesBase {
+    function run() external {
+        require(block.chainid == 100, "fork gnosis");
+        console.log("\n=== SIM: OrgDeployer v19 zk-email rule fix (Gnosis fork) ===");
+        require(ISatelliteZk(GNOSIS_SATELLITE).owner() == HUDSON, "Satellite owner != Hudson");
+
+        address before = PoaManager(GNOSIS_POA_MANAGER).getCurrentImplementationById(keccak256("OrgDeployer"));
+        console.log("Current impl:", before);
+
+        // BEFORE: prove the live impl really does register the dead selectors.
+        _requireBuggyRules(keccak256("zkrules-sim-before-gnosis"), GNOSIS_ACCOUNT_REGISTRY, GNOSIS_PAYMASTER_HUB);
+
+        vm.startPrank(HUDSON);
+        address impl = _deployImpl(DeterministicDeployer(DD));
+        ISatelliteZk(GNOSIS_SATELLITE).upgradeBeaconDirect("OrgDeployer", impl, VERSION);
+        vm.stopPrank();
+
+        address after_ = PoaManager(GNOSIS_POA_MANAGER).getCurrentImplementationById(keccak256("OrgDeployer"));
+        require(after_ == impl, "beacon not upgraded");
+        require(before != after_, "impl did not change");
+        console.log("New impl:", after_, "codesize:", after_.code.length);
+
+        // AFTER: same deploy path, correct rules.
+        _requireFixedRules(keccak256("zkrules-sim-after-gnosis"), GNOSIS_ACCOUNT_REGISTRY, GNOSIS_PAYMASTER_HUB);
+
+        console.log("\n=== PASS: SimZkEmailRulesGnosis ===");
+    }
+}
+
+contract SimZkEmailRulesArbitrum is ZkEmailRulesBase {
+    function run() external {
+        require(block.chainid == 42161, "fork arbitrum");
+        console.log("\n=== SIM: OrgDeployer v19 zk-email rule fix (Arbitrum fork) ===");
+        require(IHubZk(HUB).owner() == HUDSON, "Hub owner != Hudson");
+        require(!IHubZk(HUB).paused(), "Hub is paused");
+
+        address before = PoaManager(ARB_POA_MANAGER).getCurrentImplementationById(keccak256("OrgDeployer"));
+        console.log("Current impl:", before);
+
+        _requireBuggyRules(keccak256("zkrules-sim-before-arb"), ARB_ACCOUNT_REGISTRY, ARB_PAYMASTER_HUB);
+
+        vm.startPrank(HUDSON);
+        address impl = _deployImpl(DeterministicDeployer(DD));
+        IHubZk(HUB).upgradeBeaconLocal("OrgDeployer", impl, VERSION);
+        vm.stopPrank();
+
+        address after_ = PoaManager(ARB_POA_MANAGER).getCurrentImplementationById(keccak256("OrgDeployer"));
+        require(after_ == impl, "beacon not upgraded");
+        require(before != after_, "impl did not change");
+        console.log("New impl:", after_, "codesize:", after_.code.length);
+
+        _requireFixedRules(keccak256("zkrules-sim-after-arb"), ARB_ACCOUNT_REGISTRY, ARB_PAYMASTER_HUB);
+
+        console.log("\n=== PASS: SimZkEmailRulesArbitrum ===");
+    }
+}
+
+/*═══════════════════════════════════ BROADCASTS ═══════════════════════════════════*/
+
+contract Step1_UpgradeGnosis is ZkEmailRulesBase {
+    function run() external {
+        require(block.chainid == 100, "run on gnosis");
+        uint256 key = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        require(vm.addr(key) == ISatelliteZk(GNOSIS_SATELLITE).owner(), "signer must own the Satellite");
+
+        console.log("\n=== Step 1: OrgDeployer v19 on Gnosis ===");
+        vm.startBroadcast(key);
+        address impl = _deployImpl(DeterministicDeployer(DD));
+        // Idempotent: PoaManager.upgradeBeacon reverts SameImplementation() if the beacon already
+        // points here, so a re-run would fail the whole broadcast. Skip instead.
+        if (!_alreadyLive(GNOSIS_POA_MANAGER, impl)) {
+            ISatelliteZk(GNOSIS_SATELLITE).upgradeBeaconDirect("OrgDeployer", impl, VERSION);
+        }
+        vm.stopBroadcast();
+
+        _requireLive(GNOSIS_POA_MANAGER);
+        console.log("Gnosis upgrade: PASS");
+    }
+}
+
+contract Step2_UpgradeArbitrum is ZkEmailRulesBase {
+    function run() external {
+        require(block.chainid == 42161, "run on arbitrum");
+        uint256 key = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        require(vm.addr(key) == IHubZk(HUB).owner(), "signer must own the Hub");
+        require(!IHubZk(HUB).paused(), "Hub is paused");
+
+        console.log("\n=== Step 2: OrgDeployer v19 on Arbitrum ===");
+        vm.startBroadcast(key);
+        address impl = _deployImpl(DeterministicDeployer(DD));
+        if (!_alreadyLive(ARB_POA_MANAGER, impl)) {
+            IHubZk(HUB).upgradeBeaconLocal("OrgDeployer", impl, VERSION);
+        }
+        vm.stopBroadcast();
+
+        _requireLive(ARB_POA_MANAGER);
+        console.log("Arbitrum upgrade: PASS");
+    }
+}
+
+contract Step3_Verify is ZkEmailRulesBase {
+    function run() external view {
+        console.log("\n=== Verify OrgDeployer v19 (chainid", block.chainid, ") ===");
+        _requireLive(block.chainid == 100 ? GNOSIS_POA_MANAGER : ARB_POA_MANAGER);
+        console.log("PASS: new orgs auto-whitelist the real ZkEmailInvites claim selectors");
+    }
+}

--- a/script/upgrades/UpgradeOrgDeployerZkEmailRules.s.sol
+++ b/script/upgrades/UpgradeOrgDeployerZkEmailRules.s.sol
@@ -275,6 +275,15 @@ abstract contract ZkEmailRulesBase is Script {
 
     /* ── shared verify ── */
 
+    /// @dev Accepts EITHER env var. Do NOT collapse this to
+    ///      `vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"))` (the older upgrade scripts'
+    ///      spelling): Solidity evaluates the default eagerly, so that form reverts when
+    ///      DEPLOYER_PRIVATE_KEY is unset even if PRIVATE_KEY is set.
+    function _signerKey() internal view returns (uint256 key) {
+        key = vm.envOr("PRIVATE_KEY", uint256(0));
+        if (key == 0) key = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    }
+
     function _alreadyLive(address poaManager, address impl) internal view returns (bool live) {
         live = PoaManager(poaManager).getCurrentImplementationById(keccak256("OrgDeployer")) == impl;
         if (live) console.log("Beacon already points at", impl, "- skipping upgrade call");
@@ -353,7 +362,7 @@ contract SimZkEmailRulesArbitrum is ZkEmailRulesBase {
 contract Step1_UpgradeGnosis is ZkEmailRulesBase {
     function run() external {
         require(block.chainid == 100, "run on gnosis");
-        uint256 key = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        uint256 key = _signerKey();
         require(vm.addr(key) == ISatelliteZk(GNOSIS_SATELLITE).owner(), "signer must own the Satellite");
 
         console.log("\n=== Step 1: OrgDeployer v19 on Gnosis ===");
@@ -374,7 +383,7 @@ contract Step1_UpgradeGnosis is ZkEmailRulesBase {
 contract Step2_UpgradeArbitrum is ZkEmailRulesBase {
     function run() external {
         require(block.chainid == 42161, "run on arbitrum");
-        uint256 key = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        uint256 key = _signerKey();
         require(vm.addr(key) == IHubZk(HUB).owner(), "signer must own the Hub");
         require(!IHubZk(HUB).paused(), "Hub is paused");
 

--- a/script/zkemail/IntegrateZkEmailTest6.s.sol
+++ b/script/zkemail/IntegrateZkEmailTest6.s.sol
@@ -220,8 +220,11 @@ abstract contract Test6Base is Script {
         }
     }
 
-    /* ── Selectors (must match ZkEmailInvites external signatures exactly; copied from
-     *    OrgDeployer._appendZkEmailInvitesRules so a per-org retrofit matches new-org deploys). ── */
+    /* ── HISTORICAL: the PRE-Blocker-2 claim selectors this script actually broadcast (see the
+     *    SUPERSEDED banner above). Preserved verbatim as the record of what was written on-chain —
+     *    do NOT copy them anywhere, and do NOT "refresh" them: they are stale by design.
+     *    Any NEW script must derive selectors as `ZkEmailInvites.<fn>.selector` (issue #188);
+     *    CeremonyDeployTest6Gnosis.s.sol is the current reference. ── */
     bytes4 internal constant SEL_CLAIM_DOMAIN = bytes4(
         keccak256(
             "claimRoleByDomain((uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string),address,uint256[],bytes32[])"

--- a/src/OrgDeployer.sol
+++ b/src/OrgDeployer.sol
@@ -11,6 +11,9 @@ import {GovernanceFactory, IHatsTreeSetup} from "./factories/GovernanceFactory.s
 import {AccessFactory} from "./factories/AccessFactory.sol";
 import {ModulesFactory} from "./factories/ModulesFactory.sol";
 import {RoleConfigStructs} from "./libs/RoleConfigStructs.sol";
+/// @dev Imported ONLY for compiler-derived `.selector` constants in the paymaster auto-whitelist
+///      (no runtime cost, no creation code — the edge already exists via ModulesFactory).
+import {ZkEmailInvites} from "./ZkEmailInvites.sol";
 
 /*────────────────────── Module‑specific hooks ──────────────────────────*/
 interface IExecutorAdmin {
@@ -104,6 +107,9 @@ contract OrgDeployer is Initializable {
     error OrgExistsMismatch();
     error Reentrant();
     error InvalidRoleConfiguration();
+    /// @dev The default-paymaster-rule builder filled a different number of slots than it allocated —
+    ///      a rule was added/removed without updating the `count` literal.
+    error RuleCountMismatch();
 
     /*────────────────────────────  Events  ───────────────────────────────*/
     event OrgDeployed(
@@ -1041,13 +1047,17 @@ contract OrgDeployer is Initializable {
         i++;
 
         if (educationEnabled) {
-            _appendEducationHubRules(targets, selectors, result.educationHub, i);
-            i += 4;
+            i = _appendEducationHubRules(targets, selectors, result.educationHub, i);
         }
 
         if (zkEmailEnabled) {
             i = _appendZkEmailInvitesRules(targets, selectors, gasHints, result.zkEmailInvites, i);
         }
+
+        // Every slot must be filled: an under-count panics (array OOB) inside a helper, but an OVER-count
+        // would leave a trailing zero-address rule that PaymasterHub only rejects incidentally. Assert the
+        // invariant explicitly so a future rule addition that forgets to bump `count` fails loudly here.
+        if (i != count) revert RuleCountMismatch();
 
         // Set all rules to allowed (gas hints already populated where non-zero).
         for (uint256 j = 0; j < count; j++) {
@@ -1055,11 +1065,11 @@ contract OrgDeployer is Initializable {
         }
     }
 
-    /// @dev ZkEmailProof tuple (domain): (uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string)
-    ///      ZkEmailProofV2 tuple (email): (uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string,bytes32)
-    ///      PasskeyEnrollment tuple: (bytes32,bytes32,bytes32,uint256)
-    ///      WebAuthnAuth tuple: (bytes,bytes,uint256,uint256,bytes32,bytes32)
-    ///      4 selectors: domain claim, specific-address claim, and the two passkey register-and-claim variants.
+    /// @dev 4 selectors: domain claim, specific-address claim, and the two passkey register-and-claim variants.
+    ///      These MUST be compiler-derived `.selector` references, never hand-hashed signature strings: the
+    ///      Blocker-2 domain-binding change swapped `ZkEmailProof`'s trailing `string` for `bytes32
+    ///      fromDomainHash`, which moved all four selectors. The stale strings survived that change and every
+    ///      new org got four rules no function answers, so gasless claims failed rule validation (issue #188).
     function _appendZkEmailInvitesRules(
         address[] memory targets,
         bytes4[] memory selectors,
@@ -1069,38 +1079,22 @@ contract OrgDeployer is Initializable {
     ) private pure returns (uint256) {
         // Bare domain claim: Groth16 verify (~250k) + DKIM lookup + merkle proof + hat mint.
         targets[i] = zk;
-        selectors[i] = bytes4(
-            keccak256(
-                "claimRoleByDomain((uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string),address,uint256[],bytes32[])"
-            )
-        );
+        selectors[i] = ZkEmailInvites.claimRoleByDomain.selector;
         gasHints[i] = 800_000;
         i++;
         // Bare specific-address claim (v2 proof carries emailHash).
         targets[i] = zk;
-        selectors[i] = bytes4(
-            keccak256(
-                "claimRoleByEmail((uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string,bytes32),address,uint256[],bytes32[])"
-            )
-        );
+        selectors[i] = ZkEmailInvites.claimRoleByEmail.selector;
         gasHints[i] = 800_000;
         i++;
         // Combined register + domain claim: passkey registration + account create + proof + merkle + mint.
         targets[i] = zk;
-        selectors[i] = bytes4(
-            keccak256(
-                "registerAndClaimByDomainWithPasskey((bytes32,bytes32,bytes32,uint256),string,uint256,uint256,(bytes,bytes,uint256,uint256,bytes32,bytes32),(uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string),uint256[],bytes32[])"
-            )
-        );
+        selectors[i] = ZkEmailInvites.registerAndClaimByDomainWithPasskey.selector;
         gasHints[i] = 1_200_000;
         i++;
         // Combined register + specific-address claim.
         targets[i] = zk;
-        selectors[i] = bytes4(
-            keccak256(
-                "registerAndClaimByEmailWithPasskey((bytes32,bytes32,bytes32,uint256),string,uint256,uint256,(bytes,bytes,uint256,uint256,bytes32,bytes32),(uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string,bytes32),uint256[],bytes32[])"
-            )
-        );
+        selectors[i] = ZkEmailInvites.registerAndClaimByEmailWithPasskey.selector;
         gasHints[i] = 1_200_000;
         i++;
         return i;
@@ -1308,12 +1302,14 @@ contract OrgDeployer is Initializable {
         return i;
     }
 
+    /// @dev Returns the advanced index like every sibling helper — the caller must NOT hand-advance `i`,
+    ///      or adding a rule here silently overwrites the next module's slot.
     function _appendEducationHubRules(
         address[] memory targets,
         bytes4[] memory selectors,
         address educationHub,
         uint256 startIdx
-    ) private pure {
+    ) private pure returns (uint256) {
         targets[startIdx] = educationHub;
         selectors[startIdx] = bytes4(keccak256("completeModule(uint256,uint8)"));
         targets[startIdx + 1] = educationHub;
@@ -1322,6 +1318,7 @@ contract OrgDeployer is Initializable {
         selectors[startIdx + 2] = bytes4(keccak256("updateModule(uint256,bytes,bytes32,uint256)"));
         targets[startIdx + 3] = educationHub;
         selectors[startIdx + 3] = bytes4(keccak256("removeModule(uint256)"));
+        return startIdx + 4;
     }
 
     /**

--- a/test/OrgDeployerPaymasterRules.t.sol
+++ b/test/OrgDeployerPaymasterRules.t.sol
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.21;
+
+/// @title OrgDeployerPaymasterRules.t.sol
+/// @notice Pins the auto-whitelist rule table produced by `OrgDeployer._buildDefaultPaymasterRules`
+///         to the live ABI of every target contract.
+/// @dev    WHY THIS EXISTS (issue #188). The rule table is built from hand-hashed signature STRINGS.
+///         When `ZkEmailProof` gained `bytes32 fromDomainHash` (Blocker-2 domain binding), all four
+///         ZkEmailInvites claim selectors moved, but the strings did not — so every new org with
+///         `autoWhitelistContracts: true` got four paymaster rules that no function answers, and gasless
+///         zk-email claims silently failed rule validation. Nothing caught it: the one test that
+///         exercised those rules re-derived the SAME stale strings ("copied verbatim from OrgDeployer"),
+///         so it asserted the bug and stayed green.
+///
+///         This test is deliberately NOT a copy of the source literals. Every expected selector is a
+///         compiler-derived `Contract.fn.selector`, so it is anchored to the ABI. Set equality is
+///         asserted in BOTH directions, which makes it fail on drift, on a dropped rule, on an added
+///         rule the test doesn't know about, and on a duplicated slot.
+///
+///         It needs no fork and no RPC — it calls the pure builder directly through a harness.
+
+import "forge-std/Test.sol";
+
+import {OrgDeployer} from "../src/OrgDeployer.sol";
+import {OrgRegistry} from "../src/OrgRegistry.sol";
+import {QuickJoin} from "../src/QuickJoin.sol";
+import {TaskManager} from "../src/TaskManager.sol";
+import {HybridVoting} from "../src/HybridVoting.sol";
+import {DirectDemocracyVoting} from "../src/DirectDemocracyVoting.sol";
+import {PaymentManager} from "../src/PaymentManager.sol";
+import {EligibilityModule} from "../src/EligibilityModule.sol";
+import {ParticipationToken} from "../src/ParticipationToken.sol";
+import {EducationHub} from "../src/EducationHub.sol";
+import {UniversalAccountRegistry} from "../src/UniversalAccountRegistry.sol";
+import {ZkEmailInvites} from "../src/ZkEmailInvites.sol";
+
+/// @dev `_buildDefaultPaymasterRules` is `internal pure`, so a derived contract can expose it with no
+///      initialization, no proxy and no infra. Deploying an over-EIP-170 contract is fine in tests.
+contract OrgDeployerRulesHarness is OrgDeployer {
+    function exposeRules(DeploymentResult memory result, bool educationEnabled, address reg, address orgReg)
+        external
+        pure
+        returns (address[] memory, bytes4[] memory, bool[] memory, uint32[] memory)
+    {
+        return _buildDefaultPaymasterRules(result, educationEnabled, reg, orgReg);
+    }
+}
+
+contract OrgDeployerPaymasterRulesTest is Test {
+    OrgDeployerRulesHarness internal harness;
+
+    /* Sentinel targets — distinct so a rule written against the wrong module is visible. */
+    address internal constant HV = address(0x1001);
+    address internal constant DDV = address(0x1002);
+    address internal constant EXEC = address(0x1003);
+    address internal constant QJ = address(0x1004);
+    address internal constant PT = address(0x1005);
+    address internal constant TM = address(0x1006);
+    address internal constant EDU = address(0x1007);
+    address internal constant PAY = address(0x1008);
+    address internal constant ELIG = address(0x1009);
+    address internal constant ZK = address(0x100A);
+    address internal constant ACCT_REG = address(0x100B);
+    address internal constant ORG_REG = address(0x100C);
+
+    function setUp() public {
+        harness = new OrgDeployerRulesHarness();
+    }
+
+    /*────────────────────── the pin ──────────────────────*/
+
+    /// @notice Full table (education + zk-email enabled) must equal the ABI-derived expectation exactly.
+    function testDefaultRules_matchAbi_fullOrg() public view {
+        (address[] memory targets, bytes4[] memory selectors, bool[] memory allowed, uint32[] memory gasHints) =
+            harness.exposeRules(_result(EDU, ZK), true, ACCT_REG, ORG_REG);
+
+        (address[] memory expT, bytes4[] memory expS) = _expected(true, true);
+        assertEq(expT.length, 52, "expectation must cover 44 base + 4 education + 4 zk-email");
+        _assertSameRuleSet(targets, selectors, expT, expS);
+
+        for (uint256 i = 0; i < allowed.length; i++) {
+            assertTrue(allowed[i], "every default rule is allowed");
+            assertTrue(targets[i] != address(0), "no zero target");
+            assertTrue(selectors[i] != bytes4(0), "no zero selector");
+        }
+        assertEq(gasHints.length, targets.length, "gasHints array length");
+    }
+
+    /// @notice The zk-email rules carry the gas hints the Groth16 verify + hat mint actually need.
+    function testDefaultRules_zkEmailGasHints() public view {
+        (address[] memory targets, bytes4[] memory selectors,, uint32[] memory gasHints) =
+            harness.exposeRules(_result(EDU, ZK), true, ACCT_REG, ORG_REG);
+
+        assertEq(_hintOf(targets, selectors, gasHints, ZK, ZkEmailInvites.claimRoleByDomain.selector), 800_000);
+        assertEq(_hintOf(targets, selectors, gasHints, ZK, ZkEmailInvites.claimRoleByEmail.selector), 800_000);
+        assertEq(
+            _hintOf(targets, selectors, gasHints, ZK, ZkEmailInvites.registerAndClaimByDomainWithPasskey.selector),
+            1_200_000
+        );
+        assertEq(
+            _hintOf(targets, selectors, gasHints, ZK, ZkEmailInvites.registerAndClaimByEmailWithPasskey.selector),
+            1_200_000
+        );
+
+        // Everything else is hint-free (0 = "no per-rule cap", the hub's default).
+        for (uint256 i = 0; i < targets.length; i++) {
+            if (targets[i] != ZK) assertEq(gasHints[i], 0, "only zk-email rules carry gas hints");
+        }
+    }
+
+    /// @notice The three optional-module branches each produce exactly the count they allocate.
+    function testDefaultRules_countsPerBranch() public view {
+        (address[] memory tBoth,,,) = harness.exposeRules(_result(EDU, ZK), true, ACCT_REG, ORG_REG);
+        assertEq(tBoth.length, 52, "education + zk-email");
+
+        (address[] memory tEdu,,,) = harness.exposeRules(_result(EDU, address(0)), true, ACCT_REG, ORG_REG);
+        assertEq(tEdu.length, 48, "education only");
+
+        (address[] memory tZk,,,) = harness.exposeRules(_result(address(0), ZK), false, ACCT_REG, ORG_REG);
+        assertEq(tZk.length, 48, "zk-email only");
+
+        (address[] memory tBase,,,) = harness.exposeRules(_result(address(0), address(0)), false, ACCT_REG, ORG_REG);
+        assertEq(tBase.length, 44, "base only");
+    }
+
+    /// @notice Optional-module branches stay ABI-correct too (the zk-only branch is the one #188 broke).
+    function testDefaultRules_matchAbi_optionalBranches() public view {
+        (address[] memory tEdu, bytes4[] memory sEdu,,) =
+            harness.exposeRules(_result(EDU, address(0)), true, ACCT_REG, ORG_REG);
+        (address[] memory expTEdu, bytes4[] memory expSEdu) = _expected(true, false);
+        _assertSameRuleSet(tEdu, sEdu, expTEdu, expSEdu);
+
+        (address[] memory tZk, bytes4[] memory sZk,,) =
+            harness.exposeRules(_result(address(0), ZK), false, ACCT_REG, ORG_REG);
+        (address[] memory expTZk, bytes4[] memory expSZk) = _expected(false, true);
+        _assertSameRuleSet(tZk, sZk, expTZk, expSZk);
+
+        (address[] memory tBase, bytes4[] memory sBase,,) =
+            harness.exposeRules(_result(address(0), address(0)), false, ACCT_REG, ORG_REG);
+        (address[] memory expTBase, bytes4[] memory expSBase) = _expected(false, false);
+        _assertSameRuleSet(tBase, sBase, expTBase, expSBase);
+    }
+
+    /// @notice Tripwire on the four zk-email claim selectors' literal values.
+    /// @dev    Not redundant with the ABI check above: those move together if the struct changes again,
+    ///         and a silent move is dangerous — every LIVE org's existing paymaster rules would keep
+    ///         pointing at the old selectors and gasless claims would break in production. If this fails,
+    ///         the struct changed: update these constants AND migrate the deployed orgs' rules
+    ///         (PaymasterHub.setRulesBatch) in the same rollout. The stale pre-Blocker-2 values #188
+    ///         shipped were 0xc8864f92 / 0x50b2f726 / 0xcc1866ac / 0xebd847f2.
+    function testZkEmailClaimSelectors_areUnchanged() public pure {
+        assertEq(ZkEmailInvites.claimRoleByDomain.selector, bytes4(0x24b5e3ba), "claimRoleByDomain moved");
+        assertEq(ZkEmailInvites.claimRoleByEmail.selector, bytes4(0x8c149bab), "claimRoleByEmail moved");
+        assertEq(
+            ZkEmailInvites.registerAndClaimByDomainWithPasskey.selector,
+            bytes4(0x6108482e),
+            "registerAndClaimByDomainWithPasskey moved"
+        );
+        assertEq(
+            ZkEmailInvites.registerAndClaimByEmailWithPasskey.selector,
+            bytes4(0x998dc9d6),
+            "registerAndClaimByEmailWithPasskey moved"
+        );
+    }
+
+    /*────────────────────── helpers ──────────────────────*/
+
+    function _result(address educationHub, address zkEmailInvites)
+        internal
+        pure
+        returns (OrgDeployer.DeploymentResult memory r)
+    {
+        r.hybridVoting = HV;
+        r.directDemocracyVoting = DDV;
+        r.executor = EXEC;
+        r.quickJoin = QJ;
+        r.participationToken = PT;
+        r.taskManager = TM;
+        r.educationHub = educationHub;
+        r.paymentManager = PAY;
+        r.eligibilityModule = ELIG;
+        r.zkEmailInvites = zkEmailInvites;
+    }
+
+    /// @dev Expected (target, selector) pairs, every selector derived by the compiler from the target
+    ///      contract's ABI. Order is irrelevant — the assertion is set equality.
+    function _expected(bool educationEnabled, bool zkEmailEnabled)
+        internal
+        pure
+        returns (address[] memory targets, bytes4[] memory selectors)
+    {
+        uint256 n = 44;
+        if (educationEnabled) n += 4;
+        if (zkEmailEnabled) n += 4;
+        targets = new address[](n);
+        selectors = new bytes4[](n);
+        uint256 i;
+
+        // QuickJoin (6)
+        (targets[i], selectors[i++]) = (QJ, QuickJoin.quickJoinWithUser.selector);
+        (targets[i], selectors[i++]) = (QJ, QuickJoin.registerAndQuickJoin.selector);
+        (targets[i], selectors[i++]) = (QJ, QuickJoin.registerAndQuickJoinWithPasskey.selector);
+        (targets[i], selectors[i++]) = (QJ, QuickJoin.claimHatsWithUser.selector);
+        (targets[i], selectors[i++]) = (QJ, QuickJoin.registerAndClaimHats.selector);
+        (targets[i], selectors[i++]) = (QJ, QuickJoin.registerAndClaimHatsWithPasskey.selector);
+
+        // TaskManager (17)
+        (targets[i], selectors[i++]) = (TM, TaskManager.createTask.selector);
+        (targets[i], selectors[i++]) = (TM, TaskManager.createTasksBatch.selector);
+        (targets[i], selectors[i++]) = (TM, TaskManager.claimTask.selector);
+        (targets[i], selectors[i++]) = (TM, TaskManager.unclaimTask.selector);
+        (targets[i], selectors[i++]) = (TM, TaskManager.submitTask.selector);
+        (targets[i], selectors[i++]) = (TM, TaskManager.completeTask.selector);
+        (targets[i], selectors[i++]) = (TM, TaskManager.applyForTask.selector);
+        (targets[i], selectors[i++]) = (TM, TaskManager.approveApplication.selector);
+        (targets[i], selectors[i++]) = (TM, TaskManager.assignTask.selector);
+        (targets[i], selectors[i++]) = (TM, TaskManager.rejectTask.selector);
+        (targets[i], selectors[i++]) = (TM, TaskManager.cancelTask.selector);
+        (targets[i], selectors[i++]) = (TM, TaskManager.createAndAssignTask.selector);
+        (targets[i], selectors[i++]) = (TM, TaskManager.createProject.selector);
+        (targets[i], selectors[i++]) = (TM, TaskManager.deleteProject.selector);
+        (targets[i], selectors[i++]) = (TM, TaskManager.setFolders.selector);
+        (targets[i], selectors[i++]) = (TM, TaskManager.updateTask.selector);
+        (targets[i], selectors[i++]) = (TM, TaskManager.updateTaskMetadata.selector);
+
+        // Voting (3 + 3)
+        (targets[i], selectors[i++]) = (HV, HybridVoting.vote.selector);
+        (targets[i], selectors[i++]) = (HV, HybridVoting.announceWinner.selector);
+        (targets[i], selectors[i++]) = (HV, HybridVoting.createProposal.selector);
+        (targets[i], selectors[i++]) = (DDV, DirectDemocracyVoting.vote.selector);
+        (targets[i], selectors[i++]) = (DDV, DirectDemocracyVoting.announceWinner.selector);
+        (targets[i], selectors[i++]) = (DDV, DirectDemocracyVoting.createProposal.selector);
+
+        // PaymentManager (5)
+        (targets[i], selectors[i++]) = (PAY, PaymentManager.claimDistribution.selector);
+        (targets[i], selectors[i++]) = (PAY, PaymentManager.claimMultiple.selector);
+        (targets[i], selectors[i++]) = (PAY, PaymentManager.optOut.selector);
+        (targets[i], selectors[i++]) = (PAY, PaymentManager.createDistribution.selector);
+        (targets[i], selectors[i++]) = (PAY, PaymentManager.finalizeDistribution.selector);
+
+        // EligibilityModule (5)
+        (targets[i], selectors[i++]) = (ELIG, EligibilityModule.claimVouchedHat.selector);
+        (targets[i], selectors[i++]) = (ELIG, EligibilityModule.vouchFor.selector);
+        (targets[i], selectors[i++]) = (ELIG, EligibilityModule.revokeVouch.selector);
+        (targets[i], selectors[i++]) = (ELIG, EligibilityModule.applyForRole.selector);
+        (targets[i], selectors[i++]) = (ELIG, EligibilityModule.withdrawApplication.selector);
+
+        // ParticipationToken (3)
+        (targets[i], selectors[i++]) = (PT, ParticipationToken.requestTokens.selector);
+        (targets[i], selectors[i++]) = (PT, ParticipationToken.approveRequest.selector);
+        (targets[i], selectors[i++]) = (PT, ParticipationToken.cancelRequest.selector);
+
+        // Registries (2) — setProfileMetadata is on the account registry, updateOrgMetaAsAdmin on
+        // OrgRegistry. These being two DIFFERENT contracts is the L-53 fix; assert it stays that way.
+        (targets[i], selectors[i++]) = (ACCT_REG, UniversalAccountRegistry.setProfileMetadata.selector);
+        (targets[i], selectors[i++]) = (ORG_REG, OrgRegistry.updateOrgMetaAsAdmin.selector);
+
+        if (educationEnabled) {
+            (targets[i], selectors[i++]) = (EDU, EducationHub.completeModule.selector);
+            (targets[i], selectors[i++]) = (EDU, EducationHub.createModule.selector);
+            (targets[i], selectors[i++]) = (EDU, EducationHub.updateModule.selector);
+            (targets[i], selectors[i++]) = (EDU, EducationHub.removeModule.selector);
+        }
+
+        if (zkEmailEnabled) {
+            (targets[i], selectors[i++]) = (ZK, ZkEmailInvites.claimRoleByDomain.selector);
+            (targets[i], selectors[i++]) = (ZK, ZkEmailInvites.claimRoleByEmail.selector);
+            (targets[i], selectors[i++]) = (ZK, ZkEmailInvites.registerAndClaimByDomainWithPasskey.selector);
+            (targets[i], selectors[i++]) = (ZK, ZkEmailInvites.registerAndClaimByEmailWithPasskey.selector);
+        }
+
+        require(i == n, "expectation length mismatch");
+    }
+
+    /// @dev Set equality in both directions, plus a duplicate check on the actual table.
+    function _assertSameRuleSet(
+        address[] memory actualT,
+        bytes4[] memory actualS,
+        address[] memory expT,
+        bytes4[] memory expS
+    ) internal pure {
+        assertEq(actualT.length, expT.length, "rule count");
+        assertEq(actualS.length, actualT.length, "selectors array length");
+
+        for (uint256 e = 0; e < expT.length; e++) {
+            uint256 hits;
+            for (uint256 a = 0; a < actualT.length; a++) {
+                if (actualT[a] == expT[e] && actualS[a] == expS[e]) hits++;
+            }
+            assertEq(hits, 1, string.concat("expected rule missing or duplicated at index ", vm.toString(e)));
+        }
+        for (uint256 a = 0; a < actualT.length; a++) {
+            bool found;
+            for (uint256 e = 0; e < expT.length; e++) {
+                if (actualT[a] == expT[e] && actualS[a] == expS[e]) found = true;
+            }
+            assertTrue(
+                found,
+                string.concat(
+                    "unexpected rule ",
+                    vm.toString(actualT[a]),
+                    " / ",
+                    vm.toString(bytes32(actualS[a])),
+                    ": either a new rule was added without updating this test, or its selector drifted from the ABI"
+                )
+            );
+        }
+    }
+
+    function _hintOf(
+        address[] memory targets,
+        bytes4[] memory selectors,
+        uint32[] memory gasHints,
+        address target,
+        bytes4 selector
+    ) internal pure returns (uint256) {
+        for (uint256 i = 0; i < targets.length; i++) {
+            if (targets[i] == target && selectors[i] == selector) return gasHints[i];
+        }
+        revert("rule not found");
+    }
+}

--- a/test/ZkEmailOrgFlow.t.sol
+++ b/test/ZkEmailOrgFlow.t.sol
@@ -432,30 +432,19 @@ contract ZkEmailOrgFlowTest is DeployerTest {
         _wireZkInfra();
 
         // Deploy with autoWhitelistContracts = true and assert that all FOUR ZkEmailInvites claim
-        // selectors are now allowed rules on PaymasterHub for our org. These four selector strings
-        // are copied verbatim from OrgDeployer._appendZkEmailInvitesRules.
+        // selectors are now allowed rules on PaymasterHub for our org.
+        //
+        // These selectors are derived from the ABI by the compiler — NOT copied from
+        // OrgDeployer._appendZkEmailInvitesRules. That independence is the whole point: this test is what
+        // pins the deployer's auto-whitelist to the live ZkEmailInvites struct. The previous version copied
+        // the deployer's hand-hashed signature strings verbatim, so it stayed green through the Blocker-2
+        // domain-binding change that moved every claim selector (issue #188). Never reintroduce a literal here.
         OrgDeployer.DeploymentResult memory result = _deployZkOrgWithPaymaster(ZK_ORG_ID);
 
-        bytes4 selClaimDomain = bytes4(
-            keccak256(
-                "claimRoleByDomain((uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string),address,uint256[],bytes32[])"
-            )
-        );
-        bytes4 selClaimEmail = bytes4(
-            keccak256(
-                "claimRoleByEmail((uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string,bytes32),address,uint256[],bytes32[])"
-            )
-        );
-        bytes4 selRegisterClaimDomain = bytes4(
-            keccak256(
-                "registerAndClaimByDomainWithPasskey((bytes32,bytes32,bytes32,uint256),string,uint256,uint256,(bytes,bytes,uint256,uint256,bytes32,bytes32),(uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string),uint256[],bytes32[])"
-            )
-        );
-        bytes4 selRegisterClaimEmail = bytes4(
-            keccak256(
-                "registerAndClaimByEmailWithPasskey((bytes32,bytes32,bytes32,uint256),string,uint256,uint256,(bytes,bytes,uint256,uint256,bytes32,bytes32),(uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string,bytes32),uint256[],bytes32[])"
-            )
-        );
+        bytes4 selClaimDomain = ZkEmailInvites.claimRoleByDomain.selector;
+        bytes4 selClaimEmail = ZkEmailInvites.claimRoleByEmail.selector;
+        bytes4 selRegisterClaimDomain = ZkEmailInvites.registerAndClaimByDomainWithPasskey.selector;
+        bytes4 selRegisterClaimEmail = ZkEmailInvites.registerAndClaimByEmailWithPasskey.selector;
 
         PaymasterHub.Rule memory rClaimDomain = paymasterHub.getRule(ZK_ORG_ID, result.zkEmailInvites, selClaimDomain);
         PaymasterHub.Rule memory rClaimEmail = paymasterHub.getRule(ZK_ORG_ID, result.zkEmailInvites, selClaimEmail);
@@ -480,12 +469,17 @@ contract ZkEmailOrgFlowTest is DeployerTest {
         OrgDeployer.DeploymentResult memory result = _deployZkOrgWithPaymaster(ZK_ORG_ID);
         assertEq(result.zkEmailInvites, address(0), "ZkEmailInvites not deployed");
 
-        // Even if we query for the selector, it should be unset (allowed=false, cap=0).
-        bytes4 selClaimDomain = bytes4(
-            keccak256(
-                "claimRoleByDomain((uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string),address,uint256[],bytes32[])"
-            )
+        // The claim selectors must not be whitelisted anywhere. Probing address(0) proves nothing (a rule can
+        // never exist there — _setRulesBatch reverts on a zero target), so probe the modules that WERE
+        // deployed and got real rules.
+        bytes4 selClaimDomain = ZkEmailInvites.claimRoleByDomain.selector;
+        assertFalse(
+            paymasterHub.getRule(ZK_ORG_ID, result.quickJoin, selClaimDomain).allowed, "no zk rule on QuickJoin"
         );
+        assertFalse(
+            paymasterHub.getRule(ZK_ORG_ID, result.taskManager, selClaimDomain).allowed, "no zk rule on TaskManager"
+        );
+
         PaymasterHub.Rule memory rClaim = paymasterHub.getRule(ZK_ORG_ID, address(0), selClaimDomain);
         assertFalse(rClaim.allowed, "no rule for address(0)");
         assertEq(uint256(rClaim.maxCallGasHint), 0, "no gas hint");


### PR DESCRIPTION
Fixes #188.

## The bug

`OrgDeployer._appendZkEmailInvitesRules` derived its four selectors by hashing **pre-Blocker-2** signature strings whose `ZkEmailProof` tuple ended in `string`. The live struct ends in `bytes32 fromDomainHash`, so all four were wrong:

| | stale (registered) | live (real entrypoint) |
|---|---|---|
| `claimRoleByDomain` | `0xc8864f92` | `0x24b5e3ba` |
| `claimRoleByEmail` | `0x50b2f726` | `0x8c149bab` |
| `registerAndClaimByDomainWithPasskey` | `0xcc1866ac` | `0x6108482e` |
| `registerAndClaimByEmailWithPasskey` | `0xebd847f2` | `0x998dc9d6` |

Every new org with `autoWhitelistContracts: true` + zk-email enabled got four rules no function answers, and **zero** sponsorship on the real claim entrypoints — gasless zk-email claims fail rule validation.

`git log -S` shows both the stale strings and the `fromDomainHash` struct landed in the same squashed commit (#170): the drift was introduced mid-PR when Blocker-2 domain binding changed `ZkEmailProof`, and `OrgDeployer` wasn't updated with it.

**Blast radius.** `_appendZkEmailInvitesRules` has never run on-chain — both existing `ZkEmailInvites` modules (Test6, KUBI on Gnosis) are retrofits whose rules were set by their own scripts. But the zk infra *is* wired on both chains and the beacon *is* registered on both, so the bug is armed for the very next `deployFullOrgWithZkEmail` — i.e. `script/org/DeployComfiestHouse.s.sol`, which has not been broadcast. **Land the v19 upgrade before that.**

## The fix

**`src/OrgDeployer.sol`** — the four selectors become compiler-derived `ZkEmailInvites.<fn>.selector`, so they cannot drift from the ABI again. The import is free: `OrgDeployer` already depends on `ZkEmailInvites` transitively via `ModulesFactory`, `.selector` is a compile-time constant, and no creation code is pulled in. Production size actually drops 119 B (22,332 B, 2,244 B of EIP-170 headroom); storage layout is byte-identical.

Two hardening changes in the same builder, both prompted by what made this bug invisible:
- `_appendEducationHubRules` now returns the advanced index like every sibling helper. It was the only one returning `void` with the caller hand-advancing `i += 4` — add a rule there and it silently overwrites the zk slots.
- `if (i != count) revert RuleCountMismatch();` replaces the *incidental* loudness that previously came only from PaymasterHub's zero-address guard.

**Tests.** The test that should have caught this was tautological by its own admission — its comment read *"copied verbatim from OrgDeployer"*, so it re-derived the same wrong constant and asserted the bug. The other guard, `testPaymasterSelectorAccuracy`, is a *copy* of the source literals that never references `OrgDeployer` at all, and covered only 23 of the 49 signature strings.

`test/OrgDeployerPaymasterRules.t.sol` (new) replaces that pattern: a harness over the internal `pure` builder asserting **both-direction set equality** of all 52 `(target, selector)` pairs against `.selector` values, per-branch counts (52/48/48/44 — the first assertion of the `count` literal anywhere), the zk gas hints, and a literal tripwire on the four zk selectors so a future struct change fails loudly instead of moving both sides together (live orgs' existing rules would need migrating). No fork, no RPC, runs in ~20 ms.

**`script/upgrades/UpgradeOrgDeployerZkEmailRules.s.sol`** (new) — OrgDeployer v19 on the fee-free path (`Satellite.upgradeBeaconDirect` on Gnosis, `Hub.upgradeBeaconLocal` on Arbitrum; both call the same `poaManager.upgradeBeacon`, so per-chain bookkeeping is identical to the Hyperlane form without the 0.005 ETH fee or 5-minute relay — and both sides are fork-simulatable). Steps are idempotent. The sims deploy a **real fixture org on the fork before and after** the upgrade and read `PaymasterHub.getRule` back, because these selectors are folded constants that never appear literally in the bytecode — grepping the impl proves nothing, only a real deploy shows which rules land.

**`script/zkemail/IntegrateZkEmailTest6.s.sol`** — comment only. Its `SUPERSEDED` constants are the historical record of what was broadcast; the old comment invited copying them forward.

## Verification

- `forge test`: **1887 passed, 0 failed**. `forge fmt --check` clean. `FOUNDRY_PROFILE=production forge build --skip test` clean.
- **Fault injection** (the guards are load-bearing, not decorative):
  - reintroducing the stale `claimRoleByDomain` string → 3 of the 5 new tests fail *and* the `ZkEmailOrgFlow` E2E test fails;
  - drifting `setFolders` (one of the 21 previously-unpinned selectors) → the new test fails while `testPaymasterSelectorAccuracy` stays green.
- **Production-profile fork sims, both chains, PASS:**
  ```
  BEFORE (v18): 4/4 stale selectors sponsored, 0/4 real claim entrypoints sponsored
  AFTER  (v19): 4/4 real claim entrypoints sponsored (800k/800k/1.2M/1.2M), 0/4 stale
  ```
- Version probe (both surfaces, both chains, 2026-08-04): v19 FREE, predicted impl `0x90BAe532D26100a2106c3b16bEA1Ad27D2286b3A`. Note the issue says "v18 candidate" — v18 is already live from #187, so this ships as **v19**.

## Follow-ups (not in this PR)

- Test6 on Gnosis carries **four orphan `allowed` rules** under the stale selectors (verified live), left by the superseded retrofit script and never revoked when the ceremony added the correct ones. Harmless today — no function answers them, and a bogus call burns the same claim budget a real selector would — but it's an unreviewed grant that a future selector collision would auto-sponsor. Cleanup is one `setRulesBatch(allowed=false)` via the Satellite; worth folding into the next Test6 admin batch.
- `script/fixes/AddCreateTasksBatchSelectorRules.s.sol` hardcodes `0xc18aa1c9` (TaskManager v5 `createTasksBatch`; live is `0xf31d148f`) with no SUPERSEDED banner — same failure class, re-runnable. Ditto `0x48db6f65` for the v5 `updateTask` across four `script/fixes/` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)