### PR TITLE
feat(paymaster): type-keyed global rulebook — centralized sponsored-selector whitelist (v20)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@
 
 ## Gotchas
 
+- **Paymaster whitelist is the type-keyed GLOBAL RULEBOOK** — sponsored selectors live in PaymasterHub's global rulebook keyed by `(module typeId, selector)` and are managed via `setGlobalRulesBatch` (poaManager/protocolAdmin). The canonical list is `script/helpers/DefaultGlobalRules.sol`. To sponsor a new/changed function: add it there + broadcast one `setGlobalRulesBatch` per chain — do NOT re-add hardcoded selector lists to OrgDeployer (`_buildDefaultPaymasterRules` was deleted for this). Orgs resolve local rules first, then (in Mirror mode, the default) the rulebook via their `targetTypes` mapping; Static-mode orgs vote rules in like a pinned upgrade. All rule logic is in `PaymasterRuleLib` (delegatecall lib — its ERC-7201 slot mirrors must stay byte-identical to PaymasterHub's).
 - **Optimizer is OFF by default** — Solidity IR codegen bug causes `vm.roll()` to silently produce wrong results with optimizer enabled (foundry.toml documents the upstream issues). Use `FOUNDRY_PROFILE=production` only for real deployments, never for tests.
 - **Default EVM is osaka, production is cancun** — osaka enables the P256 precompile at `0x100` for passkey signature tests. Production targets cancun for L2 compatibility.
 - **Org deploys need ~22M gas** — exceeds L1 Sepolia block gas limit. Must deploy on L2 (Base Sepolia, Optimism Sepolia, or Arbitrum Sepolia).

--- a/docs/ORG_DEPLOYER.md
+++ b/docs/ORG_DEPLOYER.md
@@ -167,10 +167,12 @@ l.orgRegistry.registerHatsTree(params.orgId, gov.topHatId, gov.roleHatIds);
 #### 7. PaymasterHub: Shared Infrastructure
 
 ```solidity
-IPaymasterHub(l.paymasterHub).registerOrg(params.orgId, gov.topHatId, 0);
+IPaymasterHub(l.paymasterHub).registerAndConfigureOrg{value: msg.value}(params.orgId, topHatId, config);
 ```
 
 Organizations share a common PaymasterHub for gas sponsorship. Infrastructure should serve all communities, not be duplicated inefficiently.
+
+When `paymasterConfig.autoWhitelistContracts` is set, the deployer no longer seeds a hardcoded selector whitelist. Instead it registers each deployed module (and the shared registries) with its module typeId (`_buildTargetTypes`), and the org's sponsored selectors resolve through the PaymasterHub's Poa-managed **global rulebook** (see `docs/PAYMASTER_HUB.md` → Rules Engine). Orgs deployed with `autoUpgrade = true` start in Mirror mode (rules follow the rulebook automatically); `autoUpgrade = false` would start Static with a local snapshot of the current rulebook. Adding a new sponsored function no longer requires touching OrgDeployer — one `setGlobalRulesBatch` covers all Mirror orgs, current and future.
 
 #### 8-9. Access and Modules: The Living Organization
 

--- a/docs/PAYMASTER_HUB.md
+++ b/docs/PAYMASTER_HUB.md
@@ -303,13 +303,16 @@ Local rules are keyed by each org's own proxy addresses, so a new protocol funct
 Resolution order (fail-closed at every step):
 
 ```text
-local rule allowed?            → allow (local maxCallGasHint applies)
-org rules mode == Static?      → deny
-org blocked (target,selector)? → deny
-targetTypes[org][target] == 0? → deny
-global rule allowed?           → allow (global maxCallGasHint applies)
-else                           → deny (RuleDenied)
+local rule allowed?                     → allow (local maxCallGasHint applies)
+local {allowed:false, hint != 0}?       → deny (explicit deny — incl. pre-v20 writes, no block needed)
+org rules mode == Static?               → deny
+org blocked (target,selector)?          → deny
+targetTypes[org][target] == 0?          → deny
+global rule allowed?                    → allow (global maxCallGasHint applies)
+else                                    → deny (RuleDenied)
 ```
+
+Migration note: pre-v20 explicit denies written with hint = 0 leave a zero storage struct (indistinguishable from unset on-chain). The v20 rollout reconstructs those from the RuleSet event log as per-pair blocks, applied **before** any target types are registered — see `UpgradePaymasterGlobalRules.s.sol` Step4.
 
 **Managing the rulebook (poaManager or protocolAdmin):**
 

--- a/docs/PAYMASTER_HUB.md
+++ b/docs/PAYMASTER_HUB.md
@@ -276,105 +276,99 @@ hub.setSolidarityFee(100); // basis points (100 = 1%)
 
 ### Rules Engine
 
-The rules engine validates **which smart contracts and functions** users can call. Organizations whitelist/blacklist specific targets and selectors.
+The rules engine validates **which smart contracts and functions** users can call. Resolution has two tiers: each org's **local rules** (address-keyed, org-managed) and the protocol-wide **global rulebook** (type-keyed, Poa-managed). All rule logic lives in `PaymasterRuleLib`, a delegatecall library operating on the hub's own storage (EIP-170 headroom + ERC-7562-safe validation).
 
 #### Rule Structure
 
 ```solidity
 struct Rule {
+    uint32 maxCallGasHint;  // Optional gas limit hint (field order matters for decoders!)
     bool allowed;           // Is this target/selector allowed?
-    uint32 maxCallGasHint;  // Optional gas limit hint
 }
 
-// Storage: orgId → target → selector → Rule
-mapping(bytes32 => mapping(address => mapping(bytes4 => Rule))) private _rules;
+// Local rules:  orgId → target address → selector → Rule   (poa.paymasterhub.rules)
+// Global rules: module typeId → selector → Rule             (poa.paymasterhub.globalrules)
 ```
+
+#### Global Rulebook (type-keyed, Poa-managed)
+
+Local rules are keyed by each org's own proxy addresses, so a new protocol function used to require a vote in *every* org (or a `adminBatchAddRules` fan-out enumerating them all) plus an OrgDeployer redeploy. The global rulebook removes that burden — it is the `SwitchableBeacon` analog for sponsorship rules:
+
+- Entries are keyed by `(module typeId, selector)` where typeId = `keccak256(moduleName)` — the same IDs `OrgRegistry`/`ModuleTypes` use. One entry covers the matching module of **every** org.
+- Each org maps its proxy addresses to typeIds (`setTargetTypesBatch`, seeded automatically by OrgDeployer at deploy). Resolution is inert for an org until its targets are mapped.
+- Per-org **rules mode** (`setRulesMode`): `0 = Mirror` (default) — local rules first, then global rulebook; `1 = Static` — local rules only, the org votes changes in exactly like a pinned beacon upgrade.
+- Mirror orgs can veto one specific global rule without leaving Mirror mode: `setGlobalRuleBlock(orgId, target, selector, true)`.
+- The rulebook is enumerable on-chain (`getGlobalRuleCount` / `getGlobalRuleAt`), which powers `snapshotGlobalRules`.
+
+Resolution order (fail-closed at every step):
+
+```text
+local rule allowed?            → allow (local maxCallGasHint applies)
+org rules mode == Static?      → deny
+org blocked (target,selector)? → deny
+targetTypes[org][target] == 0? → deny
+global rule allowed?           → allow (global maxCallGasHint applies)
+else                           → deny (RuleDenied)
+```
+
+**Managing the rulebook (poaManager or protocolAdmin):**
+
+```solidity
+// Upsert entries (allowed=true) or remove them (allowed=false)
+hub.setGlobalRulesBatch(typeIds, selectors, allowed, maxCallGasHints);
+```
+
+The canonical seed set lives in `script/helpers/DefaultGlobalRules.sol`. To sponsor a new function protocol-wide: add it there, broadcast one `setGlobalRulesBatch` per chain — every Mirror org picks it up instantly, and no OrgDeployer redeploy is needed. Removing an entry is the central kill-switch: sponsorship stops immediately for all Mirror orgs.
+
+**Org-side controls (admin/operator hat, or PoaManager):**
+
+```solidity
+hub.setTargetTypesBatch(orgId, targets, typeIds);      // map/clear module typeIds
+hub.setRulesMode(orgId, mode);                         // 0 = Mirror, 1 = Static
+hub.setGlobalRuleBlock(orgId, target, selector, bool); // veto one global rule
+hub.adoptGlobalRules(orgId, targets, selectors);       // copy specific entries → local rules
+hub.snapshotGlobalRules(orgId, targets);               // copy ALL applicable entries → local rules
+```
+
+A Static-leaning org should pass `snapshotGlobalRules` + `setRulesMode(orgId, 1)` in one governance batch — sponsorship continues from the local copies and later rulebook changes no longer apply. OrgDeployer does this automatically for orgs deployed with `autoUpgrade = false`; Mirror orgs get only target-type mappings (zero local rules) and resolve everything through the rulebook.
+
+Trust note: this adds **no new Poa power** — PoaManager could already write any org's local rules via the `onlyOrgOperator` bypass (and `adminBatchAddRules`). The rulebook just makes that administration transparent (evented, enumerable) and instantly revocable, while Static mode / blocks give orgs an explicit opt-out.
 
 #### Validation Modes
 
 **1. Generic Mode (RULE_ID = 0x00000000)**
 
-For accounts that execute **nested calls** (e.g., SimpleAccount calling `execute(target, data)`):
+For accounts that execute **nested calls** (e.g., SimpleAccount calling `execute(target, data)`): the inner `(target, selector)` is extracted from calldata, and `executeBatch` variants are validated **per inner call** (every inner pair must resolve allowed; gas hints are not checked per-inner-call).
+
+**2. Coarse Mode (RULE_ID = 0x000000FF)**
+
+Checks `(userOp.sender, outer selector)` — account-level rules. Note the account itself has no target-type mapping, so coarse mode resolves through local rules only.
+
+#### Setting Local Rules
 
 ```solidity
-// Extracts target and selector from calldata
-target = extractTarget(userOp.callData);
-selector = extractSelector(userOp.callData);
+// Allow (clears any standing global-rule block for the pair)
+hub.setRule(orgId, target, selector, true, 500000);
 
-// Check rule
-if (!rules[target][selector].allowed) {
-    revert RuleDenied(target, selector);
-}
-```
+// EXPLICIT DENY — actually revokes for Mirror orgs: writes the local deny AND blocks the
+// global fallback (without the block, allowed=false would silently fall through to the rulebook)
+hub.setRule(orgId, target, selector, false, 0);
 
-**2. Executor Mode (RULE_ID = 0x00000001)**
+// Batch rules (same allow/deny semantics per entry)
+hub.setRulesBatch(orgId, targets, selectors, allowedFlags, gasHints);
 
-For the **org's executor contract** itself:
-
-```solidity
-// Validates executor's own functions
-target = userOp.sender; // The executor
-selector = bytes4(userOp.callData);
-
-if (!rules[target][selector].allowed) {
-    revert RuleDenied(target, selector);
-}
-```
-
-**3. Coarse Mode (RULE_ID = 0x000000FF)**
-
-**Skip validation entirely** - account-level approval only.
-
-#### Setting Rules
-
-```solidity
-// Single rule
-hub.setRule(
-    orgId,
-    0x1234...5678,              // target contract
-    0xabcdef00,                 // function selector
-    true,                       // allowed
-    500000                      // maxCallGasHint (optional)
-);
-
-// Batch rules
-hub.setRulesBatch(
-    orgId,
-    [target1, target2, target3],
-    [selector1, selector2, selector3],
-    [true, true, false],
-    [500000, 300000, 0]
-);
-
-// Clear rule
+// RESET to protocol default: deletes the local rule AND any standing block — a Mirror org
+// falls back to the global rulebook for this pair afterwards
 hub.clearRule(orgId, target, selector);
 ```
 
-**Access:** Admin or Operator hat
+**Access:** Admin or Operator hat (or PoaManager)
 
-#### Example: Whitelist DEX and Token
+Legacy note: the hub also keeps the pre-rulebook 13-field `registerAndConfigureOrg` overload (selector `0xc6f422d9`) so already-deployed OrgDeployer versions keep working across the v20 upgrade — they seed address-keyed local rules exactly as before.
 
-```solidity
-// Allow Uniswap V3 Router swaps
-hub.setRule(
-    orgId,
-    0xE592427A0AEce92De3Edee1F18E0157C05861564, // Uniswap V3 Router
-    0x414bf389,                                   // exactInputSingle(params)
-    true,
-    1000000
-);
+#### Reading effective rules
 
-// Allow USDC transfers
-hub.setRule(
-    orgId,
-    0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48, // USDC
-    0xa9059cbb,                                   // transfer(to, amount)
-    true,
-    100000
-);
-
-// Block everything else by default
-```
+`PaymasterHubLens.effectiveRuleOf(orgId, target, selector)` returns `(allowed, maxCallGasHint, source)` with `source`: 0 = denied, 1 = local rule, 2 = global rulebook. `lens.wouldValidate` predicts the full validation including global resolution. `hub.getRule` returns the LOCAL rule only.
 
 ---
 

--- a/script/deploy/DeployInfrastructure.s.sol
+++ b/script/deploy/DeployInfrastructure.s.sol
@@ -27,6 +27,7 @@ import {PoaManager} from "../../src/PoaManager.sol";
 import {OrgRegistry} from "../../src/OrgRegistry.sol";
 import {OrgDeployer} from "../../src/OrgDeployer.sol";
 import {PaymasterHub} from "../../src/PaymasterHub.sol";
+import {DefaultGlobalRules} from "../helpers/DefaultGlobalRules.sol";
 
 // Factories
 import {GovernanceFactory} from "../../src/factories/GovernanceFactory.sol";
@@ -201,6 +202,30 @@ contract DeployInfrastructure is Script {
         // Authorize OrgDeployer to register orgs with PaymasterHub
         PoaManager(poaManager).adminCall(paymasterHub, abi.encodeWithSignature("setOrgRegistrar(address)", orgDeployer));
         console.log("OrgDeployer authorized as orgRegistrar on PaymasterHub");
+
+        // Seed the global rulebook — without this, orgs deployed with autoWhitelistContracts
+        // resolve ZERO sponsored selectors (the deployer registers target types only; all
+        // sponsored selectors come from this type-keyed rulebook).
+        {
+            (
+                bytes32[] memory grTypeIds,
+                bytes4[] memory grSelectors,
+                bool[] memory grAllowed,
+                uint32[] memory grHints
+            ) = DefaultGlobalRules.defaults();
+            PoaManager(poaManager)
+                .adminCall(
+                    paymasterHub,
+                    abi.encodeWithSignature(
+                        "setGlobalRulesBatch(bytes32[],bytes4[],bool[],uint32[])",
+                        grTypeIds,
+                        grSelectors,
+                        grAllowed,
+                        grHints
+                    )
+                );
+            console.log("Global rulebook seeded with entries:", grTypeIds.length);
+        }
 
         // Register all contract types
         PoaManager pm = PoaManager(poaManager);

--- a/script/deploy/MainDeploy.s.sol
+++ b/script/deploy/MainDeploy.s.sol
@@ -14,6 +14,7 @@ import {PoaManager} from "../../src/PoaManager.sol";
 import {OrgRegistry} from "../../src/OrgRegistry.sol";
 import {OrgDeployer, ITaskManagerBootstrap} from "../../src/OrgDeployer.sol";
 import {PaymasterHub} from "../../src/PaymasterHub.sol";
+import {DefaultGlobalRules} from "../helpers/DefaultGlobalRules.sol";
 import {UniversalAccountRegistry} from "../../src/UniversalAccountRegistry.sol";
 
 // Factories
@@ -212,6 +213,29 @@ contract DeployHomeChain is DeployHelper {
         PoaManager(infra.poaManager)
             .adminCall(infra.paymasterHub, abi.encodeWithSignature("unpauseSolidarityDistribution()"));
         console.log("Solidarity distribution unpaused for onboarding");
+
+        // Seed the global rulebook — without this, orgs deployed with autoWhitelistContracts
+        // resolve ZERO sponsored selectors (the deployer registers target types only).
+        {
+            (
+                bytes32[] memory grTypeIds,
+                bytes4[] memory grSelectors,
+                bool[] memory grAllowed,
+                uint32[] memory grHints
+            ) = DefaultGlobalRules.defaults();
+            PoaManager(infra.poaManager)
+                .adminCall(
+                    infra.paymasterHub,
+                    abi.encodeWithSignature(
+                        "setGlobalRulesBatch(bytes32[],bytes4[],bool[],uint32[])",
+                        grTypeIds,
+                        grSelectors,
+                        grAllowed,
+                        grHints
+                    )
+                );
+            console.log("Global rulebook seeded with entries:", grTypeIds.length);
+        }
 
         // Deploy OrgDeployer proxy
         address deployerBeacon = PoaManager(infra.poaManager).getBeaconById(keccak256("OrgDeployer"));

--- a/script/helpers/DefaultGlobalRules.sol
+++ b/script/helpers/DefaultGlobalRules.sol
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.24;
+
+import {ModuleTypes} from "../../src/libs/ModuleTypes.sol";
+
+/**
+ * @title DefaultGlobalRules
+ * @notice Canonical seed set for the PaymasterHub GLOBAL RULEBOOK — every sponsored
+ *         (module typeId, selector) pair, with gas hints where relevant.
+ * @dev This is the single source of truth that replaced OrgDeployer._buildDefaultPaymasterRules
+ *      (which hardcoded per-org addresses and required an OrgDeployer redeploy per new function).
+ *      Used by the rulebook seeding scripts and by tests. INTERNAL library: it compiles into
+ *      scripts/tests only and is never deployed on-chain, so growing this list has no runtime
+ *      bytecode cost anywhere.
+ *
+ *      NOTE: the four ZkEmailInvites signatures fix a LATENT BUG inherited from the old
+ *      OrgDeployer list — its strings used `string` where the real proof tuple has `bytes32`
+ *      (domain hash), so the deploy-time zkemail rules matched no real function. Entries here
+ *      are cross-checked against compiler-derived contract selectors by
+ *      testDefaultGlobalRules_MatchRealContractSelectors.
+ *
+ *      To sponsor a new/changed function protocol-wide: add the entry here, then broadcast
+ *      `PaymasterHub.setGlobalRulesBatch` with the delta (or the full set — upserts are
+ *      idempotent). Every Mirror-mode org picks it up instantly; Static-mode orgs vote via
+ *      `adoptGlobalRules` / `snapshotGlobalRules` / `setRule`.
+ */
+library DefaultGlobalRules {
+    struct Entry {
+        bytes32 typeId;
+        bytes4 selector;
+        uint32 maxCallGasHint;
+    }
+
+    /// @notice The full default rulebook as parallel arrays, ready for setGlobalRulesBatch.
+    function defaults()
+        internal
+        pure
+        returns (bytes32[] memory typeIds, bytes4[] memory selectors, bool[] memory allowed, uint32[] memory hints)
+    {
+        Entry[] memory e = entries();
+        uint256 n = e.length;
+        typeIds = new bytes32[](n);
+        selectors = new bytes4[](n);
+        allowed = new bool[](n);
+        hints = new uint32[](n);
+        for (uint256 i = 0; i < n; i++) {
+            typeIds[i] = e[i].typeId;
+            selectors[i] = e[i].selector;
+            allowed[i] = true;
+            hints[i] = e[i].maxCallGasHint;
+        }
+    }
+
+    /// @notice All default rulebook entries (selector strings match the deployed module ABIs).
+    function entries() internal pure returns (Entry[] memory e) {
+        e = new Entry[](52);
+        uint256 i;
+
+        // ── QuickJoin (6) ──
+        bytes32 t = ModuleTypes.QUICK_JOIN_ID;
+        e[i++] = Entry(t, bytes4(keccak256("quickJoinWithUser()")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("registerAndQuickJoin(address,string,uint256,uint256,bytes)")), 0);
+        e[i++] = Entry(
+            t,
+            bytes4(
+                keccak256(
+                    "registerAndQuickJoinWithPasskey((bytes32,bytes32,bytes32,uint256),string,uint256,uint256,(bytes,bytes,uint256,uint256,bytes32,bytes32))"
+                )
+            ),
+            0
+        );
+        e[i++] = Entry(t, bytes4(keccak256("claimHatsWithUser(uint256[])")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("registerAndClaimHats(address,string,uint256,uint256,bytes,uint256[])")), 0);
+        e[i++] = Entry(
+            t,
+            bytes4(
+                keccak256(
+                    "registerAndClaimHatsWithPasskey((bytes32,bytes32,bytes32,uint256),string,uint256,uint256,(bytes,bytes,uint256,uint256,bytes32,bytes32),uint256[])"
+                )
+            ),
+            0
+        );
+
+        // ── TaskManager (17) — v6 create/update carry deadline params; v7 adds unclaimTask ──
+        t = ModuleTypes.TASK_MANAGER_ID;
+        e[i++] = Entry(
+            t, bytes4(keccak256("createTask(uint256,bytes,bytes32,bytes32,address,uint256,bool,uint48,uint32)")), 0
+        );
+        e[i++] = Entry(
+            t,
+            bytes4(keccak256("createTasksBatch(bytes32,(uint256,bytes,bytes32,address,uint256,bool,uint48,uint32)[])")),
+            0
+        );
+        e[i++] = Entry(t, bytes4(keccak256("claimTask(uint256)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("unclaimTask(uint256)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("submitTask(uint256,bytes32)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("completeTask(uint256)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("applyForTask(uint256,bytes32)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("approveApplication(uint256,address)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("assignTask(uint256,address)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("rejectTask(uint256,bytes32)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("cancelTask(uint256)")), 0);
+        e[i++] = Entry(
+            t,
+            bytes4(
+                keccak256(
+                    "createAndAssignTask(uint256,bytes,bytes32,bytes32,address,address,uint256,bool,uint48,uint32)"
+                )
+            ),
+            0
+        );
+        e[i++] = Entry(
+            t,
+            bytes4(
+                keccak256(
+                    "createProject((bytes,bytes32,uint256,address[],uint256[],uint256[],uint256[],uint256[],address[],uint256[]))"
+                )
+            ),
+            0
+        );
+        e[i++] = Entry(t, bytes4(keccak256("deleteProject(bytes32)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("setFolders(bytes32,bytes32)")), 0);
+        e[i++] =
+            Entry(t, bytes4(keccak256("updateTask(uint256,uint256,bytes,bytes32,address,uint256,uint48,uint32)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("updateTaskMetadata(uint256,bytes,bytes32)")), 0);
+
+        // ── HybridVoting (3) + DirectDemocracyVoting (3) ──
+        bytes4 voteSel = bytes4(keccak256("vote(uint256,uint8[],uint8[])"));
+        bytes4 announceSel = bytes4(keccak256("announceWinner(uint256)"));
+        bytes4 proposalSel =
+            bytes4(keccak256("createProposal(bytes,bytes32,uint32,uint8,(address,uint256,bytes)[][],uint256[])"));
+        e[i++] = Entry(ModuleTypes.HYBRID_VOTING_ID, voteSel, 0);
+        e[i++] = Entry(ModuleTypes.HYBRID_VOTING_ID, announceSel, 0);
+        e[i++] = Entry(ModuleTypes.HYBRID_VOTING_ID, proposalSel, 0);
+        e[i++] = Entry(ModuleTypes.DIRECT_DEMOCRACY_VOTING_ID, voteSel, 0);
+        e[i++] = Entry(ModuleTypes.DIRECT_DEMOCRACY_VOTING_ID, announceSel, 0);
+        e[i++] = Entry(ModuleTypes.DIRECT_DEMOCRACY_VOTING_ID, proposalSel, 0);
+
+        // ── PaymentManager (5) ──
+        t = ModuleTypes.PAYMENT_MANAGER_ID;
+        e[i++] = Entry(t, bytes4(keccak256("claimDistribution(uint256,uint256,bytes32[])")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("claimMultiple(uint256[],uint256[],bytes32[][])")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("optOut(bool)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("createDistribution(address,uint256,bytes32,uint256)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("finalizeDistribution(uint256,uint256)")), 0);
+
+        // ── EligibilityModule (5) ──
+        t = ModuleTypes.ELIGIBILITY_MODULE_ID;
+        e[i++] = Entry(t, bytes4(keccak256("claimVouchedHat(uint256)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("vouchFor(address,uint256)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("revokeVouch(address,uint256)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("applyForRole(uint256,bytes32)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("withdrawApplication(uint256)")), 0);
+
+        // ── ParticipationToken (3) ──
+        t = ModuleTypes.PARTICIPATION_TOKEN_ID;
+        e[i++] = Entry(t, bytes4(keccak256("requestTokens(uint96,string)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("approveRequest(uint256)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("cancelRequest(uint256)")), 0);
+
+        // ── Shared registries (2) — setProfileMetadata on UniversalAccountRegistry,
+        //    updateOrgMetaAsAdmin on OrgRegistry (two distinct contracts, L-53) ──
+        e[i++] = Entry(ModuleTypes.UNIVERSAL_ACCOUNT_REGISTRY_ID, bytes4(keccak256("setProfileMetadata(bytes32)")), 0);
+        e[i++] = Entry(ModuleTypes.ORG_REGISTRY_ID, bytes4(keccak256("updateOrgMetaAsAdmin(bytes32,bytes,bytes32)")), 0);
+
+        // ── EducationHub (4) ──
+        t = ModuleTypes.EDUCATION_HUB_ID;
+        e[i++] = Entry(t, bytes4(keccak256("completeModule(uint256,uint8)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("createModule(bytes,bytes32,uint256,uint8)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("updateModule(uint256,bytes,bytes32,uint256)")), 0);
+        e[i++] = Entry(t, bytes4(keccak256("removeModule(uint256)")), 0);
+
+        // ── ZkEmailInvites (4) — Groth16 verify + DKIM + merkle + hat mint gas hints ──
+        t = ModuleTypes.ZKEMAIL_INVITES_ID;
+        e[i++] = Entry(
+            t,
+            bytes4(
+                keccak256(
+                    "claimRoleByDomain((uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,bytes32),address,uint256[],bytes32[])"
+                )
+            ),
+            800_000
+        );
+        e[i++] = Entry(
+            t,
+            bytes4(
+                keccak256(
+                    "claimRoleByEmail((uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,bytes32,bytes32),address,uint256[],bytes32[])"
+                )
+            ),
+            800_000
+        );
+        e[i++] = Entry(
+            t,
+            bytes4(
+                keccak256(
+                    "registerAndClaimByDomainWithPasskey((bytes32,bytes32,bytes32,uint256),string,uint256,uint256,(bytes,bytes,uint256,uint256,bytes32,bytes32),(uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,bytes32),uint256[],bytes32[])"
+                )
+            ),
+            1_200_000
+        );
+        e[i++] = Entry(
+            t,
+            bytes4(
+                keccak256(
+                    "registerAndClaimByEmailWithPasskey((bytes32,bytes32,bytes32,uint256),string,uint256,uint256,(bytes,bytes,uint256,uint256,bytes32,bytes32),(uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,bytes32,bytes32),uint256[],bytes32[])"
+                )
+            ),
+            1_200_000
+        );
+
+        assert(i == e.length);
+    }
+}

--- a/script/upgrades/UpgradePaymasterGlobalRules.s.sol
+++ b/script/upgrades/UpgradePaymasterGlobalRules.s.sol
@@ -106,6 +106,46 @@ abstract contract TargetTypesData {
         bytes32[] typeIds;
     }
 
+    /// @dev A (org, target, selector) pair whose LAST pre-v20 RuleSet event has allowed=false —
+    ///      an explicit denial. Pre-v20 denies with hint=0 leave a ZERO storage struct
+    ///      (indistinguishable from unset on-chain), so once Step4 types the target the resolver
+    ///      would fall through to a global allow and silently restore sponsorship. Step4 rebuilds
+    ///      these as global-rule blocks BEFORE registering target types (denies with hint!=0 are
+    ///      additionally honored by the resolver itself, no block needed).
+    ///
+    ///      Data source: full RuleSet event scan per chain (topic0
+    ///      0x75d8443004953c3d7605bbc7f3a1bd6db7a2182752ccb451f5cdb875ebd264ea), last-write-wins
+    ///      per pair, scanned 2026-08-04. Gnosis: 7 pairs (Test6 + KUBI TaskManagers — all four
+    ///      selectors are RETIRED pre-v6 TaskManager signatures with no rulebook entry, so
+    ///      blocking them is purely behavior-preserving). Arbitrum: none.
+    ///      ⚠ RE-SCAN before broadcast — new denials may have been written since:
+    ///        cast logs --rpc-url <chain> --from-block 0 --address <hub> <topic0> --json
+    ///        (keep pairs whose last event decodes allowed=false)
+    struct DeniedPair {
+        bytes32 orgId;
+        address target;
+        bytes4 selector;
+    }
+
+    function _gnosisReconstructedDenials() internal pure returns (DeniedPair[] memory d) {
+        bytes32 test6 = 0x263b2b29f392647f0fb8ddbb26f099e812ab4ba2777e5e07b906277164181f6b;
+        address test6Tm = 0x3d93f0D090356D25E7a1614F0F8764b103ca99bc;
+        bytes32 kubi = 0xc0f2765d555e21bfad5c6b05accef86a5758e0dee3e9a5b4ee3c3f3069c2102e;
+        address kubiTm = 0xF57024fC77915Fce8f2608afdd027941bCEE3336;
+        d = new DeniedPair[](7);
+        d[0] = DeniedPair(test6, test6Tm, 0x22fa79bc);
+        d[1] = DeniedPair(test6, test6Tm, 0xaf425951);
+        d[2] = DeniedPair(test6, test6Tm, 0xc18aa1c9);
+        d[3] = DeniedPair(kubi, kubiTm, 0x22fa79bc);
+        d[4] = DeniedPair(kubi, kubiTm, 0xaf425951);
+        d[5] = DeniedPair(kubi, kubiTm, 0xc18aa1c9);
+        d[6] = DeniedPair(kubi, kubiTm, 0x48db6f65);
+    }
+
+    function _arbReconstructedDenials() internal pure returns (DeniedPair[] memory d) {
+        d = new DeniedPair[](0);
+    }
+
     /// @dev Standard 8-module org layout (no ZkEmailInvites) + the two shared registries.
     function _org8(
         bytes32 orgId,
@@ -442,7 +482,21 @@ contract Step4_RegisterTargetTypesGnosis is Script, TargetTypesData {
         uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
         require(IGnosisSatellite(GNOSIS_SATELLITE).owner() == vm.addr(deployerKey), "signer must own the Satellite");
         OrgTargets[] memory orgs = _gnosisOrgs();
+        DeniedPair[] memory denials = _gnosisReconstructedDenials();
         vm.startBroadcast(deployerKey);
+        // Reconstruct pre-v20 explicit denials as blocks BEFORE typing any target — typing is
+        // what arms the rulebook fallback, so this order leaves no window where a previously
+        // denied pair is sponsored. ⚠ Re-run the RuleSet event scan first (see DeniedPair docs).
+        for (uint256 i = 0; i < denials.length; i++) {
+            IGnosisSatellite(GNOSIS_SATELLITE)
+                .adminCall(
+                    GNOSIS_PAYMASTER,
+                    abi.encodeCall(
+                        PaymasterHub.setGlobalRuleBlock,
+                        (denials[i].orgId, denials[i].target, denials[i].selector, true)
+                    )
+                );
+        }
         for (uint256 i = 0; i < orgs.length; i++) {
             IGnosisSatellite(GNOSIS_SATELLITE)
                 .adminCall(
@@ -451,6 +505,7 @@ contract Step4_RegisterTargetTypesGnosis is Script, TargetTypesData {
                 );
         }
         vm.stopBroadcast();
+        console.log("Gnosis: reconstructed denial blocks:", denials.length);
         console.log("Gnosis target types registered for", orgs.length, "orgs");
     }
 }
@@ -461,7 +516,19 @@ contract Step4b_RegisterTargetTypesArbitrum is Script, TargetTypesData {
         uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
         require(PoaManagerHub(payable(HUB)).owner() == vm.addr(deployerKey), "signer must own the Hub");
         OrgTargets[] memory orgs = _arbOrgs();
+        DeniedPair[] memory denials = _arbReconstructedDenials();
         vm.startBroadcast(deployerKey);
+        // Blocks BEFORE types — see Step4. (Zero pairs on Arbitrum at scan time; re-scan first.)
+        for (uint256 i = 0; i < denials.length; i++) {
+            PoaManagerHub(payable(HUB))
+                .adminCall(
+                    ARB_PAYMASTER,
+                    abi.encodeCall(
+                        PaymasterHub.setGlobalRuleBlock,
+                        (denials[i].orgId, denials[i].target, denials[i].selector, true)
+                    )
+                );
+        }
         for (uint256 i = 0; i < orgs.length; i++) {
             PoaManagerHub(payable(HUB))
                 .adminCall(
@@ -470,6 +537,7 @@ contract Step4b_RegisterTargetTypesArbitrum is Script, TargetTypesData {
                 );
         }
         vm.stopBroadcast();
+        console.log("Arbitrum: reconstructed denial blocks:", denials.length);
         console.log("Arbitrum target types registered for", orgs.length, "orgs");
     }
 }
@@ -546,6 +614,43 @@ contract Step6b_UpgradeOrgDeployerArbitrum is Script {
 
 abstract contract SimBase is Script, TargetTypesData {
     uint8 constant SUBJECT_TYPE_ACCOUNT = 0x00;
+
+    bytes4 constant SIM_SEL_CLAIM_TASK = bytes4(keccak256("claimTask(uint256)"));
+    bytes4 constant SIM_SEL_SUBMIT_TASK = bytes4(keccak256("submitTask(uint256,bytes32)"));
+    bytes4 constant SIM_SEL_UNCLAIM_TASK = bytes4(keccak256("unclaimTask(uint256)"));
+
+    /// @dev BEFORE the upgrade, write two pre-v20-style explicit denials through the OLD impl's
+    ///      setRule (which predates the block mapping): a zero-hint one (leaves a ZERO struct —
+    ///      only the event log knows it was denied) and a hint-carrying one ({false, 777}).
+    ///      These model the live denials Step4 must not resurrect.
+    function _createPreV20DenialFixtures(PaymasterHub pm, address poaMgr, bytes32 orgId, address taskManager) internal {
+        vm.prank(poaMgr);
+        pm.setRule(orgId, taskManager, SIM_SEL_CLAIM_TASK, false, 0);
+        vm.prank(poaMgr);
+        pm.setRule(orgId, taskManager, SIM_SEL_SUBMIT_TASK, false, 777);
+        require(!pm.getRule(orgId, taskManager, SIM_SEL_CLAIM_TASK).allowed, "SIM: fixture denial not written");
+        require(pm.getRule(orgId, taskManager, SIM_SEL_SUBMIT_TASK).maxCallGasHint == 777, "SIM: fixture hint lost");
+    }
+
+    /// @dev AFTER seed + denial-block reconstruction + target typing: both pre-v20 denials must
+    ///      still deny — the zero-hint one via its reconstructed block, the hinted one via the
+    ///      resolver itself (assert NO block, proving the on-chain hardening) — while a sibling
+    ///      selector on the same target resolves through the rulebook.
+    function _assertPreV20DenialsPreserved(PaymasterHub pm, bytes32 orgId, address taskManager) internal {
+        PaymasterHubLens lens = new PaymasterHubLens(address(pm));
+        (bool aClaim,,) = lens.effectiveRuleOf(orgId, taskManager, SIM_SEL_CLAIM_TASK);
+        require(!aClaim, "SIM: zero-hint pre-v20 denial RESURRECTED by rulebook");
+        require(pm.isGlobalRuleBlocked(orgId, taskManager, SIM_SEL_CLAIM_TASK), "SIM: reconstructed block missing");
+        (bool aSubmit,,) = lens.effectiveRuleOf(orgId, taskManager, SIM_SEL_SUBMIT_TASK);
+        require(!aSubmit, "SIM: hinted pre-v20 denial RESURRECTED by rulebook");
+        require(
+            !pm.isGlobalRuleBlocked(orgId, taskManager, SIM_SEL_SUBMIT_TASK),
+            "SIM: hinted denial should be honored by the resolver, not a block"
+        );
+        (bool aUnclaim,,) = lens.effectiveRuleOf(orgId, taskManager, SIM_SEL_UNCLAIM_TASK);
+        require(aUnclaim, "SIM: sibling selector must still resolve via the rulebook");
+        console.log("SIM: pre-v20 explicit denials preserved (block + resolver paths).");
+    }
 
     /// @dev The LIVE OrgDeployer must keep working across the hub upgrade: replicate its exact
     ///      call — the OLD 13-field registerAndConfigureOrg selector — and prove the legacy
@@ -725,6 +830,7 @@ contract SimGnosis is SimBase {
     // Test6's live zk-email rule (set on-chain) — used as the storage-survival witness.
     bytes32 constant TEST6_ORG = 0x263b2b29f392647f0fb8ddbb26f099e812ab4ba2777e5e07b906277164181f6b;
     address constant TEST6_ZK = 0xADAf24f05EE0D647A7c2AF5cAD0F377F1B159FD2;
+    address constant TEST6_TM = 0x3d93f0D090356D25E7a1614F0F8764b103ca99bc;
     bytes32 constant KUBI_ORG = 0xc0f2765d555e21bfad5c6b05accef86a5758e0dee3e9a5b4ee3c3f3069c2102e;
 
     function run() public {
@@ -734,6 +840,9 @@ contract SimGnosis is SimBase {
         // Pre-upgrade witnesses.
         PaymasterHub.OrgFinancials memory preFin = pm.getOrgFinancials(KUBI_ORG);
         bool preZkRule = pm.getRule(TEST6_ORG, TEST6_ZK, zkSel).allowed;
+
+        // Pre-v20 explicit-denial fixtures on Test6's TaskManager (written via the OLD impl).
+        _createPreV20DenialFixtures(pm, GNOSIS_POA_MANAGER, TEST6_ORG, TEST6_TM);
 
         // 1. Deploy new impl (libs auto-deployed in-fork) + upgrade the beacon as ADMIN_EOA.
         address newImpl = address(new PaymasterHub());
@@ -768,7 +877,21 @@ contract SimGnosis is SimBase {
         // 4. Seed via the Satellite adminCall (poaManager path) + spot checks.
         _seedViaAdminCall(pm, _satelliteAdminCall);
 
-        // 5. Register target types for all live orgs + assert unclaimTask coverage.
+        // 5. Step4 order: reconstructed denial blocks FIRST (event-scan data + the zero-hint
+        //    fixture, exactly as a pre-broadcast re-scan would include it), then target types.
+        DeniedPair[] memory denials = _gnosisReconstructedDenials();
+        for (uint256 i = 0; i < denials.length; i++) {
+            _satelliteAdminCall(
+                GNOSIS_PAYMASTER,
+                abi.encodeCall(
+                    PaymasterHub.setGlobalRuleBlock, (denials[i].orgId, denials[i].target, denials[i].selector, true)
+                )
+            );
+        }
+        _satelliteAdminCall(
+            GNOSIS_PAYMASTER,
+            abi.encodeCall(PaymasterHub.setGlobalRuleBlock, (TEST6_ORG, TEST6_TM, SIM_SEL_CLAIM_TASK, true))
+        );
         OrgTargets[] memory orgs = _gnosisOrgs();
         for (uint256 i = 0; i < orgs.length; i++) {
             _satelliteAdminCall(
@@ -777,6 +900,7 @@ contract SimGnosis is SimBase {
             );
         }
         _assertOrgCoverage(pm, orgs);
+        _assertPreV20DenialsPreserved(pm, TEST6_ORG, TEST6_TM);
 
         // 6. The LIVE OrgDeployer's legacy ABI keeps working (no bricking window).
         _simLegacyRegisterAndConfigure(pm, GNOSIS_POA_MANAGER);
@@ -811,8 +935,14 @@ contract SimGnosis is SimBase {
  *   --fork-url arbitrum -vvv
  */
 contract SimArbitrum is SimBase {
+    bytes32 constant POA_ORG = 0xa71879ef0e38b15fe7080196c0102f859e0ca8e7b8c0703ec8df03c66befd069;
+    address constant POA_TM = 0x681f29751724D2bED331d3EB35e0C9B1C57aF9F0;
+
     function run() public {
         PaymasterHub pm = PaymasterHub(payable(ARB_PAYMASTER));
+
+        // Pre-v20 explicit-denial fixtures on the Poa org's TaskManager (via the OLD impl).
+        _createPreV20DenialFixtures(pm, ARB_POA_MANAGER, POA_ORG, POA_TM);
 
         // 1. Deploy new impl + upgrade the beacon as ADMIN_EOA (local, no Hyperlane).
         address newImpl = address(new PaymasterHub());
@@ -829,7 +959,21 @@ contract SimArbitrum is SimBase {
         // 2. Seed via Hub.adminCall (poaManager path) + spot checks.
         _seedViaAdminCall(pm, _hubAdminCall);
 
-        // 3. Register target types for the live org(s) + assert unclaimTask coverage.
+        // 3. Step4b order: reconstructed denial blocks FIRST (zero live pairs at scan time —
+        //    the zero-hint fixture stands in, exactly as a pre-broadcast re-scan would add it),
+        //    then target types.
+        DeniedPair[] memory denials = _arbReconstructedDenials();
+        for (uint256 i = 0; i < denials.length; i++) {
+            _hubAdminCall(
+                ARB_PAYMASTER,
+                abi.encodeCall(
+                    PaymasterHub.setGlobalRuleBlock, (denials[i].orgId, denials[i].target, denials[i].selector, true)
+                )
+            );
+        }
+        _hubAdminCall(
+            ARB_PAYMASTER, abi.encodeCall(PaymasterHub.setGlobalRuleBlock, (POA_ORG, POA_TM, SIM_SEL_CLAIM_TASK, true))
+        );
         OrgTargets[] memory orgs = _arbOrgs();
         for (uint256 i = 0; i < orgs.length; i++) {
             _hubAdminCall(
@@ -838,6 +982,7 @@ contract SimArbitrum is SimBase {
             );
         }
         _assertOrgCoverage(pm, orgs);
+        _assertPreV20DenialsPreserved(pm, POA_ORG, POA_TM);
 
         // 4. The LIVE OrgDeployer's legacy ABI keeps working (no bricking window).
         _simLegacyRegisterAndConfigure(pm, ARB_POA_MANAGER);

--- a/script/upgrades/UpgradePaymasterGlobalRules.s.sol
+++ b/script/upgrades/UpgradePaymasterGlobalRules.s.sol
@@ -362,7 +362,7 @@ abstract contract TargetTypesData {
 
 /// @title Step1_DeployImplGnosis — deploy PaymasterHub v20 impl on Gnosis via DD (CREATE3).
 /// Usage: FOUNDRY_PROFILE=production forge script .../UpgradePaymasterGlobalRules.s.sol:Step1_DeployImplGnosis \
-///        --rpc-url gnosis --broadcast --slow --optimizer-runs 1
+///        --rpc-url gnosis --broadcast --slow
 contract Step1_DeployImplGnosis is Script {
     function run() public {
         uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
@@ -378,7 +378,7 @@ contract Step1_DeployImplGnosis is Script {
         address deployed = dd.deploy(salt, type(PaymasterHub).creationCode);
         vm.stopBroadcast();
         require(deployed == predicted, "Address mismatch");
-        require(deployed.code.length <= 24576, "impl exceeds EIP-170 -- lower --optimizer-runs");
+        require(deployed.code.length <= 24576, "impl exceeds EIP-170");
         console.log("Deployed:", deployed);
     }
 }
@@ -398,7 +398,7 @@ contract Step1b_DeployImplArbitrum is Script {
         address deployed = dd.deploy(salt, type(PaymasterHub).creationCode);
         vm.stopBroadcast();
         require(deployed == predicted, "Address mismatch");
-        require(deployed.code.length <= 24576, "impl exceeds EIP-170 -- lower --optimizer-runs");
+        require(deployed.code.length <= 24576, "impl exceeds EIP-170");
         console.log("Deployed:", deployed);
     }
 }
@@ -582,7 +582,7 @@ contract Step6_UpgradeOrgDeployerGnosis is Script {
         if (predicted.code.length == 0) {
             dd.deploy(salt, type(OrgDeployer).creationCode);
         }
-        require(predicted.code.length <= 24576, "impl exceeds EIP-170 -- lower --optimizer-runs");
+        require(predicted.code.length <= 24576, "impl exceeds EIP-170");
         IGnosisSatellite(GNOSIS_SATELLITE).upgradeBeaconDirect("OrgDeployer", predicted, ORG_DEPLOYER_VERSION);
         vm.stopBroadcast();
         console.log("Gnosis OrgDeployer beacon upgraded:", predicted);
@@ -601,7 +601,7 @@ contract Step6b_UpgradeOrgDeployerArbitrum is Script {
         if (predicted.code.length == 0) {
             dd.deploy(salt, type(OrgDeployer).creationCode);
         }
-        require(predicted.code.length <= 24576, "impl exceeds EIP-170 -- lower --optimizer-runs");
+        require(predicted.code.length <= 24576, "impl exceeds EIP-170");
         PoaManagerHub(payable(HUB)).upgradeBeaconLocal("OrgDeployer", predicted, ORG_DEPLOYER_VERSION);
         vm.stopBroadcast();
         console.log("Arbitrum OrgDeployer beacon upgraded:", predicted);

--- a/script/upgrades/UpgradePaymasterGlobalRules.s.sol
+++ b/script/upgrades/UpgradePaymasterGlobalRules.s.sol
@@ -765,11 +765,16 @@ abstract contract SimBase is Script, TargetTypesData {
     }
 
     /// @dev The registered orgs' target types must match the migration data, and effective
-    ///      resolution must allow TaskManager.unclaimTask — the v7 selector that today requires
-    ///      a per-org vote — purely via the rulebook.
+    ///      resolution must allow TaskManager.unclaimTask (the v7 selector that today requires a
+    ///      per-org vote) AND createTasksBatch v6 0xf31d148f — the issue-#153 selector that Poa,
+    ///      Argus and Decentral Park are missing on-chain today (they whitelist only the dead v5
+    ///      0xc18aa1c9, reproducing AA33) — purely via the rulebook. This is what closes #153
+    ///      without broadcasting the per-org WhitelistTaskDeadlineRules*ViaGovernance scripts.
     function _assertOrgCoverage(PaymasterHub pm, OrgTargets[] memory orgs) internal {
         PaymasterHubLens lens = new PaymasterHubLens(address(pm));
         bytes4 unclaimSel = bytes4(keccak256("unclaimTask(uint256)"));
+        bytes4 batchSelV6 =
+            bytes4(keccak256("createTasksBatch(bytes32,(uint256,bytes,bytes32,address,uint256,bool,uint48,uint32)[])"));
         for (uint256 i = 0; i < orgs.length; i++) {
             // Skip orgs that never registered with the paymaster (defensive).
             if (pm.getOrgConfig(orgs[i].orgId).adminHatId == 0) {
@@ -788,6 +793,8 @@ abstract contract SimBase is Script, TargetTypesData {
             (bool allowed,, uint8 source) = lens.effectiveRuleOf(orgs[i].orgId, taskManager, unclaimSel);
             require(allowed, "SIM: unclaimTask not covered by rulebook for live org");
             require(source == 2 || pm.getRule(orgs[i].orgId, taskManager, unclaimSel).allowed, "SIM: bad source");
+            (bool batchAllowed,,) = lens.effectiveRuleOf(orgs[i].orgId, taskManager, batchSelV6);
+            require(batchAllowed, "SIM: createTasksBatch v6 (#153) not healed for live org");
         }
         console.log("SIM: all registered orgs resolve unclaimTask via the rulebook.");
     }

--- a/script/upgrades/UpgradePaymasterGlobalRules.s.sol
+++ b/script/upgrades/UpgradePaymasterGlobalRules.s.sol
@@ -1,0 +1,863 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.24;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import {PaymasterHub} from "../../src/PaymasterHub.sol";
+import {PaymasterHubLens} from "../../src/PaymasterHubLens.sol";
+import {OrgDeployer} from "../../src/OrgDeployer.sol";
+import {ZkEmailInvites} from "../../src/ZkEmailInvites.sol";
+import {PaymasterRuleLib} from "../../src/libs/PaymasterRuleLib.sol";
+import {ModuleTypes} from "../../src/libs/ModuleTypes.sol";
+import {DefaultGlobalRules} from "../helpers/DefaultGlobalRules.sol";
+import {PackedUserOperation} from "../../src/interfaces/PackedUserOperation.sol";
+import {PoaManagerHub} from "../../src/crosschain/PoaManagerHub.sol";
+import {PoaManager} from "../../src/PoaManager.sol";
+import {DeterministicDeployer} from "../../src/crosschain/DeterministicDeployer.sol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// UpgradePaymasterGlobalRules (PaymasterHub v20 — type-keyed GLOBAL RULEBOOK)
+//
+// Upgrades the live PaymasterHub on Gnosis + Arbitrum to the global-rulebook impl:
+//   • Sponsorship rules resolve local-first, then (Mirror mode, the default) through a
+//     protocol-managed rulebook keyed by (module typeId, selector) — one setGlobalRulesBatch
+//     covers every Mirror org, replacing per-org adminBatchAddRules fan-outs and
+//     OrgDeployer selector-list redeploys.
+//   • Per-org targetTypes map proxy addresses → typeIds; per-org rules mode (Mirror/Static);
+//     per-pair block veto; adopt/snapshot helpers for Static orgs.
+//   • All rule logic moved to PaymasterRuleLib (new delegatecall library; hub runtime SHRANK
+//     to 21,936 B at runs=200 — 2,640 B EIP-170 headroom).
+//   • PaymasterHubLens gains effectiveRuleOf + global-aware wouldValidate → must be redeployed.
+//
+// The live "PaymasterHub" proxies are BeaconProxies — the upgrade goes through
+// PoaManager.upgradeBeacon, driven by Satellite.upgradeBeaconDirect (Gnosis, owner = ADMIN_EOA)
+// and PoaManagerHub.upgradeBeaconLocal (Arbitrum, owner = ADMIN_EOA). Admin calls that must
+// arrive as the hub's poaManager route through Satellite/Hub.adminCall (which forwards via the
+// local PoaManager.adminCall).
+//
+// Version: v20 — two-surface probed FREE (registry getVersionCount=16 + getImplementation
+//   exit-code AND cast code at DeterministicDeployer.computeAddress) on BOTH chains, 2026-08-04.
+//   Predicted impl (CREATE3, salt-only): 0xC0137F27de9E16875dc309f512D61169E46BDE6f on both.
+//
+// Live migration data (subgraphs, 2026-08-04): 9 Gnosis orgs + 1 Arbitrum org, each mapped to
+// its module typeIds below. All were bootstrap-deployed with autoUpgrade=true, so they stay in
+// the default Mirror rules mode (no mode writes needed) and the rulebook covers them the moment
+// Step3+Step4 land. UniversalAccountRegistry / OrgRegistry per chain resolved on-chain
+// (hub.getOnboardingConfig().accountRegistry / OrgDeployer layout slot+3).
+//
+// ABI COMPATIBILITY: DeployConfig grew 3 appended fields, changing registerAndConfigureOrg's
+// selector (old 0xc6f422d9 → new 0x8eac29d9). The v20 hub keeps a LEGACY overload with the old
+// selector, so the LIVE OrgDeployer proxies keep deploying orgs (address-keyed local rules,
+// exactly as today) with NO lockstep requirement — Step6 upgrades the OrgDeployer beacon to the
+// type-registering deployer whenever convenient. Both sims exercise the legacy selector.
+//
+// Order per chain: Step1 (impl) → Step2 (beacon upgrade) → Step3 (seed rulebook)
+//                  → Step4 (org target types) → Step5 (redeploy Lens) → Step6 (OrgDeployer v19,
+//                  two-surface probed FREE on both chains 2026-08-04, predicted
+//                  0x90BAe532D26100a2106c3b16bEA1Ad27D2286b3A).
+//
+// Sims (run BOTH before any broadcast):
+//   FOUNDRY_PROFILE=production forge script script/upgrades/UpgradePaymasterGlobalRules.s.sol:SimGnosis \
+//     --fork-url gnosis -vvv
+//   FOUNDRY_PROFILE=production forge script script/upgrades/UpgradePaymasterGlobalRules.s.sol:SimArbitrum \
+//     --fork-url arbitrum -vvv
+// ─────────────────────────────────────────────────────────────────────────────
+
+address constant DD = 0x4aC8B5ebEb9D8C3dE3180ddF381D552d59e8835a;
+address constant HUB = 0xB72840B343654eAfb2CFf7acC4Fc6b59E6c3CC71; // PoaManagerHub (Arbitrum)
+address constant ARB_PAYMASTER = 0xD6659bCaFAdCB9CC2F57B7aE923c7F1Ca4438a11;
+address constant GNOSIS_PAYMASTER = 0xdEf1038C297493c0b5f82F0CDB49e929B53B4108;
+address constant GNOSIS_POA_MANAGER = 0x794fD39e75140ee1545B1B022E5486B7c863789b;
+address constant ARB_POA_MANAGER = 0xFF585Fae4A944cD173B19158C6FC5E08980b0815;
+address constant GNOSIS_SATELLITE = 0x4Ad70029a9247D369a5bEA92f90840B9ee58eD06; // PoaManagerSatellite
+address constant ADMIN_EOA = 0xA6F4D9f44Dd980b7168D829d5f74c2b00a46b2c9;
+string constant VERSION = "v20";
+string constant ORG_DEPLOYER_VERSION = "v19";
+
+/// @dev Selector of the pre-rulebook registerAndConfigureOrg — the one the LIVE OrgDeployer
+///      proxies call. The v20 hub MUST keep answering it (legacy overload).
+bytes4 constant LEGACY_REGISTER_AND_CONFIGURE_SELECTOR = 0xc6f422d9;
+
+// Shared registries (target-typed so gasless profile/metadata calls resolve via the rulebook)
+address constant GNOSIS_ACCOUNT_REGISTRY = 0x55F72CEB09cBC1fAAED734b6505b99b0a1DFA1cA;
+address constant GNOSIS_ORG_REGISTRY = 0x3744b372abc41589226313F2bB1dB3aCAa22A854;
+address constant ARB_ACCOUNT_REGISTRY = 0x01A13c92321E9CA2C02577b92A4F8d2FDC4d8513;
+address constant ARB_ORG_REGISTRY = 0x7B023B9566b96616D54935AE8De80579c93f62aC;
+
+/// @dev Satellite/Hub adminCall forwards through the local PoaManager, so the hub sees
+///      msg.sender == poaManager and the poaManager-gated paths (setGlobalRulesBatch,
+///      setTargetTypesBatch bypass, unpause, registrar) all pass.
+interface IGnosisSatellite {
+    function owner() external view returns (address);
+    function adminCall(address target, bytes calldata data) external returns (bytes memory);
+    function upgradeBeaconDirect(string calldata typeName, address newImpl, string calldata version) external;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Live-org target-type migration data (generated from the Poa subgraphs 2026-08-04)
+// ─────────────────────────────────────────────────────────────────────────────
+
+abstract contract TargetTypesData {
+    struct OrgTargets {
+        bytes32 orgId;
+        address[] targets;
+        bytes32[] typeIds;
+    }
+
+    /// @dev Standard 8-module org layout (no ZkEmailInvites) + the two shared registries.
+    function _org8(
+        bytes32 orgId,
+        address quickJoin,
+        address taskManager,
+        address hybridVoting,
+        address ddVoting,
+        address paymentManager,
+        address eligibility,
+        address token,
+        address educationHub,
+        address acctReg,
+        address orgReg
+    ) internal pure returns (OrgTargets memory o) {
+        o.orgId = orgId;
+        o.targets = new address[](10);
+        o.typeIds = new bytes32[](10);
+        o.targets[0] = quickJoin;
+        o.typeIds[0] = ModuleTypes.QUICK_JOIN_ID;
+        o.targets[1] = taskManager;
+        o.typeIds[1] = ModuleTypes.TASK_MANAGER_ID;
+        o.targets[2] = hybridVoting;
+        o.typeIds[2] = ModuleTypes.HYBRID_VOTING_ID;
+        o.targets[3] = ddVoting;
+        o.typeIds[3] = ModuleTypes.DIRECT_DEMOCRACY_VOTING_ID;
+        o.targets[4] = paymentManager;
+        o.typeIds[4] = ModuleTypes.PAYMENT_MANAGER_ID;
+        o.targets[5] = eligibility;
+        o.typeIds[5] = ModuleTypes.ELIGIBILITY_MODULE_ID;
+        o.targets[6] = token;
+        o.typeIds[6] = ModuleTypes.PARTICIPATION_TOKEN_ID;
+        o.targets[7] = educationHub;
+        o.typeIds[7] = ModuleTypes.EDUCATION_HUB_ID;
+        o.targets[8] = acctReg;
+        o.typeIds[8] = ModuleTypes.UNIVERSAL_ACCOUNT_REGISTRY_ID;
+        o.targets[9] = orgReg;
+        o.typeIds[9] = ModuleTypes.ORG_REGISTRY_ID;
+    }
+
+    /// @dev 8-module org + ZkEmailInvites + the two shared registries.
+    function _org9(OrgTargets memory base, address zkEmailInvites) internal pure returns (OrgTargets memory o) {
+        o.orgId = base.orgId;
+        uint256 n = base.targets.length;
+        o.targets = new address[](n + 1);
+        o.typeIds = new bytes32[](n + 1);
+        for (uint256 i = 0; i < n; i++) {
+            o.targets[i] = base.targets[i];
+            o.typeIds[i] = base.typeIds[i];
+        }
+        o.targets[n] = zkEmailInvites;
+        o.typeIds[n] = ModuleTypes.ZKEMAIL_INVITES_ID;
+    }
+
+    function _gnosisOrgs() internal pure returns (OrgTargets[] memory orgs) {
+        orgs = new OrgTargets[](9);
+        address ar = GNOSIS_ACCOUNT_REGISTRY;
+        address orr = GNOSIS_ORG_REGISTRY;
+        // Argus
+        orgs[0] = _org8(
+            0x112de94b6e6cba0ccece7301df866a932711655946942d795f07334e3fd6f46b,
+            0xD942D29601aBFbce51a67618938B5cb07Fe4EFBD,
+            0xd17D6038eD29aC294cf8cDC4eFC87d30261b77DC,
+            0xa9209AfAdF721C2a55eC5875CC4716a9F1C5b0b7,
+            0xe675763055700fbb05163c146598Aa6D7DC20827,
+            0x409F51250dC5C66BB1D6952f947D841192f1140e,
+            0xB37a97C8136F6d300C399162cEfAb5B61c675cAF,
+            0x5cafc2FA0653b34BDC51d738D67E70409A4b4806,
+            0x5D5a2bbCE6718C38622b900215586222c747Cf7e,
+            ar,
+            orr
+        );
+        // Test3
+        orgs[1] = _org8(
+            0x204558076efb2042ebc9b034aab36d85d672d8ac1fa809288da5b453a4714aae,
+            0xC82b179f5b4e325aC1B77A423FDb266AeBfCA5E8,
+            0x8f5BD281Eb4794Fc3eafFD2e558691FB98b815d7,
+            0xaB09811a03143C528Bb1C670a52f19F968BEB9c9,
+            0x2C2338CBEE744f086C8Fc229b58335e1F0b3d4f5,
+            0x7bF9FF6cb7bE5180B383C4F8FaB55ff28c5c4eC6,
+            0x2cF31A59e474e697370daffF78Fc5Cf6D23E5F9C,
+            0x5f63C2F6cBBbd17267Af39b6375319D3761f2DE4,
+            0x8Abe743864DF61055219d77abDfc72e23AD0BccE,
+            ar,
+            orr
+        );
+        // Test6 (has ZkEmailInvites)
+        orgs[2] = _org9(
+            _org8(
+                0x263b2b29f392647f0fb8ddbb26f099e812ab4ba2777e5e07b906277164181f6b,
+                0x09d7006724C2Ba9bf9084ad9db6DbB09B990843d,
+                0x3d93f0D090356D25E7a1614F0F8764b103ca99bc,
+                0xF642DdE77848dC195c8089F4042A311Ed650d7a6,
+                0xd2667117ED47aD259fEf73F54f31a3eF9A5D889F,
+                0x10E96701746B567882b74E39a24AEe7267c22Bb5,
+                0xf01F2bDd5C86E7B676117cB0d6E2c07aa36E8c8B,
+                0x6083c52b2F5861F327526bD646EaA754edDD5cCf,
+                0x6a29222E29FDc0000AbA55329DfF0a50D9a8e8F9,
+                ar,
+                orr
+            ),
+            0xADAf24f05EE0D647A7c2AF5cAD0F377F1B159FD2
+        );
+        // Decentral Park
+        orgs[3] = _org8(
+            0x3721271eb827a52a5adf676136d302efe19c34e72f08e080b07b225eecf27d78,
+            0xBEba9EF99aa6E0693c22b60d4Ea5ed7C395F26f1,
+            0x2D9d397A842B8D691ea2A232062CbC8eF8eBbdB7,
+            0x1B80CA1EF7F274E141658A666fc12277957bF7A1,
+            0xF3e3EB13214D9F98e6115e3C2602aE66340CD575,
+            0xebC2224Dc7Ee7DdcE889e49685dB095780Be17a1,
+            0xe4A02F20B8282A272879e31479Ee070dab07B015,
+            0x1A8b31903C98e514332991a70C00566ec2DeE14e,
+            0x80a78A0b7E0d491B7cc4cF0bAFe8bce3be9e1454,
+            ar,
+            orr
+        );
+        // Test2
+        orgs[4] = _org8(
+            0x4da432f1ecd4c0ac028ebde3a3f78510a21d54087b161590a63080d33b702b8d,
+            0x14Aced4F1B6fB1EF4030E7E7E19A3e6aB0B931a1,
+            0xD89c1B5872D7D66d00B4Aa737682DD7660998d34,
+            0xFFe27f0C75E9B0C96D9B41A07D3035F61380c89d,
+            0x30459389b46391c730534F8118637AF19FD251fC,
+            0x2B09C556Be0E8e8C1D43143ffF411062123189Bc,
+            0xEd3F68663dC51f1499F4A574B2eDA15efc3a3580,
+            0x34aa1bD79a3A5eb5d2B208eb4f091ccF6B1081d5,
+            0x7d01F85d1B0FAD1fE50efC8111d1579987bC57A4,
+            ar,
+            orr
+        );
+        // Test
+        orgs[5] = _org8(
+            0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658,
+            0xB1ff2Bd0231770ccc91801aa1fae4b3226E1fE41,
+            0x366c605A3064a680fb5c05Bf9EeDa512fdDBF03a,
+            0x150c21831BB8cCf397EB33deA4315E4DC7818abA,
+            0xd466Cd1bE97747828a8eE7982021874aa8413ae0,
+            0xcCD256221DECFF032f38fBd84E01651a4De6d82F,
+            0x76a0225F4Ac5fA105F4D294ba4e9C1D3fb7D6601,
+            0xE4F9CB9C843D0A5bd5D52e3266138B13A635743b,
+            0x33CD0B9ae54c43C11Fd05fE00afd3DBC71D9603E,
+            ar,
+            orr
+        );
+        // Test5
+        orgs[6] = _org8(
+            0x9e199fafc1079dfb2b375cdac741cefb6c51d5f471f8afffa517442b6160463c,
+            0x5378548e0E4523A16a9AdADD7Aa227d9814096a2,
+            0x4daA78FAA39ee9011f17c99Bea620fc8478CAce2,
+            0x639A22665366c1Ce1D2917e28e31aF3826887128,
+            0xB47Ef9562bFf0322d096Ddc183d12aE2eCDb8A49,
+            0xb4Bdc5B29BFb69e8FAE0B899E6B5a436B9eDeD6f,
+            0xfCCAb58A9222CA5c550981930d5b9C3b3E99a198,
+            0xb13ab847458D64fcDd0bd71c70B0bc4622DacfcF,
+            0x01C9c2d6cbe47c73Fd3656f7cB78B7C869D18f98,
+            ar,
+            orr
+        );
+        // KUBI (has ZkEmailInvites)
+        orgs[7] = _org9(
+            _org8(
+                0xc0f2765d555e21bfad5c6b05accef86a5758e0dee3e9a5b4ee3c3f3069c2102e,
+                0x5dBda3649B7044C8fDd0E540e86E536dDA7926Cf,
+                0xF57024fC77915Fce8f2608afdd027941bCEE3336,
+                0x13CBd5eD47bF177968B24D84516a75879c23971E,
+                0xe24Cb844C73095569FA146D673D45c252894200f,
+                0x4009c825b38Fb0ebB6391d5FABe4FAf90e178dF1,
+                0x27114Cb757BeDF77E30EeB0Ca635e3368d8C2914,
+                0x23641B4b54E1bf63FD519b242407b9314093B33C,
+                0x83C7Aa49C0C5a55E22640AC164abA838E6f1f7ae,
+                ar,
+                orr
+            ),
+            0x32cc2D8563e691A3Ca43723A9F558f7AD8dbA9ec
+        );
+        // tkrjehbcuebc
+        orgs[8] = _org8(
+            0xf8eb3652e8f049128d4e3c9315875697f42990714f5e3410f15458805cc9073c,
+            0x50876A6A46879AA4922a242f6dAA2f220D120996,
+            0x5FD3d65Eb46eD4258E5D94902ada696188079E1f,
+            0xf5331F8FA5a9946e27beFE1D8dE257A8C99AF919,
+            0x53C30146deD3Bd00788F222dF870688feECFCFbb,
+            0x851808C371F5Ac05499BfC1B5958AF0B20F76CA7,
+            0xf842787abFb3812a6231BAca65fA35FD57828cEb,
+            0x504C218d9A8D5706505f8890be6449a5408DEB44,
+            0x28dbcC45Df2e9A2e6665570BECBDdc14d0a62D46,
+            ar,
+            orr
+        );
+    }
+
+    function _arbOrgs() internal pure returns (OrgTargets[] memory orgs) {
+        orgs = new OrgTargets[](1);
+        // Poa (governance org)
+        orgs[0] = _org8(
+            0xa71879ef0e38b15fe7080196c0102f859e0ca8e7b8c0703ec8df03c66befd069,
+            0x366c605A3064a680fb5c05Bf9EeDa512fdDBF03a,
+            0x681f29751724D2bED331d3EB35e0C9B1C57aF9F0,
+            0x34aa1bD79a3A5eb5d2B208eb4f091ccF6B1081d5,
+            0xC82b179f5b4e325aC1B77A423FDb266AeBfCA5E8,
+            0xAe470B8366AF331F52D9eA26efD7Cb2d276878B3,
+            0xE4F9CB9C843D0A5bd5D52e3266138B13A635743b,
+            0x33CD0B9ae54c43C11Fd05fE00afd3DBC71D9603E,
+            0xe37Db8cCD295C9E4fEbb19a91efe13aCe24ca596,
+            ARB_ACCOUNT_REGISTRY,
+            ARB_ORG_REGISTRY
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Broadcast steps
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// @title Step1_DeployImplGnosis — deploy PaymasterHub v20 impl on Gnosis via DD (CREATE3).
+/// Usage: FOUNDRY_PROFILE=production forge script .../UpgradePaymasterGlobalRules.s.sol:Step1_DeployImplGnosis \
+///        --rpc-url gnosis --broadcast --slow --optimizer-runs 1
+contract Step1_DeployImplGnosis is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+        bytes32 salt = dd.computeSalt("PaymasterHub", VERSION);
+        address predicted = dd.computeAddress(salt);
+        console.log("Predicted PaymasterHub v20 impl:", predicted);
+        if (predicted.code.length > 0) {
+            console.log("Already deployed. Skipping.");
+            return;
+        }
+        vm.startBroadcast(deployerKey);
+        address deployed = dd.deploy(salt, type(PaymasterHub).creationCode);
+        vm.stopBroadcast();
+        require(deployed == predicted, "Address mismatch");
+        require(deployed.code.length <= 24576, "impl exceeds EIP-170 -- lower --optimizer-runs");
+        console.log("Deployed:", deployed);
+    }
+}
+
+/// @title Step1b_DeployImplArbitrum — same, on Arbitrum.
+contract Step1b_DeployImplArbitrum is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+        bytes32 salt = dd.computeSalt("PaymasterHub", VERSION);
+        address predicted = dd.computeAddress(salt);
+        if (predicted.code.length > 0) {
+            console.log("Already deployed. Skipping.");
+            return;
+        }
+        vm.startBroadcast(deployerKey);
+        address deployed = dd.deploy(salt, type(PaymasterHub).creationCode);
+        vm.stopBroadcast();
+        require(deployed == predicted, "Address mismatch");
+        require(deployed.code.length <= 24576, "impl exceeds EIP-170 -- lower --optimizer-runs");
+        console.log("Deployed:", deployed);
+    }
+}
+
+/// @title Step2_UpgradeGnosis — point the Gnosis PaymasterHub beacon at v20 (destination-chain
+///        direct path; no Hyperlane fee/wait). Registers (PaymasterHub, v20) in the registry.
+contract Step2_UpgradeGnosis is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        require(IGnosisSatellite(GNOSIS_SATELLITE).owner() == vm.addr(deployerKey), "signer must own the Satellite");
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+        address impl = dd.computeAddress(dd.computeSalt("PaymasterHub", VERSION));
+        require(impl.code.length > 0, "run Step1 first");
+        vm.startBroadcast(deployerKey);
+        IGnosisSatellite(GNOSIS_SATELLITE).upgradeBeaconDirect("PaymasterHub", impl, VERSION);
+        vm.stopBroadcast();
+        console.log("Gnosis PaymasterHub beacon upgraded to v20:", impl);
+    }
+}
+
+/// @title Step2b_UpgradeArbitrum — same via PoaManagerHub.upgradeBeaconLocal.
+contract Step2b_UpgradeArbitrum is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        require(PoaManagerHub(payable(HUB)).owner() == vm.addr(deployerKey), "signer must own the Hub");
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+        address impl = dd.computeAddress(dd.computeSalt("PaymasterHub", VERSION));
+        require(impl.code.length > 0, "run Step1b first");
+        vm.startBroadcast(deployerKey);
+        PoaManagerHub(payable(HUB)).upgradeBeaconLocal("PaymasterHub", impl, VERSION);
+        vm.stopBroadcast();
+        console.log("Arbitrum PaymasterHub beacon upgraded to v20:", impl);
+    }
+}
+
+/// @title Step3_SeedRulebookGnosis — seed the global rulebook with the canonical default set.
+/// @dev Routed through Satellite.adminCall → PoaManager.adminCall so the hub sees poaManager
+///      (independent of protocolAdmin state). Idempotent: entries are pure upserts.
+contract Step3_SeedRulebookGnosis is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        require(IGnosisSatellite(GNOSIS_SATELLITE).owner() == vm.addr(deployerKey), "signer must own the Satellite");
+        (bytes32[] memory typeIds, bytes4[] memory selectors, bool[] memory allowed, uint32[] memory hints) =
+            DefaultGlobalRules.defaults();
+        vm.startBroadcast(deployerKey);
+        IGnosisSatellite(GNOSIS_SATELLITE)
+            .adminCall(
+                GNOSIS_PAYMASTER, abi.encodeCall(PaymasterHub.setGlobalRulesBatch, (typeIds, selectors, allowed, hints))
+            );
+        vm.stopBroadcast();
+        uint256 count = PaymasterHub(payable(GNOSIS_PAYMASTER)).getGlobalRuleCount();
+        console.log("Gnosis global rulebook seeded. Entries:", count);
+        require(count >= typeIds.length, "rulebook count below seed size");
+    }
+}
+
+/// @title Step3b_SeedRulebookArbitrum — same via PoaManagerHub.adminCall.
+contract Step3b_SeedRulebookArbitrum is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        require(PoaManagerHub(payable(HUB)).owner() == vm.addr(deployerKey), "signer must own the Hub");
+        (bytes32[] memory typeIds, bytes4[] memory selectors, bool[] memory allowed, uint32[] memory hints) =
+            DefaultGlobalRules.defaults();
+        vm.startBroadcast(deployerKey);
+        PoaManagerHub(payable(HUB))
+            .adminCall(
+                ARB_PAYMASTER, abi.encodeCall(PaymasterHub.setGlobalRulesBatch, (typeIds, selectors, allowed, hints))
+            );
+        vm.stopBroadcast();
+        uint256 count = PaymasterHub(payable(ARB_PAYMASTER)).getGlobalRuleCount();
+        console.log("Arbitrum global rulebook seeded. Entries:", count);
+        require(count >= typeIds.length, "rulebook count below seed size");
+    }
+}
+
+/// @title Step4_RegisterTargetTypesGnosis — map every live Gnosis org's modules to typeIds.
+/// @dev One adminCall per org (poaManager bypass on setTargetTypesBatch). All live orgs are
+///      Mirror-mode by default, so this is the switch that turns the rulebook ON for them.
+contract Step4_RegisterTargetTypesGnosis is Script, TargetTypesData {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        require(IGnosisSatellite(GNOSIS_SATELLITE).owner() == vm.addr(deployerKey), "signer must own the Satellite");
+        OrgTargets[] memory orgs = _gnosisOrgs();
+        vm.startBroadcast(deployerKey);
+        for (uint256 i = 0; i < orgs.length; i++) {
+            IGnosisSatellite(GNOSIS_SATELLITE)
+                .adminCall(
+                    GNOSIS_PAYMASTER,
+                    abi.encodeCall(PaymasterHub.setTargetTypesBatch, (orgs[i].orgId, orgs[i].targets, orgs[i].typeIds))
+                );
+        }
+        vm.stopBroadcast();
+        console.log("Gnosis target types registered for", orgs.length, "orgs");
+    }
+}
+
+/// @title Step4b_RegisterTargetTypesArbitrum — same for the Arbitrum org(s).
+contract Step4b_RegisterTargetTypesArbitrum is Script, TargetTypesData {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        require(PoaManagerHub(payable(HUB)).owner() == vm.addr(deployerKey), "signer must own the Hub");
+        OrgTargets[] memory orgs = _arbOrgs();
+        vm.startBroadcast(deployerKey);
+        for (uint256 i = 0; i < orgs.length; i++) {
+            PoaManagerHub(payable(HUB))
+                .adminCall(
+                    ARB_PAYMASTER,
+                    abi.encodeCall(PaymasterHub.setTargetTypesBatch, (orgs[i].orgId, orgs[i].targets, orgs[i].typeIds))
+                );
+        }
+        vm.stopBroadcast();
+        console.log("Arbitrum target types registered for", orgs.length, "orgs");
+    }
+}
+
+/// @title Step5_RedeployLensGnosis / Step5b_RedeployLensArbitrum — redeploy PaymasterHubLens.
+/// @dev wouldValidate/isAllowed now resolve through the global rulebook and effectiveRuleOf is
+///      new. Update the Lens address in the frontend/bundler preflight config after broadcast.
+contract Step5_RedeployLensGnosis is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        vm.startBroadcast(deployerKey);
+        PaymasterHubLens lens = new PaymasterHubLens(GNOSIS_PAYMASTER);
+        vm.stopBroadcast();
+        console.log("New Gnosis PaymasterHubLens:", address(lens));
+        console.log("ACTION: update the Lens address in the frontend/bundler preflight config.");
+    }
+}
+
+contract Step5b_RedeployLensArbitrum is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        vm.startBroadcast(deployerKey);
+        PaymasterHubLens lens = new PaymasterHubLens(ARB_PAYMASTER);
+        vm.stopBroadcast();
+        console.log("New Arbitrum PaymasterHubLens:", address(lens));
+        console.log("ACTION: update the Lens address in the frontend/bundler preflight config.");
+    }
+}
+
+/// @title Step6_UpgradeOrgDeployerGnosis — deploy OrgDeployer v19 (type-registering) + upgrade
+///        its beacon. NOT time-critical: until this lands, the old deployer keeps working via
+///        the hub's legacy registerAndConfigureOrg overload (orgs get address-keyed local rules
+///        as today); after it, new orgs get target types + Mirror resolution instead.
+contract Step6_UpgradeOrgDeployerGnosis is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        require(IGnosisSatellite(GNOSIS_SATELLITE).owner() == vm.addr(deployerKey), "signer must own the Satellite");
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+        bytes32 salt = dd.computeSalt("OrgDeployer", ORG_DEPLOYER_VERSION);
+        address predicted = dd.computeAddress(salt);
+        vm.startBroadcast(deployerKey);
+        if (predicted.code.length == 0) {
+            dd.deploy(salt, type(OrgDeployer).creationCode);
+        }
+        require(predicted.code.length <= 24576, "impl exceeds EIP-170 -- lower --optimizer-runs");
+        IGnosisSatellite(GNOSIS_SATELLITE).upgradeBeaconDirect("OrgDeployer", predicted, ORG_DEPLOYER_VERSION);
+        vm.stopBroadcast();
+        console.log("Gnosis OrgDeployer beacon upgraded to v19:", predicted);
+    }
+}
+
+/// @title Step6b_UpgradeOrgDeployerArbitrum — same via PoaManagerHub.upgradeBeaconLocal.
+contract Step6b_UpgradeOrgDeployerArbitrum is Script {
+    function run() public {
+        uint256 deployerKey = vm.envOr("PRIVATE_KEY", vm.envUint("DEPLOYER_PRIVATE_KEY"));
+        require(PoaManagerHub(payable(HUB)).owner() == vm.addr(deployerKey), "signer must own the Hub");
+        DeterministicDeployer dd = DeterministicDeployer(DD);
+        bytes32 salt = dd.computeSalt("OrgDeployer", ORG_DEPLOYER_VERSION);
+        address predicted = dd.computeAddress(salt);
+        vm.startBroadcast(deployerKey);
+        if (predicted.code.length == 0) {
+            dd.deploy(salt, type(OrgDeployer).creationCode);
+        }
+        require(predicted.code.length <= 24576, "impl exceeds EIP-170 -- lower --optimizer-runs");
+        PoaManagerHub(payable(HUB)).upgradeBeaconLocal("OrgDeployer", predicted, ORG_DEPLOYER_VERSION);
+        vm.stopBroadcast();
+        console.log("Arbitrum OrgDeployer beacon upgraded to v19:", predicted);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Simulations — run under FOUNDRY_PROFILE=production against live forks.
+// ─────────────────────────────────────────────────────────────────────────────
+
+abstract contract SimBase is Script, TargetTypesData {
+    uint8 constant SUBJECT_TYPE_ACCOUNT = 0x00;
+
+    /// @dev The LIVE OrgDeployer must keep working across the hub upgrade: replicate its exact
+    ///      call — the OLD 13-field registerAndConfigureOrg selector — and prove the legacy
+    ///      overload registers the org and applies address-keyed local rules as before.
+    function _simLegacyRegisterAndConfigure(PaymasterHub pm, address poaMgr) internal {
+        // The legacy overload's selector must be byte-identical to what the deployed
+        // OrgDeployer bytecode emits (0xc6f422d9).
+        bytes4 computed = bytes4(
+            keccak256(
+                "registerAndConfigureOrg(bytes32,uint256,(uint256,uint256,uint256,uint32,uint32,uint32,address[],bytes4[],bool[],uint32[],bytes32[],uint128[],uint32[]))"
+            )
+        );
+        require(computed == LEGACY_REGISTER_AND_CONFIGURE_SELECTOR, "SIM: legacy selector drifted");
+
+        bytes32 org = keccak256(abi.encodePacked("legacy-abi-sim", vm.getBlockTimestamp()));
+        address legacyTarget = address(0x1E6ACC);
+        bytes4 legacySel = bytes4(keccak256("doLegacyThing()"));
+
+        PaymasterRuleLib.LegacyDeployConfig memory cfg;
+        cfg.ruleTargets = new address[](1);
+        cfg.ruleTargets[0] = legacyTarget;
+        cfg.ruleSelectors = new bytes4[](1);
+        cfg.ruleSelectors[0] = legacySel;
+        cfg.ruleAllowed = new bool[](1);
+        cfg.ruleAllowed[0] = true;
+        cfg.ruleMaxCallGasHints = new uint32[](1);
+
+        vm.prank(poaMgr);
+        (bool ok,) =
+            address(pm).call(abi.encodeWithSelector(LEGACY_REGISTER_AND_CONFIGURE_SELECTOR, org, uint256(1), cfg));
+        require(ok, "SIM: legacy registerAndConfigureOrg reverted -- live OrgDeployer would brick");
+        require(pm.getOrgConfig(org).adminHatId == 1, "SIM: legacy path did not register org");
+        require(pm.getRule(org, legacyTarget, legacySel).allowed, "SIM: legacy path did not seed local rule");
+        require(pm.getRulesMode(org) == 0 && pm.getTargetType(org, legacyTarget) == bytes32(0), "SIM: legacy defaults");
+        console.log("SIM: legacy 13-field registerAndConfigureOrg selector still served (no deployer lockstep).");
+    }
+
+    /// @dev End-to-end proof on live state: register a throwaway Mirror org whose ONLY rule
+    ///      coverage is the freshly seeded global rulebook, fund it, and validate a userOp
+    ///      calling TaskManager.claimTask through the type mapping. Then prove Static mode and
+    ///      the per-pair block both deny.
+    function _simEndToEnd(PaymasterHub pm, address poaMgr) internal {
+        bytes32 org = keccak256(abi.encodePacked("global-rules-sim", vm.getBlockTimestamp()));
+        address fakeTaskManager = address(0x7A5C7A5C);
+        address sender = address(0xD00D);
+        bytes4 claimSel = bytes4(keccak256("claimTask(uint256)"));
+
+        // Register with target types + Mirror mode via the registrar (poaManager) path.
+        PaymasterRuleLib.DeployConfig memory cfg;
+        cfg.typeTargets = new address[](1);
+        cfg.typeTargets[0] = fakeTaskManager;
+        cfg.typeIds = new bytes32[](1);
+        cfg.typeIds[0] = ModuleTypes.TASK_MANAGER_ID;
+        vm.prank(poaMgr);
+        pm.registerAndConfigureOrg(org, 1, cfg);
+        require(pm.getRulesMode(org) == 0, "SIM: fresh org not in Mirror mode");
+        require(pm.getTargetType(org, fakeTaskManager) == ModuleTypes.TASK_MANAGER_ID, "SIM: target type not set");
+
+        // Budget for the account subject + org deposit so rules are the binding constraint.
+        bytes32 subjectKey = keccak256(abi.encodePacked(SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(sender)))));
+        vm.prank(poaMgr);
+        pm.setBudget(org, subjectKey, type(uint128).max, 7 days);
+        address funder = address(0xF00D11);
+        vm.deal(funder, 2 ether);
+        vm.prank(funder);
+        pm.depositForOrg{value: 1 ether}(org);
+
+        // No local rule exists — validation must resolve through the GLOBAL rulebook.
+        require(!pm.getRule(org, fakeTaskManager, claimSel).allowed, "SIM: unexpected local rule");
+        PackedUserOperation memory op = _op(address(pm), org, sender, fakeTaskManager, claimSel);
+        address ep = pm.ENTRY_POINT();
+        vm.prank(ep);
+        (, uint256 vd) = pm.validatePaymasterUserOp(op, bytes32(0), 0.001 ether);
+        require(vd == 0, "SIM: global-rule validation failed");
+        console.log("SIM: userOp validated via global rulebook (no local rules).");
+
+        // Static mode denies the global fallback...
+        vm.prank(poaMgr);
+        pm.setRulesMode(org, 1);
+        vm.prank(ep);
+        (bool okStatic,) =
+            address(pm).call(abi.encodeCall(PaymasterHub.validatePaymasterUserOp, (op, bytes32(0), 0.001 ether)));
+        require(!okStatic, "SIM: Static mode failed to deny global rule");
+        vm.prank(poaMgr);
+        pm.setRulesMode(org, 0);
+
+        // ...and so does a per-pair block, without leaving Mirror mode.
+        vm.prank(poaMgr);
+        pm.setGlobalRuleBlock(org, fakeTaskManager, claimSel, true);
+        vm.prank(ep);
+        (bool okBlocked,) =
+            address(pm).call(abi.encodeCall(PaymasterHub.validatePaymasterUserOp, (op, bytes32(0), 0.001 ether)));
+        require(!okBlocked, "SIM: block veto failed to deny global rule");
+        console.log("SIM: Static mode + block veto both deny as designed.");
+    }
+
+    function _op(address pm, bytes32 orgId, address sender, address target, bytes4 selector)
+        internal
+        pure
+        returns (PackedUserOperation memory op)
+    {
+        bytes memory innerCall = abi.encodeWithSelector(selector, uint256(1));
+        op.sender = sender;
+        op.callData = abi.encodeWithSignature("execute(address,uint256,bytes)", target, 0, innerCall);
+        op.accountGasLimits = bytes32(uint256(100_000) << 128 | uint256(100_000));
+        op.preVerificationGas = 50_000;
+        op.gasFees = bytes32(uint256(1 gwei) << 128 | uint256(1 gwei));
+        bytes memory pmData = abi.encodePacked(
+            uint8(1), orgId, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(sender))), uint32(0), uint64(0)
+        );
+        op.paymasterAndData = abi.encodePacked(pm, uint128(200_000), uint128(100_000), pmData);
+    }
+
+    /// @dev The registered orgs' target types must match the migration data, and effective
+    ///      resolution must allow TaskManager.unclaimTask — the v7 selector that today requires
+    ///      a per-org vote — purely via the rulebook.
+    function _assertOrgCoverage(PaymasterHub pm, OrgTargets[] memory orgs) internal {
+        PaymasterHubLens lens = new PaymasterHubLens(address(pm));
+        bytes4 unclaimSel = bytes4(keccak256("unclaimTask(uint256)"));
+        for (uint256 i = 0; i < orgs.length; i++) {
+            // Skip orgs that never registered with the paymaster (defensive).
+            if (pm.getOrgConfig(orgs[i].orgId).adminHatId == 0) {
+                console.log("SIM: org not registered with hub, skipped:");
+                console.logBytes32(orgs[i].orgId);
+                continue;
+            }
+            address taskManager;
+            for (uint256 j = 0; j < orgs[i].targets.length; j++) {
+                require(
+                    pm.getTargetType(orgs[i].orgId, orgs[i].targets[j]) == orgs[i].typeIds[j],
+                    "SIM: target type mismatch"
+                );
+                if (orgs[i].typeIds[j] == ModuleTypes.TASK_MANAGER_ID) taskManager = orgs[i].targets[j];
+            }
+            (bool allowed,, uint8 source) = lens.effectiveRuleOf(orgs[i].orgId, taskManager, unclaimSel);
+            require(allowed, "SIM: unclaimTask not covered by rulebook for live org");
+            require(source == 2 || pm.getRule(orgs[i].orgId, taskManager, unclaimSel).allowed, "SIM: bad source");
+        }
+        console.log("SIM: all registered orgs resolve unclaimTask via the rulebook.");
+    }
+
+    function _seedViaAdminCall(PaymasterHub pm, function(address, bytes memory) internal returns (bytes memory) call)
+        internal
+    {
+        (bytes32[] memory typeIds, bytes4[] memory selectors, bool[] memory allowed, uint32[] memory hints) =
+            DefaultGlobalRules.defaults();
+        call(address(pm), abi.encodeCall(PaymasterHub.setGlobalRulesBatch, (typeIds, selectors, allowed, hints)));
+        require(pm.getGlobalRuleCount() == typeIds.length, "SIM: rulebook count mismatch");
+        // Spot checks: TaskManager claim + the zk-email hint.
+        require(
+            pm.getGlobalRule(ModuleTypes.TASK_MANAGER_ID, bytes4(keccak256("claimTask(uint256)"))).allowed,
+            "SIM: claimTask missing from rulebook"
+        );
+        bytes4 zkSel = ZkEmailInvites.claimRoleByDomain.selector;
+        require(
+            pm.getGlobalRule(ModuleTypes.ZKEMAIL_INVITES_ID, zkSel).maxCallGasHint == 800_000,
+            "SIM: zk-email gas hint wrong"
+        );
+        console.log("SIM: rulebook seeded + spot checks OK. Entries:", pm.getGlobalRuleCount());
+    }
+}
+
+/**
+ * @title SimGnosis
+ * @notice Fork-sim of the FULL v20 rollout against LIVE Gnosis state:
+ *   (1) beacon upgrade via Satellite.upgradeBeaconDirect (pranked ADMIN_EOA);
+ *   (2) pre/post storage survival on a live org's financials + an existing local rule;
+ *   (3) rulebook seed via Satellite.adminCall (poaManager path) + spot checks;
+ *   (4) target-type registration for all 9 live orgs + effective unclaimTask coverage;
+ *   (5) end-to-end validatePaymasterUserOp for a throwaway Mirror org with ZERO local rules;
+ *   (6) Static-mode + block-veto denials; (7) stranger cannot touch the rulebook.
+ *
+ * FOUNDRY_PROFILE=production forge script script/upgrades/UpgradePaymasterGlobalRules.s.sol:SimGnosis \
+ *   --fork-url gnosis -vvv
+ */
+contract SimGnosis is SimBase {
+    // Test6's live zk-email rule (set on-chain) — used as the storage-survival witness.
+    bytes32 constant TEST6_ORG = 0x263b2b29f392647f0fb8ddbb26f099e812ab4ba2777e5e07b906277164181f6b;
+    address constant TEST6_ZK = 0xADAf24f05EE0D647A7c2AF5cAD0F377F1B159FD2;
+    bytes32 constant KUBI_ORG = 0xc0f2765d555e21bfad5c6b05accef86a5758e0dee3e9a5b4ee3c3f3069c2102e;
+
+    function run() public {
+        PaymasterHub pm = PaymasterHub(payable(GNOSIS_PAYMASTER));
+        bytes4 zkSel = ZkEmailInvites.claimRoleByDomain.selector;
+
+        // Pre-upgrade witnesses.
+        PaymasterHub.OrgFinancials memory preFin = pm.getOrgFinancials(KUBI_ORG);
+        bool preZkRule = pm.getRule(TEST6_ORG, TEST6_ZK, zkSel).allowed;
+
+        // 1. Deploy new impl (libs auto-deployed in-fork) + upgrade the beacon as ADMIN_EOA.
+        address newImpl = address(new PaymasterHub());
+        require(newImpl.code.length <= 24576, "SIM: impl exceeds EIP-170");
+        console.log("SIM Gnosis impl size:", newImpl.code.length);
+        vm.prank(ADMIN_EOA);
+        IGnosisSatellite(GNOSIS_SATELLITE).upgradeBeaconDirect("PaymasterHub", newImpl, VERSION);
+        require(
+            PoaManager(GNOSIS_POA_MANAGER).getCurrentImplementationById(keccak256("PaymasterHub")) == newImpl,
+            "SIM: beacon not upgraded"
+        );
+
+        // 2. Storage survived; new namespaces start empty; live orgs default to Mirror.
+        PaymasterHub.OrgFinancials memory postFin = pm.getOrgFinancials(KUBI_ORG);
+        require(preFin.deposited == postFin.deposited && preFin.spent == postFin.spent, "SIM: financials drifted");
+        require(pm.getRule(TEST6_ORG, TEST6_ZK, zkSel).allowed == preZkRule, "SIM: local rule drifted");
+        require(pm.getGlobalRuleCount() == 0, "SIM: rulebook should start empty");
+        require(pm.getRulesMode(TEST6_ORG) == 0, "SIM: live org should default to Mirror");
+        console.log("SIM Gnosis: storage survived upgrade; rulebook empty; Mirror default.");
+
+        // 3. Stranger cannot write the rulebook.
+        bytes32[] memory t1 = new bytes32[](1);
+        t1[0] = ModuleTypes.TASK_MANAGER_ID;
+        bytes4[] memory s1 = new bytes4[](1);
+        bool[] memory a1 = new bool[](1);
+        a1[0] = true;
+        uint32[] memory h1 = new uint32[](1);
+        vm.prank(address(0xBADBAD));
+        (bool okBad,) = GNOSIS_PAYMASTER.call(abi.encodeCall(PaymasterHub.setGlobalRulesBatch, (t1, s1, a1, h1)));
+        require(!okBad, "SIM: stranger seeded the rulebook");
+
+        // 4. Seed via the Satellite adminCall (poaManager path) + spot checks.
+        _seedViaAdminCall(pm, _satelliteAdminCall);
+
+        // 5. Register target types for all live orgs + assert unclaimTask coverage.
+        OrgTargets[] memory orgs = _gnosisOrgs();
+        for (uint256 i = 0; i < orgs.length; i++) {
+            _satelliteAdminCall(
+                GNOSIS_PAYMASTER,
+                abi.encodeCall(PaymasterHub.setTargetTypesBatch, (orgs[i].orgId, orgs[i].targets, orgs[i].typeIds))
+            );
+        }
+        _assertOrgCoverage(pm, orgs);
+
+        // 6. The LIVE OrgDeployer's legacy ABI keeps working (no bricking window).
+        _simLegacyRegisterAndConfigure(pm, GNOSIS_POA_MANAGER);
+
+        // 7. Full end-to-end validation on a throwaway Mirror org.
+        _simEndToEnd(pm, GNOSIS_POA_MANAGER);
+
+        // 8. Step6 mechanics: OrgDeployer v19 beacon upgrade path works.
+        address newDeployerImpl = address(new OrgDeployer());
+        vm.prank(ADMIN_EOA);
+        IGnosisSatellite(GNOSIS_SATELLITE).upgradeBeaconDirect("OrgDeployer", newDeployerImpl, ORG_DEPLOYER_VERSION);
+        require(
+            PoaManager(GNOSIS_POA_MANAGER).getCurrentImplementationById(keccak256("OrgDeployer")) == newDeployerImpl,
+            "SIM: OrgDeployer beacon not upgraded"
+        );
+        console.log("SIM: OrgDeployer beacon upgrade to v19 OK.");
+
+        console.log("PASS: SimGnosis - v20 global rulebook validated against live Gnosis state.");
+    }
+
+    function _satelliteAdminCall(address target, bytes memory data) internal returns (bytes memory ret) {
+        vm.prank(ADMIN_EOA);
+        ret = IGnosisSatellite(GNOSIS_SATELLITE).adminCall(target, data);
+    }
+}
+
+/**
+ * @title SimArbitrum
+ * @notice Same rollout sim against LIVE Arbitrum state (Hub.upgradeBeaconLocal + Hub.adminCall).
+ *
+ * FOUNDRY_PROFILE=production forge script script/upgrades/UpgradePaymasterGlobalRules.s.sol:SimArbitrum \
+ *   --fork-url arbitrum -vvv
+ */
+contract SimArbitrum is SimBase {
+    function run() public {
+        PaymasterHub pm = PaymasterHub(payable(ARB_PAYMASTER));
+
+        // 1. Deploy new impl + upgrade the beacon as ADMIN_EOA (local, no Hyperlane).
+        address newImpl = address(new PaymasterHub());
+        require(newImpl.code.length <= 24576, "SIM: impl exceeds EIP-170");
+        console.log("SIM Arbitrum impl size:", newImpl.code.length);
+        vm.prank(ADMIN_EOA);
+        PoaManagerHub(payable(HUB)).upgradeBeaconLocal("PaymasterHub", newImpl, VERSION);
+        require(
+            PoaManager(ARB_POA_MANAGER).getCurrentImplementationById(keccak256("PaymasterHub")) == newImpl,
+            "SIM: beacon not upgraded"
+        );
+        require(pm.getGlobalRuleCount() == 0, "SIM: rulebook should start empty");
+
+        // 2. Seed via Hub.adminCall (poaManager path) + spot checks.
+        _seedViaAdminCall(pm, _hubAdminCall);
+
+        // 3. Register target types for the live org(s) + assert unclaimTask coverage.
+        OrgTargets[] memory orgs = _arbOrgs();
+        for (uint256 i = 0; i < orgs.length; i++) {
+            _hubAdminCall(
+                ARB_PAYMASTER,
+                abi.encodeCall(PaymasterHub.setTargetTypesBatch, (orgs[i].orgId, orgs[i].targets, orgs[i].typeIds))
+            );
+        }
+        _assertOrgCoverage(pm, orgs);
+
+        // 4. The LIVE OrgDeployer's legacy ABI keeps working (no bricking window).
+        _simLegacyRegisterAndConfigure(pm, ARB_POA_MANAGER);
+
+        // 5. Full end-to-end validation on a throwaway Mirror org.
+        _simEndToEnd(pm, ARB_POA_MANAGER);
+
+        // 6. Step6b mechanics: OrgDeployer v19 beacon upgrade path works.
+        address newDeployerImpl = address(new OrgDeployer());
+        vm.prank(ADMIN_EOA);
+        PoaManagerHub(payable(HUB)).upgradeBeaconLocal("OrgDeployer", newDeployerImpl, ORG_DEPLOYER_VERSION);
+        require(
+            PoaManager(ARB_POA_MANAGER).getCurrentImplementationById(keccak256("OrgDeployer")) == newDeployerImpl,
+            "SIM: OrgDeployer beacon not upgraded"
+        );
+        console.log("SIM: OrgDeployer beacon upgrade to v19 OK.");
+
+        console.log("PASS: SimArbitrum - v20 global rulebook validated against live Arbitrum state.");
+    }
+
+    function _hubAdminCall(address target, bytes memory data) internal returns (bytes memory ret) {
+        vm.prank(ADMIN_EOA);
+        ret = PoaManagerHub(payable(HUB)).adminCall(target, data);
+    }
+}

--- a/script/upgrades/UpgradePaymasterSecurity.s.sol
+++ b/script/upgrades/UpgradePaymasterSecurity.s.sol
@@ -6,6 +6,7 @@ import "forge-std/console.sol";
 import {PaymasterHub} from "../../src/PaymasterHub.sol";
 import {PaymasterHubLens} from "../../src/PaymasterHubLens.sol";
 import {PaymasterHubErrors} from "../../src/libs/PaymasterHubErrors.sol";
+import {PaymasterRuleLib} from "../../src/libs/PaymasterRuleLib.sol";
 import {IPaymaster} from "../../src/interfaces/IPaymaster.sol";
 import {PackedUserOperation} from "../../src/interfaces/PackedUserOperation.sol";
 import {PoaManagerHub} from "../../src/crosschain/PoaManagerHub.sol";
@@ -370,7 +371,7 @@ contract SimGnosis is SimBase {
         bcaps[0] = type(uint128).max;
         blens[0] = 7 days;
 
-        PaymasterHub.DeployConfig memory cfg = PaymasterHub.DeployConfig({
+        PaymasterRuleLib.DeployConfig memory cfg = PaymasterRuleLib.DeployConfig({
             operatorHatId: 0,
             maxFeePerGas: 100 gwei,
             maxPriorityFeePerGas: 100 gwei,
@@ -383,7 +384,10 @@ contract SimGnosis is SimBase {
             ruleMaxCallGasHints: hints,
             budgetSubjectKeys: bkeys,
             budgetCapsPerEpoch: bcaps,
-            budgetEpochLens: blens
+            budgetEpochLens: blens,
+            typeTargets: new address[](0),
+            typeIds: new bytes32[](0),
+            rulesMode: 0
         });
 
         vm.prank(poaMgr);

--- a/src/OrgDeployer.sol
+++ b/src/OrgDeployer.sol
@@ -11,6 +11,7 @@ import {GovernanceFactory, IHatsTreeSetup} from "./factories/GovernanceFactory.s
 import {AccessFactory} from "./factories/AccessFactory.sol";
 import {ModulesFactory} from "./factories/ModulesFactory.sol";
 import {RoleConfigStructs} from "./libs/RoleConfigStructs.sol";
+import {ModuleTypes} from "./libs/ModuleTypes.sol";
 
 /*────────────────────── Module‑specific hooks ──────────────────────────*/
 interface IExecutorAdmin {
@@ -50,6 +51,10 @@ interface IPaymasterHub {
         bytes32[] budgetSubjectKeys;
         uint128[] budgetCapsPerEpoch;
         uint32[] budgetEpochLens;
+        // Target module-type registration for global-rulebook resolution (PaymasterRuleLib)
+        address[] typeTargets;
+        bytes32[] typeIds;
+        uint8 rulesMode; // 0 = Mirror (follow global rulebook), 1 = Static (local snapshot)
     }
 
     function registerOrg(bytes32 orgId, uint256 adminHatId, uint256 operatorHatId) external;
@@ -955,12 +960,14 @@ contract OrgDeployer is Initializable {
         bool hasConfig = hasFeeCaps || pmCfg.autoWhitelistContracts || hasBudgets || msg.value > 0;
 
         if (hasConfig) {
-            // Build rules for auto-whitelisting deployed contracts
-            (address[] memory targets, bytes4[] memory selectors, bool[] memory allowed, uint32[] memory gasHints) = pmCfg.autoWhitelistContracts
-                ? _buildDefaultPaymasterRules(
-                    result, params.educationHubConfig.enabled, params.registryAddr, address(l.orgRegistry)
-                )
-                : (new address[](0), new bytes4[](0), new bool[](0), new uint32[](0));
+            // Map deployed org contracts (+ shared registries) to module typeIds so the org's
+            // sponsorship rules resolve through the PaymasterHub's type-keyed GLOBAL RULEBOOK.
+            // Replaces the former hardcoded per-selector whitelist (_buildDefaultPaymasterRules):
+            // new/changed functions are now added once to the rulebook by Poa instead of
+            // requiring an OrgDeployer redeploy plus a vote in every org.
+            (address[] memory typeTargets, bytes32[] memory typeIds) = pmCfg.autoWhitelistContracts
+                ? _buildTargetTypes(result, params.registryAddr, address(l.orgRegistry))
+                : (new address[](0), new bytes32[](0));
 
             // Build per-role-hat budgets if configured (+ the zk-email CLAIM budget when the module deploys)
             (bytes32[] memory budgetKeys, uint128[] memory budgetCaps, uint32[] memory budgetEpochLens) = hasBudgets
@@ -976,13 +983,19 @@ contract OrgDeployer is Initializable {
                 maxCallGas: pmCfg.maxCallGas,
                 maxVerificationGas: pmCfg.maxVerificationGas,
                 maxPreVerificationGas: pmCfg.maxPreVerificationGas,
-                ruleTargets: targets,
-                ruleSelectors: selectors,
-                ruleAllowed: allowed,
-                ruleMaxCallGasHints: gasHints,
+                ruleTargets: new address[](0),
+                ruleSelectors: new bytes4[](0),
+                ruleAllowed: new bool[](0),
+                ruleMaxCallGasHints: new uint32[](0),
                 budgetSubjectKeys: budgetKeys,
                 budgetCapsPerEpoch: budgetCaps,
-                budgetEpochLens: budgetEpochLens
+                budgetEpochLens: budgetEpochLens,
+                typeTargets: typeTargets,
+                typeIds: typeIds,
+                // autoUpgrade orgs mirror the global rulebook; pinned orgs get a Static local
+                // snapshot of it and vote changes in afterwards (bootstrap currently requires
+                // autoUpgrade=true, so Static-at-deploy is future-proofing).
+                rulesMode: params.autoUpgrade ? 0 : 1
             });
 
             IPaymasterHub(l.paymasterHub).registerAndConfigureOrg{value: msg.value}(params.orgId, topHatId, config);
@@ -993,335 +1006,57 @@ contract OrgDeployer is Initializable {
     }
 
     /**
-     * @notice Build default paymaster whitelist rules for deployed org contracts
-     * @dev Whitelists common user-facing functions on QuickJoin, TaskManager, Voting, etc.
-     *      Split into per-contract helpers to stay under stack-depth limits with via_ir.
+     * @notice Map the org's deployed contracts (and the shared registries) to module typeIds
+     * @dev Sponsored selectors per typeId live in the PaymasterHub's global rulebook, managed by
+     *      Poa (setGlobalRulesBatch) — see script/helpers/DefaultGlobalRules.sol for the seed set.
+     *      `registryAddr` is the UniversalAccountRegistry (holds `setProfileMetadata`),
+     *      `orgRegistryAddr` is the OrgRegistry (holds `updateOrgMetaAsAdmin`) — two distinct
+     *      contracts (L-53).
      */
-    /// @dev `registryAddr` is the UniversalAccountRegistry (holds `setProfileMetadata`),
-    ///      `orgRegistryAddr` is the OrgRegistry (holds `updateOrgMetaAsAdmin`). These are
-    ///      two distinct contracts — L-53 fix: `updateOrgMetaAsAdmin` was previously
-    ///      registered against `registryAddr`, so gasless org-metadata edits never worked
-    ///      (the paymaster rule pointed at a contract that doesn't implement the selector).
-    function _buildDefaultPaymasterRules(
-        DeploymentResult memory result,
-        bool educationEnabled,
-        address registryAddr,
-        address orgRegistryAddr
-    )
+    function _buildTargetTypes(DeploymentResult memory result, address registryAddr, address orgRegistryAddr)
         internal
         pure
-        returns (address[] memory targets, bytes4[] memory selectors, bool[] memory allowed, uint32[] memory gasHints)
+        returns (address[] memory typeTargets, bytes32[] memory typeIds)
     {
-        // Count: QuickJoin(6) + TaskManager(17) + HybridVoting(3) + DDVoting(3) + PaymentManager(5) + EligibilityModule(5) + ParticipationToken(3) + Registry(2) + EducationHub(0 or 4) + ZkEmailInvites(0 or 4)
-        uint256 count = 44;
-        if (educationEnabled) count += 4;
+        bool educationEnabled = result.educationHub != address(0);
         bool zkEmailEnabled = result.zkEmailInvites != address(0);
-        if (zkEmailEnabled) count += 4;
 
-        targets = new address[](count);
-        selectors = new bytes4[](count);
-        allowed = new bool[](count);
-        gasHints = new uint32[](count);
+        uint256 count = 9;
+        if (educationEnabled) count += 1;
+        if (zkEmailEnabled) count += 1;
 
-        uint256 i = 0;
-        i = _appendQuickJoinRules(targets, selectors, result.quickJoin, i);
-        i = _appendTaskManagerRules(targets, selectors, result.taskManager, i);
-        i = _appendVotingRules(targets, selectors, result.hybridVoting, result.directDemocracyVoting, i);
-        i = _appendPaymentManagerRules(targets, selectors, result.paymentManager, i);
-        i = _appendEligibilityRules(targets, selectors, result.eligibilityModule, i);
-        i = _appendParticipationTokenRules(targets, selectors, result.participationToken, i);
+        typeTargets = new address[](count);
+        typeIds = new bytes32[](count);
 
-        // setProfileMetadata lives on UniversalAccountRegistry (registryAddr).
-        targets[i] = registryAddr;
-        selectors[i] = bytes4(keccak256("setProfileMetadata(bytes32)"));
-        i++;
-        // updateOrgMetaAsAdmin lives on OrgRegistry (orgRegistryAddr), NOT the account registry.
-        targets[i] = orgRegistryAddr;
-        selectors[i] = bytes4(keccak256("updateOrgMetaAsAdmin(bytes32,bytes,bytes32)"));
-        i++;
+        typeTargets[0] = result.quickJoin;
+        typeIds[0] = ModuleTypes.QUICK_JOIN_ID;
+        typeTargets[1] = result.taskManager;
+        typeIds[1] = ModuleTypes.TASK_MANAGER_ID;
+        typeTargets[2] = result.hybridVoting;
+        typeIds[2] = ModuleTypes.HYBRID_VOTING_ID;
+        typeTargets[3] = result.directDemocracyVoting;
+        typeIds[3] = ModuleTypes.DIRECT_DEMOCRACY_VOTING_ID;
+        typeTargets[4] = result.paymentManager;
+        typeIds[4] = ModuleTypes.PAYMENT_MANAGER_ID;
+        typeTargets[5] = result.eligibilityModule;
+        typeIds[5] = ModuleTypes.ELIGIBILITY_MODULE_ID;
+        typeTargets[6] = result.participationToken;
+        typeIds[6] = ModuleTypes.PARTICIPATION_TOKEN_ID;
+        typeTargets[7] = registryAddr;
+        typeIds[7] = ModuleTypes.UNIVERSAL_ACCOUNT_REGISTRY_ID;
+        typeTargets[8] = orgRegistryAddr;
+        typeIds[8] = ModuleTypes.ORG_REGISTRY_ID;
 
+        uint256 i = 9;
         if (educationEnabled) {
-            _appendEducationHubRules(targets, selectors, result.educationHub, i);
-            i += 4;
+            typeTargets[i] = result.educationHub;
+            typeIds[i] = ModuleTypes.EDUCATION_HUB_ID;
+            i++;
         }
-
         if (zkEmailEnabled) {
-            i = _appendZkEmailInvitesRules(targets, selectors, gasHints, result.zkEmailInvites, i);
+            typeTargets[i] = result.zkEmailInvites;
+            typeIds[i] = ModuleTypes.ZKEMAIL_INVITES_ID;
         }
-
-        // Set all rules to allowed (gas hints already populated where non-zero).
-        for (uint256 j = 0; j < count; j++) {
-            allowed[j] = true;
-        }
-    }
-
-    /// @dev ZkEmailProof tuple (domain): (uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string)
-    ///      ZkEmailProofV2 tuple (email): (uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string,bytes32)
-    ///      PasskeyEnrollment tuple: (bytes32,bytes32,bytes32,uint256)
-    ///      WebAuthnAuth tuple: (bytes,bytes,uint256,uint256,bytes32,bytes32)
-    ///      4 selectors: domain claim, specific-address claim, and the two passkey register-and-claim variants.
-    function _appendZkEmailInvitesRules(
-        address[] memory targets,
-        bytes4[] memory selectors,
-        uint32[] memory gasHints,
-        address zk,
-        uint256 i
-    ) private pure returns (uint256) {
-        // Bare domain claim: Groth16 verify (~250k) + DKIM lookup + merkle proof + hat mint.
-        targets[i] = zk;
-        selectors[i] = bytes4(
-            keccak256(
-                "claimRoleByDomain((uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string),address,uint256[],bytes32[])"
-            )
-        );
-        gasHints[i] = 800_000;
-        i++;
-        // Bare specific-address claim (v2 proof carries emailHash).
-        targets[i] = zk;
-        selectors[i] = bytes4(
-            keccak256(
-                "claimRoleByEmail((uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string,bytes32),address,uint256[],bytes32[])"
-            )
-        );
-        gasHints[i] = 800_000;
-        i++;
-        // Combined register + domain claim: passkey registration + account create + proof + merkle + mint.
-        targets[i] = zk;
-        selectors[i] = bytes4(
-            keccak256(
-                "registerAndClaimByDomainWithPasskey((bytes32,bytes32,bytes32,uint256),string,uint256,uint256,(bytes,bytes,uint256,uint256,bytes32,bytes32),(uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string),uint256[],bytes32[])"
-            )
-        );
-        gasHints[i] = 1_200_000;
-        i++;
-        // Combined register + specific-address claim.
-        targets[i] = zk;
-        selectors[i] = bytes4(
-            keccak256(
-                "registerAndClaimByEmailWithPasskey((bytes32,bytes32,bytes32,uint256),string,uint256,uint256,(bytes,bytes,uint256,uint256,bytes32,bytes32),(uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string,bytes32),uint256[],bytes32[])"
-            )
-        );
-        gasHints[i] = 1_200_000;
-        i++;
-        return i;
-    }
-
-    function _appendQuickJoinRules(address[] memory targets, bytes4[] memory selectors, address qj, uint256 i)
-        private
-        pure
-        returns (uint256)
-    {
-        targets[i] = qj;
-        selectors[i] = bytes4(keccak256("quickJoinWithUser()"));
-        i++;
-        targets[i] = qj;
-        selectors[i] = bytes4(keccak256("registerAndQuickJoin(address,string,uint256,uint256,bytes)"));
-        i++;
-        targets[i] = qj;
-        selectors[i] = bytes4(
-            keccak256(
-                "registerAndQuickJoinWithPasskey((bytes32,bytes32,bytes32,uint256),string,uint256,uint256,(bytes,bytes,uint256,uint256,bytes32,bytes32))"
-            )
-        );
-        i++;
-        targets[i] = qj;
-        selectors[i] = bytes4(keccak256("claimHatsWithUser(uint256[])"));
-        i++;
-        targets[i] = qj;
-        selectors[i] = bytes4(keccak256("registerAndClaimHats(address,string,uint256,uint256,bytes,uint256[])"));
-        i++;
-        targets[i] = qj;
-        selectors[i] = bytes4(
-            keccak256(
-                "registerAndClaimHatsWithPasskey((bytes32,bytes32,bytes32,uint256),string,uint256,uint256,(bytes,bytes,uint256,uint256,bytes32,bytes32),uint256[])"
-            )
-        );
-        i++;
-        return i;
-    }
-
-    function _appendTaskManagerRules(address[] memory targets, bytes4[] memory selectors, address tm, uint256 i)
-        private
-        pure
-        returns (uint256)
-    {
-        // TaskManager v6: create/update selectors carry deadline params (uint48 absoluteDeadline,
-        // uint32 completionWindow appended).
-        targets[i] = tm;
-        selectors[i] = bytes4(keccak256("createTask(uint256,bytes,bytes32,bytes32,address,uint256,bool,uint48,uint32)"));
-        i++;
-        targets[i] = tm;
-        selectors[i] =
-            bytes4(keccak256("createTasksBatch(bytes32,(uint256,bytes,bytes32,address,uint256,bool,uint48,uint32)[])"));
-        i++;
-        targets[i] = tm;
-        selectors[i] = bytes4(keccak256("claimTask(uint256)"));
-        i++;
-        // TaskManager v7: voluntary claim release (and ASSIGN release of an expired claim).
-        targets[i] = tm;
-        selectors[i] = bytes4(keccak256("unclaimTask(uint256)"));
-        i++;
-        targets[i] = tm;
-        selectors[i] = bytes4(keccak256("submitTask(uint256,bytes32)"));
-        i++;
-        targets[i] = tm;
-        selectors[i] = bytes4(keccak256("completeTask(uint256)"));
-        i++;
-        targets[i] = tm;
-        selectors[i] = bytes4(keccak256("applyForTask(uint256,bytes32)"));
-        i++;
-        targets[i] = tm;
-        selectors[i] = bytes4(keccak256("approveApplication(uint256,address)"));
-        i++;
-        targets[i] = tm;
-        selectors[i] = bytes4(keccak256("assignTask(uint256,address)"));
-        i++;
-        targets[i] = tm;
-        selectors[i] = bytes4(keccak256("rejectTask(uint256,bytes32)"));
-        i++;
-        targets[i] = tm;
-        selectors[i] = bytes4(keccak256("cancelTask(uint256)"));
-        i++;
-        targets[i] = tm;
-        selectors[i] = bytes4(
-            keccak256("createAndAssignTask(uint256,bytes,bytes32,bytes32,address,address,uint256,bool,uint48,uint32)")
-        );
-        i++;
-        targets[i] = tm;
-        selectors[i] = bytes4(
-            keccak256(
-                "createProject((bytes,bytes32,uint256,address[],uint256[],uint256[],uint256[],uint256[],address[],uint256[]))"
-            )
-        );
-        i++;
-        targets[i] = tm;
-        selectors[i] = bytes4(keccak256("deleteProject(bytes32)"));
-        i++;
-        // TaskManager v4: setFolders is gated on executor OR organizerHatIds wearer;
-        // whitelist for gasless 4337/passkey calls by organizer-hat holders.
-        targets[i] = tm;
-        selectors[i] = bytes4(keccak256("setFolders(bytes32,bytes32)"));
-        i++;
-        // TaskManager v5: post-claim edit functions, gated on EDIT_META / EDIT_FULL perms.
-        // Whitelist for gasless 4337/passkey calls by edit-permitted hat holders.
-        // (updateTask signature is the v6 variant with deadline params.)
-        targets[i] = tm;
-        selectors[i] = bytes4(keccak256("updateTask(uint256,uint256,bytes,bytes32,address,uint256,uint48,uint32)"));
-        i++;
-        targets[i] = tm;
-        selectors[i] = bytes4(keccak256("updateTaskMetadata(uint256,bytes,bytes32)"));
-        i++;
-        return i;
-    }
-
-    function _appendVotingRules(address[] memory targets, bytes4[] memory selectors, address hv, address ddv, uint256 i)
-        private
-        pure
-        returns (uint256)
-    {
-        bytes4 voteSel = bytes4(keccak256("vote(uint256,uint8[],uint8[])"));
-        bytes4 announceSel = bytes4(keccak256("announceWinner(uint256)"));
-        bytes4 proposalSel =
-            bytes4(keccak256("createProposal(bytes,bytes32,uint32,uint8,(address,uint256,bytes)[][],uint256[])"));
-
-        targets[i] = hv;
-        selectors[i] = voteSel;
-        i++;
-        targets[i] = hv;
-        selectors[i] = announceSel;
-        i++;
-        targets[i] = hv;
-        selectors[i] = proposalSel;
-        i++;
-        targets[i] = ddv;
-        selectors[i] = voteSel;
-        i++;
-        targets[i] = ddv;
-        selectors[i] = announceSel;
-        i++;
-        targets[i] = ddv;
-        selectors[i] = proposalSel;
-        i++;
-        return i;
-    }
-
-    function _appendPaymentManagerRules(address[] memory targets, bytes4[] memory selectors, address pm, uint256 i)
-        private
-        pure
-        returns (uint256)
-    {
-        targets[i] = pm;
-        selectors[i] = bytes4(keccak256("claimDistribution(uint256,uint256,bytes32[])"));
-        i++;
-        targets[i] = pm;
-        selectors[i] = bytes4(keccak256("claimMultiple(uint256[],uint256[],bytes32[][])"));
-        i++;
-        targets[i] = pm;
-        selectors[i] = bytes4(keccak256("optOut(bool)"));
-        i++;
-        targets[i] = pm;
-        selectors[i] = bytes4(keccak256("createDistribution(address,uint256,bytes32,uint256)"));
-        i++;
-        targets[i] = pm;
-        selectors[i] = bytes4(keccak256("finalizeDistribution(uint256,uint256)"));
-        i++;
-        return i;
-    }
-
-    function _appendEligibilityRules(address[] memory targets, bytes4[] memory selectors, address em, uint256 i)
-        private
-        pure
-        returns (uint256)
-    {
-        targets[i] = em;
-        selectors[i] = bytes4(keccak256("claimVouchedHat(uint256)"));
-        i++;
-        targets[i] = em;
-        selectors[i] = bytes4(keccak256("vouchFor(address,uint256)"));
-        i++;
-        targets[i] = em;
-        selectors[i] = bytes4(keccak256("revokeVouch(address,uint256)"));
-        i++;
-        targets[i] = em;
-        selectors[i] = bytes4(keccak256("applyForRole(uint256,bytes32)"));
-        i++;
-        targets[i] = em;
-        selectors[i] = bytes4(keccak256("withdrawApplication(uint256)"));
-        i++;
-        return i;
-    }
-
-    function _appendParticipationTokenRules(address[] memory targets, bytes4[] memory selectors, address pt, uint256 i)
-        private
-        pure
-        returns (uint256)
-    {
-        targets[i] = pt;
-        selectors[i] = bytes4(keccak256("requestTokens(uint96,string)"));
-        i++;
-        targets[i] = pt;
-        selectors[i] = bytes4(keccak256("approveRequest(uint256)"));
-        i++;
-        targets[i] = pt;
-        selectors[i] = bytes4(keccak256("cancelRequest(uint256)"));
-        i++;
-        return i;
-    }
-
-    function _appendEducationHubRules(
-        address[] memory targets,
-        bytes4[] memory selectors,
-        address educationHub,
-        uint256 startIdx
-    ) private pure {
-        targets[startIdx] = educationHub;
-        selectors[startIdx] = bytes4(keccak256("completeModule(uint256,uint8)"));
-        targets[startIdx + 1] = educationHub;
-        selectors[startIdx + 1] = bytes4(keccak256("createModule(bytes,bytes32,uint256,uint8)"));
-        targets[startIdx + 2] = educationHub;
-        selectors[startIdx + 2] = bytes4(keccak256("updateModule(uint256,bytes,bytes32,uint256)"));
-        targets[startIdx + 3] = educationHub;
-        selectors[startIdx + 3] = bytes4(keccak256("removeModule(uint256)"));
     }
 
     /**

--- a/src/PaymasterHub.sol
+++ b/src/PaymasterHub.sol
@@ -860,7 +860,10 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
         for (uint256 i; i < len;) {
             if (targets[i] == address(0)) revert PaymasterHubErrors.ZeroAddress();
             if (_getOrgsStorage()[orgIds[i]].adminHatId != 0) {
-                _getRulesStorage()[orgIds[i]][targets[i]][selectors[i]] = Rule({allowed: true, maxCallGasHint: 0});
+                // Routed through the lib writer so the write EMITS RuleSet (the old inline write
+                // was event-less — subgraph-invisible state) and shares the allow semantics
+                // (a fresh allow clears any standing global-rule block for the pair).
+                PaymasterRuleLib.writeLocalRule(orgIds[i], targets[i], selectors[i], true, 0);
             }
             unchecked {
                 ++i;

--- a/src/PaymasterHub.sol
+++ b/src/PaymasterHub.sol
@@ -18,6 +18,7 @@ import {PaymasterCalldataLib} from "./libs/PaymasterCalldataLib.sol";
 import {PaymasterAdminLib} from "./libs/PaymasterAdminLib.sol";
 import {PaymasterFinanceLib} from "./libs/PaymasterFinanceLib.sol";
 import {PaymasterSponsorshipLib} from "./libs/PaymasterSponsorshipLib.sol";
+import {PaymasterRuleLib} from "./libs/PaymasterRuleLib.sol";
 
 /**
  * @title PaymasterHub
@@ -47,7 +48,6 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
     uint8 private constant SPONSORSHIP_ORG_DEPLOY = 2;
 
     uint32 private constant RULE_ID_GENERIC = 0x00000000;
-    uint32 private constant RULE_ID_COARSE = 0x000000FF;
 
     uint32 private constant MIN_EPOCH_LENGTH = 1 hours;
     uint32 private constant MAX_EPOCH_LENGTH = 365 days;
@@ -179,6 +179,18 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
         keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.orgdeploy.counts")) - 1));
     bytes32 private constant ONBOARDING_COUNTS_STORAGE_LOCATION =
         keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.onboarding.counts")) - 1));
+    // Global rulebook namespaces — written exclusively via PaymasterRuleLib (delegatecall);
+    // mirrored here only for the read-only getters. Slot derivations MUST match the lib.
+    bytes32 private constant GLOBAL_RULES_STORAGE_LOCATION =
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.globalrules")) - 1));
+    bytes32 private constant GLOBAL_RULE_KEYS_STORAGE_LOCATION =
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.globalrulekeys")) - 1));
+    bytes32 private constant TARGET_TYPES_STORAGE_LOCATION =
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.targettypes")) - 1));
+    bytes32 private constant RULES_MODES_STORAGE_LOCATION =
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.rulesmodes")) - 1));
+    bytes32 private constant GLOBAL_RULE_BLOCKS_STORAGE_LOCATION =
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.globalruleblocks")) - 1));
 
     // ============ Constructor ============
     /// @custom:oz-upgrades-unsafe-allow constructor
@@ -258,31 +270,6 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
         PaymasterAdminLib.setProtocolAdmin(newAdmin);
     }
 
-    // ============ Deploy Config Struct ============
-
-    /**
-     * @notice Configuration passed by OrgDeployer during org creation
-     * @dev Allows initial paymaster setup in the same transaction as org deployment
-     */
-    struct DeployConfig {
-        uint256 operatorHatId;
-        // Fee caps (all zeros = skip)
-        uint256 maxFeePerGas;
-        uint256 maxPriorityFeePerGas;
-        uint32 maxCallGas;
-        uint32 maxVerificationGas;
-        uint32 maxPreVerificationGas;
-        // Rules batch (empty arrays = skip)
-        address[] ruleTargets;
-        bytes4[] ruleSelectors;
-        bool[] ruleAllowed;
-        uint32[] ruleMaxCallGasHints;
-        // Budgets batch (empty arrays = skip)
-        bytes32[] budgetSubjectKeys;
-        uint128[] budgetCapsPerEpoch;
-        uint32[] budgetEpochLens;
-    }
-
     // ============ Org Registration ============
 
     /**
@@ -299,73 +286,45 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
 
     /**
      * @notice Register and configure an org with paymaster in one call
-     * @dev Called by OrgDeployer to register, configure rules/fee caps, and optionally deposit ETH
+     * @dev Called by OrgDeployer to register, configure rules/fee caps/target types/rules mode,
+     *      and optionally deposit ETH. Config application is delegated to PaymasterRuleLib
+     *      (EIP-170 headroom); the registrar gate and org registration stay here.
      * @param orgId Unique organization identifier
      * @param adminHatId Hat ID for org admin (topHat)
-     * @param config Initial paymaster configuration (operator hat, fee caps, rules)
+     * @param config Initial paymaster configuration (operator hat, fee caps, rules, target types)
      */
-    function registerAndConfigureOrg(bytes32 orgId, uint256 adminHatId, DeployConfig calldata config) external payable {
+    function registerAndConfigureOrg(bytes32 orgId, uint256 adminHatId, PaymasterRuleLib.DeployConfig calldata config)
+        external
+        payable
+    {
         _onlyRegistrar();
         _registerOrg(orgId, adminHatId, config.operatorHatId);
 
-        // Set fee caps if any non-zero
-        if (
-            config.maxFeePerGas != 0 || config.maxPriorityFeePerGas != 0 || config.maxCallGas != 0
-                || config.maxVerificationGas != 0 || config.maxPreVerificationGas != 0
-        ) {
-            FeeCaps storage feeCaps = _getFeeCapsStorage()[orgId];
-            feeCaps.maxFeePerGas = config.maxFeePerGas;
-            feeCaps.maxPriorityFeePerGas = config.maxPriorityFeePerGas;
-            feeCaps.maxCallGas = config.maxCallGas;
-            feeCaps.maxVerificationGas = config.maxVerificationGas;
-            feeCaps.maxPreVerificationGas = config.maxPreVerificationGas;
+        PaymasterRuleLib.applyDeployConfig(orgId, config);
 
-            emit PaymasterHubErrors.FeeCapsSet(
-                orgId,
-                config.maxFeePerGas,
-                config.maxPriorityFeePerGas,
-                config.maxCallGas,
-                config.maxVerificationGas,
-                config.maxPreVerificationGas
-            );
+        // Deposit ETH if sent
+        if (msg.value > 0) {
+            _depositForOrg(orgId, msg.value);
         }
+    }
 
-        // Set rules if arrays provided
-        if (config.ruleTargets.length > 0) {
-            _setRulesBatch(
-                orgId, config.ruleTargets, config.ruleSelectors, config.ruleAllowed, config.ruleMaxCallGasHints
-            );
-        }
+    /**
+     * @notice Legacy-ABI overload of registerAndConfigureOrg (pre-rulebook 13-field DeployConfig)
+     * @dev Retains the function selector the LIVE OrgDeployer proxies call, so the hub upgrade
+     *      needs NO lockstep OrgDeployer upgrade: orgs deployed through an un-upgraded deployer
+     *      get fee caps + address-keyed local rules + budgets exactly as before (no target types,
+     *      default Mirror mode — inert until types are mapped). Remove once every chain's
+     *      OrgDeployer speaks the new ABI.
+     */
+    function registerAndConfigureOrg(
+        bytes32 orgId,
+        uint256 adminHatId,
+        PaymasterRuleLib.LegacyDeployConfig calldata config
+    ) external payable {
+        _onlyRegistrar();
+        _registerOrg(orgId, adminHatId, config.operatorHatId);
 
-        // Set budgets if arrays provided
-        if (config.budgetSubjectKeys.length > 0) {
-            uint256 budgetLen = config.budgetSubjectKeys.length;
-            if (budgetLen != config.budgetCapsPerEpoch.length || budgetLen != config.budgetEpochLens.length) {
-                revert PaymasterHubErrors.ArrayLengthMismatch();
-            }
-
-            mapping(bytes32 => Budget) storage budgets = _getBudgetsStorage()[orgId];
-
-            for (uint256 j; j < budgetLen;) {
-                uint32 epochLen = config.budgetEpochLens[j];
-                if (epochLen < MIN_EPOCH_LENGTH || epochLen > MAX_EPOCH_LENGTH) {
-                    revert PaymasterHubErrors.InvalidEpochLength();
-                }
-
-                Budget storage budget = budgets[config.budgetSubjectKeys[j]];
-                budget.capPerEpoch = config.budgetCapsPerEpoch[j];
-                budget.epochLen = epochLen;
-                budget.epochStart = uint32(block.timestamp);
-
-                emit PaymasterHubErrors.BudgetSet(
-                    orgId, config.budgetSubjectKeys[j], config.budgetCapsPerEpoch[j], epochLen, uint32(block.timestamp)
-                );
-
-                unchecked {
-                    ++j;
-                }
-            }
-        }
+        PaymasterRuleLib.applyLegacyDeployConfig(orgId, config);
 
         // Deposit ETH if sent
         if (msg.value > 0) {
@@ -623,8 +582,9 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
                 subjectKey = _validateSubjectEligibility(userOp.sender, subjectType, subjectId);
             }
 
-            // Validate target/selector rules
-            _validateRules(userOp, ruleId, orgId);
+            // Validate target/selector rules (local org rules with global rulebook fallback for
+            // Mirror-mode orgs — delegatecall lib, hub's own storage only, ERC-7562 safe)
+            PaymasterRuleLib.validateRules(userOp, ruleId, orgId);
 
             // Validate fee and gas caps
             _validateFeeCaps(userOp, orgId);
@@ -823,11 +783,9 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
         external
         onlyOrgOperator(orgId)
     {
-        if (target == address(0)) revert PaymasterHubErrors.ZeroAddress();
-
-        mapping(address => mapping(bytes4 => Rule)) storage rules = _getRulesStorage()[orgId];
-        rules[target][selector] = Rule({allowed: allowed, maxCallGasHint: maxCallGasHint});
-        emit PaymasterHubErrors.RuleSet(orgId, target, selector, allowed, maxCallGasHint);
+        // allowed=false is an EXPLICIT DENY (also blocks the global fallback for Mirror orgs);
+        // clearRule resets the pair to the protocol default instead. See PaymasterRuleLib.
+        PaymasterRuleLib.writeLocalRule(orgId, target, selector, allowed, maxCallGasHint);
     }
 
     /**
@@ -840,7 +798,51 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
         bool[] calldata allowed,
         uint32[] calldata maxCallGasHints
     ) external onlyOrgOperator(orgId) {
-        _setRulesBatch(orgId, targets, selectors, allowed, maxCallGasHints);
+        PaymasterRuleLib.writeLocalRulesBatch(orgId, targets, selectors, allowed, maxCallGasHints);
+    }
+
+    // ============ Global Rulebook (see PaymasterRuleLib) ============
+
+    /// @notice Set or remove protocol-wide rulebook entries keyed by (module typeId, selector)
+    /// @dev poaManager/protocolAdmin gated (inside the lib). One entry covers the matching module
+    ///      of every Mirror-mode org — replaces per-org adminBatchAddRules fan-outs.
+    function setGlobalRulesBatch(
+        bytes32[] calldata typeIds,
+        bytes4[] calldata selectors,
+        bool[] calldata allowed,
+        uint32[] calldata maxCallGasHints
+    ) external {
+        PaymasterRuleLib.setGlobalRulesBatch(typeIds, selectors, allowed, maxCallGasHints);
+    }
+
+    /// @notice Map an org's target addresses to module typeIds for global rule resolution
+    /// @dev Org admin/operator/poaManager gated (inside the lib); bytes32(0) clears an entry
+    function setTargetTypesBatch(bytes32 orgId, address[] calldata targets, bytes32[] calldata typeIds) external {
+        PaymasterRuleLib.setTargetTypesBatch(orgId, targets, typeIds);
+    }
+
+    /// @notice Switch an org between Mirror (0, follow global rulebook) and Static (1, local only)
+    /// @dev Org admin/operator/poaManager gated (inside the lib)
+    function setRulesMode(bytes32 orgId, uint8 mode) external {
+        PaymasterRuleLib.setRulesMode(orgId, mode);
+    }
+
+    /// @notice Block or unblock a single global rule for an org without leaving Mirror mode
+    /// @dev Org admin/operator/poaManager gated (inside the lib)
+    function setGlobalRuleBlock(bytes32 orgId, address target, bytes4 selector, bool blocked) external {
+        PaymasterRuleLib.setGlobalRuleBlock(orgId, target, selector, blocked);
+    }
+
+    /// @notice Copy specific current global rulebook entries into the org's local rules
+    /// @dev Org admin/operator/poaManager gated (inside the lib)
+    function adoptGlobalRules(bytes32 orgId, address[] calldata targets, bytes4[] calldata selectors) external {
+        PaymasterRuleLib.adoptGlobalRules(orgId, targets, selectors);
+    }
+
+    /// @notice Copy all applicable global rulebook entries into the org's local rules
+    /// @dev Org admin/operator/poaManager gated (inside the lib)
+    function snapshotGlobalRules(bytes32 orgId, address[] calldata targets) external {
+        PaymasterRuleLib.snapshotGlobalRules(orgId, targets);
     }
 
     /// @notice Batch-add rules across orgs. Skips unregistered orgs.
@@ -866,40 +868,13 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
         }
     }
 
-    function _setRulesBatch(
-        bytes32 orgId,
-        address[] calldata targets,
-        bytes4[] calldata selectors,
-        bool[] calldata allowed,
-        uint32[] calldata maxCallGasHints
-    ) internal {
-        uint256 length = targets.length;
-        if (length != selectors.length || length != allowed.length || length != maxCallGasHints.length) {
-            revert PaymasterHubErrors.ArrayLengthMismatch();
-        }
-
-        mapping(address => mapping(bytes4 => Rule)) storage rules = _getRulesStorage()[orgId];
-
-        for (uint256 i; i < length;) {
-            if (targets[i] == address(0)) revert PaymasterHubErrors.ZeroAddress();
-
-            rules[targets[i]][selectors[i]] = Rule({allowed: allowed[i], maxCallGasHint: maxCallGasHints[i]});
-
-            emit PaymasterHubErrors.RuleSet(orgId, targets[i], selectors[i], allowed[i], maxCallGasHints[i]);
-
-            unchecked {
-                ++i;
-            }
-        }
-    }
-
     /**
      * @notice Clear a rule for target/selector combination
      */
     function clearRule(bytes32 orgId, address target, bytes4 selector) external onlyOrgOperator(orgId) {
-        mapping(address => mapping(bytes4 => Rule)) storage rules = _getRulesStorage()[orgId];
-        delete rules[target][selector];
-        emit PaymasterHubErrors.RuleSet(orgId, target, selector, false, 0);
+        // Resets the pair to the protocol default: deletes the local rule AND any standing
+        // block, so a Mirror org falls back to the global rulebook afterwards.
+        PaymasterRuleLib.clearLocalRule(orgId, target, selector);
     }
 
     /**
@@ -1215,6 +1190,58 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
     }
 
     /**
+     * @notice Get a global rulebook entry for a (module typeId, selector) pair
+     * @param typeId Module type identifier (keccak256 of the type name, per ModuleTypes)
+     * @param selector The function selector
+     * @return The Rule struct
+     */
+    function getGlobalRule(bytes32 typeId, bytes4 selector) external view returns (Rule memory) {
+        return _getGlobalRulesStorage()[typeId][selector];
+    }
+
+    /**
+     * @notice Number of entries currently in the global rulebook
+     */
+    function getGlobalRuleCount() external view returns (uint256) {
+        return _getGlobalRuleKeysStorage().keys.length;
+    }
+
+    /**
+     * @notice Enumerate the global rulebook
+     * @param index Position in the enumeration (0-based, unordered, changes on removal)
+     * @return typeId Module type identifier
+     * @return selector Function selector
+     * @return rule The Rule struct for the entry
+     */
+    function getGlobalRuleAt(uint256 index) external view returns (bytes32 typeId, bytes4 selector, Rule memory rule) {
+        PaymasterRuleLib.GlobalRuleKey storage key = _getGlobalRuleKeysStorage().keys[index];
+        typeId = key.typeId;
+        selector = key.selector;
+        rule = _getGlobalRulesStorage()[typeId][selector];
+    }
+
+    /**
+     * @notice Get the module typeId registered for an org's target address (bytes32(0) = none)
+     */
+    function getTargetType(bytes32 orgId, address target) external view returns (bytes32) {
+        return _getTargetTypesStorage()[orgId][target];
+    }
+
+    /**
+     * @notice Get an org's rules mode (0 = Mirror: local + global rulebook; 1 = Static: local only)
+     */
+    function getRulesMode(bytes32 orgId) external view returns (uint8) {
+        return _getRulesModesStorage()[orgId];
+    }
+
+    /**
+     * @notice Whether an org has vetoed the global rule for (target, selector)
+     */
+    function isGlobalRuleBlocked(bytes32 orgId, address target, bytes4 selector) external view returns (bool) {
+        return _getGlobalRuleBlocksStorage()[orgId][target][selector];
+    }
+
+    /**
      * @notice Get the fee caps for an org
      * @param orgId Organization identifier
      * @return The FeeCaps struct
@@ -1308,6 +1335,45 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
 
     function _getBudgetsStorage() private pure returns (mapping(bytes32 => mapping(bytes32 => Budget)) storage $) {
         bytes32 slot = BUDGETS_STORAGE_LOCATION;
+        assembly {
+            $.slot := slot
+        }
+    }
+
+    function _getGlobalRulesStorage() private pure returns (mapping(bytes32 => mapping(bytes4 => Rule)) storage $) {
+        bytes32 slot = GLOBAL_RULES_STORAGE_LOCATION;
+        assembly {
+            $.slot := slot
+        }
+    }
+
+    function _getGlobalRuleKeysStorage() private pure returns (PaymasterRuleLib.GlobalRulesEnum storage $) {
+        bytes32 slot = GLOBAL_RULE_KEYS_STORAGE_LOCATION;
+        assembly {
+            $.slot := slot
+        }
+    }
+
+    function _getTargetTypesStorage() private pure returns (mapping(bytes32 => mapping(address => bytes32)) storage $) {
+        bytes32 slot = TARGET_TYPES_STORAGE_LOCATION;
+        assembly {
+            $.slot := slot
+        }
+    }
+
+    function _getRulesModesStorage() private pure returns (mapping(bytes32 => uint8) storage $) {
+        bytes32 slot = RULES_MODES_STORAGE_LOCATION;
+        assembly {
+            $.slot := slot
+        }
+    }
+
+    function _getGlobalRuleBlocksStorage()
+        private
+        pure
+        returns (mapping(bytes32 => mapping(address => mapping(bytes4 => bool))) storage $)
+    {
+        bytes32 slot = GLOBAL_RULE_BLOCKS_STORAGE_LOCATION;
         assembly {
             $.slot := slot
         }
@@ -1453,120 +1519,9 @@ contract PaymasterHub is IPaymaster, Initializable, UUPSUpgradeable, ReentrancyG
         }
     }
 
-    function _validateRules(PackedUserOperation calldata userOp, uint32 ruleId, bytes32 orgId) private view {
-        bytes calldata callData = userOp.callData;
-        if (callData.length < 4) revert PaymasterHubErrors.InvalidPaymasterData();
-
-        // For RULE_ID_GENERIC, executeBatch needs per-inner-call validation
-        if (ruleId == RULE_ID_GENERIC) {
-            bytes4 outerSelector = bytes4(callData[0:4]);
-            // executeBatch(address[],uint256[],bytes[]) or executeBatch(address[],bytes[])
-            if (outerSelector == bytes4(0x47e1da2a) || outerSelector == bytes4(0x18dfb3c7)) {
-                _validateBatchRules(callData, outerSelector, orgId);
-                return;
-            }
-        }
-
-        // Single-call path (existing logic)
-        (address target, bytes4 selector) = _extractTargetSelector(userOp, ruleId);
-
-        mapping(address => mapping(bytes4 => Rule)) storage rules = _getRulesStorage()[orgId];
-        Rule storage rule = rules[target][selector];
-
-        if (!rule.allowed) revert PaymasterHubErrors.RuleDenied(target, selector);
-
-        // Check gas hint if set
-        if (rule.maxCallGasHint > 0) {
-            (, uint128 callGasLimit) = UserOpLib.unpackAccountGasLimits(userOp.accountGasLimits);
-            if (callGasLimit > rule.maxCallGasHint) revert PaymasterHubErrors.GasTooHigh();
-        }
-    }
-
-    /// @dev Validates that every inner call in an executeBatch is allowed by org rules.
-    ///      Decodes the batch targets and datas, then checks each (target, selector) pair.
-    ///      Gas hints are not checked per-call (total callGasLimit still applies via FeeCaps).
-    ///      Inner calls with < 4 bytes of data use selector bytes4(0) (treated as raw ETH transfer / fallback).
-    function _validateBatchRules(bytes calldata callData, bytes4 outerSelector, bytes32 orgId) private view {
-        mapping(address => mapping(bytes4 => Rule)) storage rules = _getRulesStorage()[orgId];
-
-        // Decode targets and datas from either batch format
-        address[] memory targets;
-        bytes[] memory datas;
-        if (outerSelector == bytes4(0x47e1da2a)) {
-            // executeBatch(address[],uint256[],bytes[]) — PasskeyAccount pattern
-            (targets,, datas) = abi.decode(callData[4:], (address[], uint256[], bytes[]));
-        } else {
-            // executeBatch(address[],bytes[]) — SimpleAccount pattern (0x18dfb3c7)
-            (targets, datas) = abi.decode(callData[4:], (address[], bytes[]));
-        }
-
-        if (targets.length != datas.length) revert PaymasterHubErrors.ArrayLengthMismatch();
-        for (uint256 i = 0; i < targets.length;) {
-            bytes4 innerSelector;
-            if (datas[i].length >= 4) {
-                bytes memory d = datas[i];
-                assembly {
-                    innerSelector := mload(add(d, 0x20))
-                }
-            }
-            Rule storage rule = rules[targets[i]][innerSelector];
-            if (!rule.allowed) revert PaymasterHubErrors.RuleDenied(targets[i], innerSelector);
-            unchecked {
-                ++i;
-            }
-        }
-    }
-
-    function _extractTargetSelector(PackedUserOperation calldata userOp, uint32 ruleId)
-        private
-        pure
-        returns (address target, bytes4 selector)
-    {
-        bytes calldata callData = userOp.callData;
-
-        if (callData.length < 4) revert PaymasterHubErrors.InvalidPaymasterData();
-
-        if (ruleId == RULE_ID_GENERIC) {
-            // ERC-4337 account execute patterns (SimpleAccount, PasskeyAccount, etc.)
-            selector = bytes4(callData[0:4]);
-
-            // Check for execute(address,uint256,bytes) - 0xb61d27f6
-            // Used by SimpleAccount, PasskeyAccount, and most ERC-4337 wallets
-            if (selector == 0xb61d27f6 && callData.length >= 0x64) {
-                assembly {
-                    // Extract target address at offset 0x04
-                    target := calldataload(add(callData.offset, 0x04))
-
-                    // Read the bytes data offset pointer at position 0x44
-                    // This offset is relative to the start of params (0x04)
-                    let dataOffset := calldataload(add(callData.offset, 0x44))
-
-                    // Only extract inner selector if dataOffset is the standard 0x60
-                    // (3rd dynamic param in ABI encoding). A non-standard offset could
-                    // allow an attacker to point at arbitrary calldata.
-                    if eq(dataOffset, 0x60) {
-                        let dataStart := add(add(0x04, dataOffset), 0x20)
-                        if lt(dataStart, callData.length) {
-                            selector := calldataload(add(callData.offset, dataStart))
-                        }
-                    }
-                }
-                selector = bytes4(selector);
-            }
-            // For RULE_ID_GENERIC, executeBatch selectors (0x47e1da2a, 0x18dfb3c7) are
-            // intercepted by _validateRules → _validateBatchRules before reaching here.
-            // Any other outer selector (including non-execute custom functions) falls through.
-            else {
-                target = userOp.sender;
-            }
-        } else if (ruleId == RULE_ID_COARSE) {
-            // Coarse mode: only check account's selector
-            target = userOp.sender;
-            selector = bytes4(callData[0:4]);
-        } else {
-            revert PaymasterHubErrors.InvalidRuleId();
-        }
-    }
+    // NOTE: rule validation (_validateRules / _validateBatchRules / _extractTargetSelector)
+    // moved to PaymasterRuleLib (delegatecall) together with the new global-rulebook fallback
+    // resolution — see PaymasterRuleLib.validateRules. Keeping hub copies would be dead code.
 
     function _validateFeeCaps(PackedUserOperation calldata userOp, bytes32 orgId) private view {
         FeeCaps storage caps = _getFeeCapsStorage()[orgId];

--- a/src/PaymasterHubLens.sol
+++ b/src/PaymasterHubLens.sol
@@ -93,6 +93,13 @@ interface IPaymasterHubStorage {
     function getOrgDeployCount(address account) external view returns (uint8);
     function ENTRY_POINT() external view returns (address);
     function HATS() external view returns (address);
+    // Global rulebook getters (PaymasterRuleLib feature)
+    function getGlobalRule(bytes32 typeId, bytes4 selector) external view returns (Rule memory);
+    function getGlobalRuleCount() external view returns (uint256);
+    function getGlobalRuleAt(uint256 index) external view returns (bytes32 typeId, bytes4 selector, Rule memory rule);
+    function getTargetType(bytes32 orgId, address target) external view returns (bytes32);
+    function getRulesMode(bytes32 orgId) external view returns (uint8);
+    function isGlobalRuleBlocked(bytes32 orgId, address target, bytes4 selector) external view returns (bool);
 }
 
 /**
@@ -154,12 +161,48 @@ contract PaymasterHubLens {
         return budget.capPerEpoch > budget.usedInEpoch ? budget.capPerEpoch - budget.usedInEpoch : 0;
     }
 
+    /// @notice The org's LOCAL rule only (no global fallback) — see effectiveRuleOf for resolution
     function ruleOf(bytes32 orgId, address target, bytes4 selector) external view returns (Rule memory) {
         return hub.getRule(orgId, target, selector);
     }
 
+    /// @notice Whether (target, selector) is sponsored for the org — local rule OR global fallback
     function isAllowed(bytes32 orgId, address target, bytes4 selector) external view returns (bool) {
-        return hub.getRule(orgId, target, selector).allowed;
+        (bool allowed,,) = _effectiveRule(orgId, target, selector);
+        return allowed;
+    }
+
+    /// @notice Resolve the rule the hub would enforce for (org, target, selector)
+    /// @return allowed Whether the pair is sponsored
+    /// @return maxCallGasHint The gas hint that applies (from whichever rule resolved)
+    /// @return source 0 = denied, 1 = local rule, 2 = global rulebook
+    function effectiveRuleOf(bytes32 orgId, address target, bytes4 selector)
+        external
+        view
+        returns (bool allowed, uint32 maxCallGasHint, uint8 source)
+    {
+        return _effectiveRule(orgId, target, selector);
+    }
+
+    /// @dev Mirrors PaymasterRuleLib._resolveRule exactly: local allowed wins; global rulebook
+    ///      applies only for Mirror-mode orgs, not blocked, with a registered target typeId.
+    function _effectiveRule(bytes32 orgId, address target, bytes4 selector)
+        private
+        view
+        returns (bool allowed, uint32 maxCallGasHint, uint8 source)
+    {
+        Rule memory local = hub.getRule(orgId, target, selector);
+        if (local.allowed) return (true, local.maxCallGasHint, 1);
+
+        if (hub.getRulesMode(orgId) != 0) return (false, 0, 0); // Static: local only
+        if (hub.isGlobalRuleBlocked(orgId, target, selector)) return (false, 0, 0);
+
+        bytes32 typeId = hub.getTargetType(orgId, target);
+        if (typeId == bytes32(0)) return (false, 0, 0);
+
+        Rule memory global = hub.getGlobalRule(typeId, selector);
+        if (!global.allowed) return (false, 0, 0);
+        return (true, global.maxCallGasHint, 2);
     }
 
     function orgConfig(bytes32 orgId) external view returns (OrgConfig memory) {
@@ -357,7 +400,8 @@ contract PaymasterHubLens {
                             innerSelector := mload(add(d, 0x20))
                         }
                     }
-                    if (!hub.getRule(orgId, targets[i], innerSelector).allowed) return false;
+                    (bool innerAllowed,,) = _effectiveRule(orgId, targets[i], innerSelector);
+                    if (!innerAllowed) return false;
                     unchecked {
                         ++i;
                     }
@@ -367,14 +411,14 @@ contract PaymasterHubLens {
         }
 
         (address target, bytes4 selector) = _extractTargetSelector(userOp, ruleId);
-        Rule memory rule = hub.getRule(orgId, target, selector);
-        if (!rule.allowed) return false;
-        // Parity with PaymasterHub._validateRules single-call path: a set maxCallGasHint
+        (bool allowed, uint32 maxCallGasHint,) = _effectiveRule(orgId, target, selector);
+        if (!allowed) return false;
+        // Parity with PaymasterRuleLib.validateRules single-call path: a set maxCallGasHint
         // rejects ops whose callGasLimit exceeds it (GasTooHigh). The batch path above
         // intentionally skips per-call gas hints, matching the hub.
-        if (rule.maxCallGasHint > 0) {
+        if (maxCallGasHint > 0) {
             (, uint128 callGasLimit) = UserOpLib.unpackAccountGasLimits(userOp.accountGasLimits);
-            if (callGasLimit > rule.maxCallGasHint) return false;
+            if (callGasLimit > maxCallGasHint) return false;
         }
         return true;
     }

--- a/src/PaymasterHubLens.sol
+++ b/src/PaymasterHubLens.sol
@@ -194,6 +194,9 @@ contract PaymasterHubLens {
         Rule memory local = hub.getRule(orgId, target, selector);
         if (local.allowed) return (true, local.maxCallGasHint, 1);
 
+        // Explicit pre-v20 deny ({allowed:false, hint != 0}) — mirrors PaymasterRuleLib.
+        if (local.maxCallGasHint != 0) return (false, 0, 0);
+
         if (hub.getRulesMode(orgId) != 0) return (false, 0, 0); // Static: local only
         if (hub.isGlobalRuleBlocked(orgId, target, selector)) return (false, 0, 0);
 

--- a/src/libs/ModuleTypes.sol
+++ b/src/libs/ModuleTypes.sol
@@ -31,4 +31,8 @@ library ModuleTypes {
     bytes32 constant PASSKEY_ACCOUNT_ID = keccak256("PasskeyAccount");
     bytes32 constant PASSKEY_ACCOUNT_FACTORY_ID = keccak256("PasskeyAccountFactory");
     bytes32 constant ZKEMAIL_INVITES_ID = keccak256("ZkEmailInvites");
+    // Protocol singletons (not per-org modules) — used as PaymasterHub global-rulebook typeIds
+    // so gasless calls to shared registries resolve through the same type-keyed whitelist.
+    bytes32 constant UNIVERSAL_ACCOUNT_REGISTRY_ID = keccak256("UniversalAccountRegistry");
+    bytes32 constant ORG_REGISTRY_ID = keccak256("OrgRegistry");
 }

--- a/src/libs/PaymasterHubErrors.sol
+++ b/src/libs/PaymasterHubErrors.sol
@@ -131,6 +131,17 @@ library PaymasterHubErrors {
     /// @notice Org deploy request is malformed (bad calldata, has initCode, etc.)
     error InvalidOrgDeployRequest();
 
+    // ============ Global Rulebook Errors ============
+
+    /// @notice Rules mode value out of range (0 = Mirror, 1 = Static)
+    error InvalidRulesMode();
+
+    /// @notice Module typeId is zero / target has no registered typeId
+    error InvalidTypeId();
+
+    /// @notice Referenced global rulebook entry does not exist
+    error GlobalRuleUnknown();
+
     // ============ Events ============
 
     /// @notice Emitted when the PaymasterHub is initialized
@@ -216,4 +227,17 @@ library PaymasterHubErrors {
 
     /// @notice Emitted when solidarity fund distribution is unpaused
     event SolidarityDistributionUnpaused();
+
+    /// @notice Emitted when a protocol-level global rulebook entry is set (allowed=true) or removed (allowed=false)
+    /// @dev typeId = keccak256(module type name), matching ModuleTypes / OrgRegistry typeIds
+    event GlobalRuleSet(bytes32 indexed typeId, bytes4 indexed selector, bool allowed, uint32 maxCallGasHint);
+
+    /// @notice Emitted when an org target is mapped to a module typeId (bytes32(0) = cleared)
+    event TargetTypeSet(bytes32 indexed orgId, address indexed target, bytes32 indexed typeId);
+
+    /// @notice Emitted when an org's rules mode changes (0 = Mirror: local + global rulebook; 1 = Static: local only)
+    event RulesModeSet(bytes32 indexed orgId, uint8 mode);
+
+    /// @notice Emitted when an org blocks/unblocks a single global rule (Mirror-mode veto)
+    event GlobalRuleBlockSet(bytes32 indexed orgId, address indexed target, bytes4 indexed selector, bool blocked);
 }

--- a/src/libs/PaymasterRuleLib.sol
+++ b/src/libs/PaymasterRuleLib.sol
@@ -1,0 +1,809 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.24;
+
+import {PackedUserOperation, UserOpLib} from "../interfaces/PackedUserOperation.sol";
+import {IHats} from "lib/hats-protocol/src/Interfaces/IHats.sol";
+import {PaymasterHubErrors} from "./PaymasterHubErrors.sol";
+
+/**
+ * @title PaymasterRuleLib
+ * @author POA Engineering
+ * @notice PaymasterHub's sponsorship-rule engine: per-org rule validation (moved out of the hub),
+ *         the protocol-managed GLOBAL RULEBOOK, and org rules-mode management. Extracted as an
+ *         EXTERNAL (delegatecall) library to reclaim EIP-170 bytecode headroom, mirroring the
+ *         PaymasterAdminLib / PaymasterSponsorshipLib pattern.
+ *
+ *         Global rulebook design (the SwitchableBeacon analog for sponsorship rules):
+ *         - Local rules stay `orgId => target => selector => Rule` (unchanged, always win when set).
+ *         - The rulebook is keyed by `(module typeId, selector)` where typeId is the same
+ *           keccak256(moduleName) used by OrgRegistry/ModuleTypes — NOT by address — so one
+ *           entry covers every org's proxy of that module type.
+ *         - Each org maps its own proxy addresses to typeIds (`targetTypes`), registered at
+ *           deploy by OrgDeployer and maintainable by org governance.
+ *         - Rules mode per org: Mirror (0, default) resolves local-then-global; Static (1)
+ *           resolves local only — the org votes new rules in, exactly like a pinned beacon.
+ *         - Mirror orgs can veto a single global rule via `setGlobalRuleBlock` without leaving
+ *           Mirror mode.
+ *         Resolution order: local allowed → pass; org Static → deny; org block → deny;
+ *         target typeId unset → deny; global rule allowed → pass; else deny. Fail-closed at
+ *         every step, and fully inert for an org until its targetTypes are registered.
+ *
+ * @dev STORAGE: operates on the HUB's own ERC-7201 namespaced slots via delegatecall — struct
+ *      definitions and slot derivations below MUST stay byte-identical to PaymasterHub's.
+ *      Append-only, never reorder/remove fields. Events emitted here surface with the hub as
+ *      `address` (delegatecall), so subgraph indexing is unchanged. All storage touched during
+ *      `validateRules` is the hub's own, keeping ERC-7562 validation-time access rules intact.
+ */
+library PaymasterRuleLib {
+    // ============ Constants (mirror PaymasterHub) ============
+    uint32 private constant RULE_ID_GENERIC = 0x00000000;
+    uint32 private constant RULE_ID_COARSE = 0x000000FF;
+    uint32 private constant MIN_EPOCH_LENGTH = 1 hours;
+    uint32 private constant MAX_EPOCH_LENGTH = 365 days;
+
+    /// @notice Org resolves rules locally, then falls through to the global rulebook (default).
+    uint8 internal constant RULES_MODE_MIRROR = 0;
+    /// @notice Org resolves rules locally only; global rulebook is ignored.
+    uint8 internal constant RULES_MODE_STATIC = 1;
+
+    // ============ Storage structs (byte-identical mirrors of PaymasterHub's) ============
+    struct MainStorage {
+        address entryPoint;
+        address hats;
+        address poaManager;
+        address orgRegistrar;
+        address protocolAdmin;
+    }
+
+    struct OrgConfig {
+        uint256 adminHatId;
+        uint256 operatorHatId;
+        bool paused;
+        uint40 registeredAt;
+        bool bannedFromSolidarity;
+    }
+
+    struct Rule {
+        uint32 maxCallGasHint;
+        bool allowed;
+    }
+
+    struct FeeCaps {
+        uint256 maxFeePerGas;
+        uint256 maxPriorityFeePerGas;
+        uint32 maxCallGas;
+        uint32 maxVerificationGas;
+        uint32 maxPreVerificationGas;
+    }
+
+    struct Budget {
+        uint128 capPerEpoch;
+        uint128 usedInEpoch;
+        uint32 epochLen;
+        uint32 epochStart;
+    }
+
+    // ============ Global rulebook structs (owned by this lib, new namespaces) ============
+
+    /// @notice Enumeration entry for one global rulebook rule.
+    struct GlobalRuleKey {
+        bytes32 typeId;
+        bytes4 selector;
+    }
+
+    /// @dev Enumerable set of global rulebook entries. `indexPlusOne` is keyed by
+    ///      keccak256(abi.encodePacked(typeId, selector)); 0 = absent.
+    struct GlobalRulesEnum {
+        GlobalRuleKey[] keys;
+        mapping(bytes32 => uint256) indexPlusOne;
+    }
+
+    /**
+     * @notice Legacy (pre-rulebook) deploy configuration — byte-identical to the DeployConfig
+     *         tuple the LIVE OrgDeployer proxies were compiled against.
+     * @dev Kept so `registerAndConfigureOrg(bytes32,uint256,LegacyDeployConfig)` retains the OLD
+     *      function selector: the deployed OrgDeployer keeps working (seeding address-keyed local
+     *      rules exactly as before) across the hub upgrade, with NO lockstep deployer upgrade
+     *      required. Remove only after every chain's OrgDeployer is upgraded to the new ABI.
+     */
+    struct LegacyDeployConfig {
+        uint256 operatorHatId;
+        uint256 maxFeePerGas;
+        uint256 maxPriorityFeePerGas;
+        uint32 maxCallGas;
+        uint32 maxVerificationGas;
+        uint32 maxPreVerificationGas;
+        address[] ruleTargets;
+        bytes4[] ruleSelectors;
+        bool[] ruleAllowed;
+        uint32[] ruleMaxCallGasHints;
+        bytes32[] budgetSubjectKeys;
+        uint128[] budgetCapsPerEpoch;
+        uint32[] budgetEpochLens;
+    }
+
+    /**
+     * @notice Configuration passed by OrgDeployer during org creation
+     * @dev Moved here from PaymasterHub (same ABI tuple; new fields appended). Allows initial
+     *      paymaster setup in the same transaction as org deployment.
+     */
+    struct DeployConfig {
+        uint256 operatorHatId;
+        // Fee caps (all zeros = skip)
+        uint256 maxFeePerGas;
+        uint256 maxPriorityFeePerGas;
+        uint32 maxCallGas;
+        uint32 maxVerificationGas;
+        uint32 maxPreVerificationGas;
+        // Explicit rules batch (empty arrays = skip)
+        address[] ruleTargets;
+        bytes4[] ruleSelectors;
+        bool[] ruleAllowed;
+        uint32[] ruleMaxCallGasHints;
+        // Budgets batch (empty arrays = skip)
+        bytes32[] budgetSubjectKeys;
+        uint128[] budgetCapsPerEpoch;
+        uint32[] budgetEpochLens;
+        // Target module-type registration for global rulebook resolution (empty arrays = skip)
+        address[] typeTargets;
+        bytes32[] typeIds;
+        // Rules mode: 0 = Mirror (follow global rulebook), 1 = Static (local rules only;
+        // current global rulebook entries are snapshotted into local rules at registration)
+        uint8 rulesMode;
+    }
+
+    // ============ ERC-7201 slots ============
+    // Mirrors of PaymasterHub's existing namespaces:
+    bytes32 private constant MAIN_STORAGE_LOCATION =
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.main")) - 1));
+    bytes32 private constant ORGS_STORAGE_LOCATION =
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.orgs")) - 1));
+    bytes32 private constant RULES_STORAGE_LOCATION =
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.rules")) - 1));
+    bytes32 private constant FEECAPS_STORAGE_LOCATION =
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.feeCaps")) - 1));
+    bytes32 private constant BUDGETS_STORAGE_LOCATION =
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.budgets")) - 1));
+    // New namespaces owned by this lib (also mirrored by PaymasterHub's view getters):
+    bytes32 private constant GLOBAL_RULES_STORAGE_LOCATION =
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.globalrules")) - 1));
+    bytes32 private constant GLOBAL_RULE_KEYS_STORAGE_LOCATION =
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.globalrulekeys")) - 1));
+    bytes32 private constant TARGET_TYPES_STORAGE_LOCATION =
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.targettypes")) - 1));
+    bytes32 private constant RULES_MODES_STORAGE_LOCATION =
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.rulesmodes")) - 1));
+    bytes32 private constant GLOBAL_RULE_BLOCKS_STORAGE_LOCATION =
+        keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.globalruleblocks")) - 1));
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // Validation (ERC-4337 validation hot path — hub's own storage only)
+    // ═════════════════════════════════════════════════════════════════════════
+
+    /// @notice Validate the userOp's (target, selector) against org rules with global fallback.
+    /// @dev Moved from PaymasterHub._validateRules and extended with global rulebook resolution.
+    ///      Reverts RuleDenied / GasTooHigh / InvalidRuleId / InvalidPaymasterData on failure.
+    function validateRules(PackedUserOperation calldata userOp, uint32 ruleId, bytes32 orgId) external view {
+        bytes calldata callData = userOp.callData;
+        if (callData.length < 4) revert PaymasterHubErrors.InvalidPaymasterData();
+
+        // For RULE_ID_GENERIC, executeBatch needs per-inner-call validation
+        if (ruleId == RULE_ID_GENERIC) {
+            bytes4 outerSelector = bytes4(callData[0:4]);
+            // executeBatch(address[],uint256[],bytes[]) or executeBatch(address[],bytes[])
+            if (outerSelector == bytes4(0x47e1da2a) || outerSelector == bytes4(0x18dfb3c7)) {
+                _validateBatchRules(callData, outerSelector, orgId);
+                return;
+            }
+        }
+
+        // Single-call path
+        (address target, bytes4 selector) = _extractTargetSelector(userOp, ruleId);
+
+        (bool allowed, uint32 maxCallGasHint) = _resolveRule(orgId, target, selector);
+        if (!allowed) revert PaymasterHubErrors.RuleDenied(target, selector);
+
+        // Check gas hint if set
+        if (maxCallGasHint > 0) {
+            (, uint128 callGasLimit) = UserOpLib.unpackAccountGasLimits(userOp.accountGasLimits);
+            if (callGasLimit > maxCallGasHint) revert PaymasterHubErrors.GasTooHigh();
+        }
+    }
+
+    /// @dev Resolve the effective rule for (org, target, selector): local rule wins when allowed;
+    ///      otherwise the global rulebook applies only when the org is in Mirror mode, has not
+    ///      blocked the pair, and has a typeId registered for the target. Fail-closed.
+    function _resolveRule(bytes32 orgId, address target, bytes4 selector)
+        private
+        view
+        returns (bool allowed, uint32 maxCallGasHint)
+    {
+        Rule storage local = _rules()[orgId][target][selector];
+        if (local.allowed) return (true, local.maxCallGasHint);
+
+        if (_rulesModes()[orgId] != RULES_MODE_MIRROR) return (false, 0);
+        if (_globalRuleBlocks()[orgId][target][selector]) return (false, 0);
+
+        bytes32 typeId = _targetTypes()[orgId][target];
+        if (typeId == bytes32(0)) return (false, 0);
+
+        Rule storage global = _globalRules()[typeId][selector];
+        if (!global.allowed) return (false, 0);
+        return (true, global.maxCallGasHint);
+    }
+
+    /// @dev Validates that every inner call in an executeBatch is allowed (local or global).
+    ///      Gas hints are not checked per-call (total callGasLimit still applies via FeeCaps).
+    ///      Inner calls with < 4 bytes of data use selector bytes4(0) (raw ETH transfer / fallback).
+    function _validateBatchRules(bytes calldata callData, bytes4 outerSelector, bytes32 orgId) private view {
+        // Decode targets and datas from either batch format
+        address[] memory targets;
+        bytes[] memory datas;
+        if (outerSelector == bytes4(0x47e1da2a)) {
+            // executeBatch(address[],uint256[],bytes[]) — PasskeyAccount pattern
+            (targets,, datas) = abi.decode(callData[4:], (address[], uint256[], bytes[]));
+        } else {
+            // executeBatch(address[],bytes[]) — SimpleAccount pattern (0x18dfb3c7)
+            (targets, datas) = abi.decode(callData[4:], (address[], bytes[]));
+        }
+
+        if (targets.length != datas.length) revert PaymasterHubErrors.ArrayLengthMismatch();
+        for (uint256 i = 0; i < targets.length;) {
+            bytes4 innerSelector;
+            if (datas[i].length >= 4) {
+                bytes memory d = datas[i];
+                assembly {
+                    innerSelector := mload(add(d, 0x20))
+                }
+            }
+            (bool allowed,) = _resolveRule(orgId, targets[i], innerSelector);
+            if (!allowed) revert PaymasterHubErrors.RuleDenied(targets[i], innerSelector);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /// @dev Moved verbatim from PaymasterHub._extractTargetSelector.
+    function _extractTargetSelector(PackedUserOperation calldata userOp, uint32 ruleId)
+        private
+        pure
+        returns (address target, bytes4 selector)
+    {
+        bytes calldata callData = userOp.callData;
+
+        if (callData.length < 4) revert PaymasterHubErrors.InvalidPaymasterData();
+
+        if (ruleId == RULE_ID_GENERIC) {
+            // ERC-4337 account execute patterns (SimpleAccount, PasskeyAccount, etc.)
+            selector = bytes4(callData[0:4]);
+
+            // Check for execute(address,uint256,bytes) - 0xb61d27f6
+            // Used by SimpleAccount, PasskeyAccount, and most ERC-4337 wallets
+            if (selector == 0xb61d27f6 && callData.length >= 0x64) {
+                assembly {
+                    // Extract target address at offset 0x04
+                    target := calldataload(add(callData.offset, 0x04))
+
+                    // Read the bytes data offset pointer at position 0x44
+                    // This offset is relative to the start of params (0x04)
+                    let dataOffset := calldataload(add(callData.offset, 0x44))
+
+                    // Only extract inner selector if dataOffset is the standard 0x60
+                    // (3rd dynamic param in ABI encoding). A non-standard offset could
+                    // allow an attacker to point at arbitrary calldata.
+                    if eq(dataOffset, 0x60) {
+                        let dataStart := add(add(0x04, dataOffset), 0x20)
+                        if lt(dataStart, callData.length) {
+                            selector := calldataload(add(callData.offset, dataStart))
+                        }
+                    }
+                }
+                selector = bytes4(selector);
+            }
+            // For RULE_ID_GENERIC, executeBatch selectors (0x47e1da2a, 0x18dfb3c7) are
+            // intercepted by validateRules → _validateBatchRules before reaching here.
+            // Any other outer selector (including non-execute custom functions) falls through.
+            else {
+                target = userOp.sender;
+            }
+        } else if (ruleId == RULE_ID_COARSE) {
+            // Coarse mode: only check account's selector
+            target = userOp.sender;
+            selector = bytes4(callData[0:4]);
+        } else {
+            revert PaymasterHubErrors.InvalidRuleId();
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // Global rulebook administration (poaManager / protocolAdmin)
+    // ═════════════════════════════════════════════════════════════════════════
+
+    /// @notice Set or remove global rulebook entries keyed by (module typeId, selector).
+    /// @dev `allowed[i] = true` upserts the entry (and adds it to the enumeration);
+    ///      `allowed[i] = false` deletes it (and removes it from the enumeration).
+    ///      One entry here covers the matching module of EVERY Mirror-mode org — this is the
+    ///      lever that replaces per-org adminBatchAddRules fan-outs and OrgDeployer redeploys.
+    function setGlobalRulesBatch(
+        bytes32[] calldata typeIds,
+        bytes4[] calldata selectors,
+        bool[] calldata allowed,
+        uint32[] calldata maxCallGasHints
+    ) external {
+        _requirePoaOrProtocolAdmin();
+        uint256 len = typeIds.length;
+        if (len != selectors.length || len != allowed.length || len != maxCallGasHints.length) {
+            revert PaymasterHubErrors.ArrayLengthMismatch();
+        }
+
+        // Per-entry work lives in its own frame — the four calldata arrays plus the
+        // enumeration locals overflow the stack under the production via-IR profile otherwise.
+        for (uint256 i; i < len;) {
+            _setGlobalRule(typeIds[i], selectors[i], allowed[i], maxCallGasHints[i]);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    function _setGlobalRule(bytes32 typeId, bytes4 selector, bool allowed, uint32 maxCallGasHint) private {
+        if (typeId == bytes32(0)) revert PaymasterHubErrors.InvalidTypeId();
+
+        GlobalRulesEnum storage en = _globalRuleKeys();
+        bytes32 enumKey = keccak256(abi.encodePacked(typeId, selector));
+
+        if (allowed) {
+            _globalRules()[typeId][selector] = Rule({maxCallGasHint: maxCallGasHint, allowed: true});
+            if (en.indexPlusOne[enumKey] == 0) {
+                en.keys.push(GlobalRuleKey({typeId: typeId, selector: selector}));
+                en.indexPlusOne[enumKey] = en.keys.length;
+            }
+            emit PaymasterHubErrors.GlobalRuleSet(typeId, selector, true, maxCallGasHint);
+        } else {
+            delete _globalRules()[typeId][selector];
+            uint256 idxPlusOne = en.indexPlusOne[enumKey];
+            if (idxPlusOne != 0) {
+                uint256 lastIdx = en.keys.length - 1;
+                if (idxPlusOne - 1 != lastIdx) {
+                    GlobalRuleKey memory last = en.keys[lastIdx];
+                    en.keys[idxPlusOne - 1] = last;
+                    en.indexPlusOne[keccak256(abi.encodePacked(last.typeId, last.selector))] = idxPlusOne;
+                }
+                en.keys.pop();
+                delete en.indexPlusOne[enumKey];
+            }
+            emit PaymasterHubErrors.GlobalRuleSet(typeId, selector, false, 0);
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // Org-level configuration (org admin / operator / poaManager)
+    // ═════════════════════════════════════════════════════════════════════════
+
+    /// @notice Map an org's target addresses to module typeIds for global rule resolution.
+    /// @dev typeId = bytes32(0) clears the mapping (target stops resolving global rules).
+    function setTargetTypesBatch(bytes32 orgId, address[] calldata targets, bytes32[] calldata typeIds) external {
+        _requireOrgOperator(orgId);
+        if (targets.length != typeIds.length) revert PaymasterHubErrors.ArrayLengthMismatch();
+        _writeTargetTypes(orgId, targets, typeIds);
+    }
+
+    /// @notice Switch an org between Mirror (0, follow global rulebook) and Static (1, local only).
+    /// @dev A Static switch does NOT snapshot global rules into local rules — pair it with
+    ///      `snapshotGlobalRules` in the same governance batch to keep current sponsorships.
+    function setRulesMode(bytes32 orgId, uint8 mode) external {
+        _requireOrgOperator(orgId);
+        if (mode > RULES_MODE_STATIC) revert PaymasterHubErrors.InvalidRulesMode();
+        _rulesModes()[orgId] = mode;
+        emit PaymasterHubErrors.RulesModeSet(orgId, mode);
+    }
+
+    /// @notice Block (or unblock) a single global rule for this org without leaving Mirror mode.
+    /// @dev Only affects global fallback resolution; an explicit local allowed rule still wins.
+    function setGlobalRuleBlock(bytes32 orgId, address target, bytes4 selector, bool blocked) external {
+        _requireOrgOperator(orgId);
+        if (target == address(0)) revert PaymasterHubErrors.ZeroAddress();
+        _globalRuleBlocks()[orgId][target][selector] = blocked;
+        emit PaymasterHubErrors.GlobalRuleBlockSet(orgId, target, selector, blocked);
+    }
+
+    /// @notice Copy specific current global rulebook entries into the org's local rules.
+    /// @dev For Static-mode orgs voting to adopt individual new functions: resolves each
+    ///      target's typeId, requires the global entry to exist, and writes it as a local rule
+    ///      (emitting RuleSet like any local rule change).
+    function adoptGlobalRules(bytes32 orgId, address[] calldata targets, bytes4[] calldata selectors) external {
+        _requireOrgOperator(orgId);
+        uint256 len = targets.length;
+        if (len != selectors.length) revert PaymasterHubErrors.ArrayLengthMismatch();
+
+        for (uint256 i; i < len;) {
+            bytes32 typeId = _targetTypes()[orgId][targets[i]];
+            if (typeId == bytes32(0)) revert PaymasterHubErrors.InvalidTypeId();
+
+            Rule storage global = _globalRules()[typeId][selectors[i]];
+            if (!global.allowed) revert PaymasterHubErrors.GlobalRuleUnknown();
+
+            _rules()[orgId][targets[i]][selectors[i]] = Rule({maxCallGasHint: global.maxCallGasHint, allowed: true});
+            emit PaymasterHubErrors.RuleSet(orgId, targets[i], selectors[i], true, global.maxCallGasHint);
+
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /// @notice Copy ALL applicable global rulebook entries into the org's local rules.
+    /// @dev Iterates the enumerable rulebook and writes a local rule for every entry whose
+    ///      typeId matches one of `targets` (per the org's registered targetTypes). Use when
+    ///      switching to Static mode to keep current sponsorships, or to catch a Static org
+    ///      up to the current rulebook in one governance action.
+    function snapshotGlobalRules(bytes32 orgId, address[] calldata targets) external {
+        _requireOrgOperator(orgId);
+        _snapshotGlobalRules(orgId, targets);
+    }
+
+    /// @notice Write a batch of local org rules (auth performed by the hub's onlyOrgOperator).
+    /// @dev Body of the former PaymasterHub._setRulesBatch, shared with applyDeployConfig.
+    ///      An entry with allowed=false is an EXPLICIT DENY: it also sets the global-rule block
+    ///      so a Mirror org's revocation actually revokes (pre-rulebook, allowed=false was a
+    ///      guaranteed deny; without the block it would silently fall through to the rulebook).
+    ///      allowed=true clears any standing block for the pair (a fresh allow supersedes it).
+    function writeLocalRulesBatch(
+        bytes32 orgId,
+        address[] calldata targets,
+        bytes4[] calldata selectors,
+        bool[] calldata allowed,
+        uint32[] calldata maxCallGasHints
+    ) external {
+        _writeLocalRulesBatch(orgId, targets, selectors, allowed, maxCallGasHints);
+    }
+
+    /// @notice Write a single local org rule (auth performed by the hub's onlyOrgOperator).
+    /// @dev Same explicit-deny semantics as writeLocalRulesBatch.
+    function writeLocalRule(bytes32 orgId, address target, bytes4 selector, bool allowed, uint32 maxCallGasHint)
+        external
+    {
+        if (target == address(0)) revert PaymasterHubErrors.ZeroAddress();
+
+        _rules()[orgId][target][selector] = Rule({maxCallGasHint: maxCallGasHint, allowed: allowed});
+        emit PaymasterHubErrors.RuleSet(orgId, target, selector, allowed, maxCallGasHint);
+
+        bool blocked = _globalRuleBlocks()[orgId][target][selector];
+        if (!allowed && !blocked) {
+            _globalRuleBlocks()[orgId][target][selector] = true;
+            emit PaymasterHubErrors.GlobalRuleBlockSet(orgId, target, selector, true);
+        } else if (allowed && blocked) {
+            _globalRuleBlocks()[orgId][target][selector] = false;
+            emit PaymasterHubErrors.GlobalRuleBlockSet(orgId, target, selector, false);
+        }
+    }
+
+    /// @notice Delete a local rule AND any standing block for the pair (auth by the hub).
+    /// @dev "Reset to protocol default": for a Mirror org the pair falls back to the global
+    ///      rulebook afterwards. Use setRule(...,false,...) to deny instead.
+    function clearLocalRule(bytes32 orgId, address target, bytes4 selector) external {
+        delete _rules()[orgId][target][selector];
+        emit PaymasterHubErrors.RuleSet(orgId, target, selector, false, 0);
+        if (_globalRuleBlocks()[orgId][target][selector]) {
+            _globalRuleBlocks()[orgId][target][selector] = false;
+            emit PaymasterHubErrors.GlobalRuleBlockSet(orgId, target, selector, false);
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // Deploy-time configuration (called from registrar-gated hub function)
+    // ═════════════════════════════════════════════════════════════════════════
+
+    /// @notice Apply an OrgDeployer DeployConfig to a freshly registered org.
+    /// @dev Body of the former PaymasterHub.registerAndConfigureOrg config application, extended
+    ///      with target-type registration, rules mode, and the Static-mode snapshot. Caller
+    ///      (PaymasterHub) has already enforced the registrar gate and registered the org.
+    ///      Deploy-time state emits the same events as the setters (subgraph indexes from logs).
+    function applyDeployConfig(bytes32 orgId, DeployConfig calldata config) external {
+        _applyFeeCaps(
+            orgId,
+            config.maxFeePerGas,
+            config.maxPriorityFeePerGas,
+            config.maxCallGas,
+            config.maxVerificationGas,
+            config.maxPreVerificationGas
+        );
+
+        // Target module types for global rulebook resolution
+        if (config.typeTargets.length > 0) {
+            if (config.typeTargets.length != config.typeIds.length) {
+                revert PaymasterHubErrors.ArrayLengthMismatch();
+            }
+            _writeTargetTypes(orgId, config.typeTargets, config.typeIds);
+        }
+
+        // Rules mode (0 = Mirror default; emit regardless so indexers see the deploy-time value)
+        if (config.rulesMode > RULES_MODE_STATIC) revert PaymasterHubErrors.InvalidRulesMode();
+        if (config.rulesMode != RULES_MODE_MIRROR) {
+            _rulesModes()[orgId] = config.rulesMode;
+        }
+        emit PaymasterHubErrors.RulesModeSet(orgId, config.rulesMode);
+
+        // Static orgs start from a local copy of the current global rulebook, then govern it.
+        if (config.rulesMode == RULES_MODE_STATIC && config.typeTargets.length > 0) {
+            _snapshotGlobalRules(orgId, config.typeTargets);
+        }
+
+        // Explicit rules if arrays provided (applied AFTER the snapshot so they can override it)
+        if (config.ruleTargets.length > 0) {
+            _writeLocalRulesBatch(
+                orgId, config.ruleTargets, config.ruleSelectors, config.ruleAllowed, config.ruleMaxCallGasHints
+            );
+        }
+
+        _applyBudgets(orgId, config.budgetSubjectKeys, config.budgetCapsPerEpoch, config.budgetEpochLens);
+    }
+
+    /// @notice Apply a pre-rulebook (13-field) DeployConfig — the ABI the LIVE OrgDeployer calls.
+    /// @dev Same application semantics as before the upgrade: fee caps + address-keyed local
+    ///      rules + budgets. No target types are registered and the org stays in default Mirror
+    ///      mode (inert until types are mapped), so orgs deployed through an un-upgraded
+    ///      OrgDeployer behave exactly as they did pre-v20.
+    function applyLegacyDeployConfig(bytes32 orgId, LegacyDeployConfig calldata config) external {
+        _applyFeeCaps(
+            orgId,
+            config.maxFeePerGas,
+            config.maxPriorityFeePerGas,
+            config.maxCallGas,
+            config.maxVerificationGas,
+            config.maxPreVerificationGas
+        );
+
+        if (config.ruleTargets.length > 0) {
+            _writeLocalRulesBatch(
+                orgId, config.ruleTargets, config.ruleSelectors, config.ruleAllowed, config.ruleMaxCallGasHints
+            );
+        }
+
+        _applyBudgets(orgId, config.budgetSubjectKeys, config.budgetCapsPerEpoch, config.budgetEpochLens);
+    }
+
+    function _applyFeeCaps(
+        bytes32 orgId,
+        uint256 maxFeePerGas,
+        uint256 maxPriorityFeePerGas,
+        uint32 maxCallGas,
+        uint32 maxVerificationGas,
+        uint32 maxPreVerificationGas
+    ) private {
+        if (
+            maxFeePerGas == 0 && maxPriorityFeePerGas == 0 && maxCallGas == 0 && maxVerificationGas == 0
+                && maxPreVerificationGas == 0
+        ) return;
+
+        FeeCaps storage feeCaps = _feeCaps()[orgId];
+        feeCaps.maxFeePerGas = maxFeePerGas;
+        feeCaps.maxPriorityFeePerGas = maxPriorityFeePerGas;
+        feeCaps.maxCallGas = maxCallGas;
+        feeCaps.maxVerificationGas = maxVerificationGas;
+        feeCaps.maxPreVerificationGas = maxPreVerificationGas;
+
+        emit PaymasterHubErrors.FeeCapsSet(
+            orgId, maxFeePerGas, maxPriorityFeePerGas, maxCallGas, maxVerificationGas, maxPreVerificationGas
+        );
+    }
+
+    function _applyBudgets(
+        bytes32 orgId,
+        bytes32[] calldata budgetSubjectKeys,
+        uint128[] calldata budgetCapsPerEpoch,
+        uint32[] calldata budgetEpochLens
+    ) private {
+        uint256 budgetLen = budgetSubjectKeys.length;
+        if (budgetLen == 0) return;
+        if (budgetLen != budgetCapsPerEpoch.length || budgetLen != budgetEpochLens.length) {
+            revert PaymasterHubErrors.ArrayLengthMismatch();
+        }
+
+        mapping(bytes32 => Budget) storage budgets = _budgets()[orgId];
+
+        for (uint256 j; j < budgetLen;) {
+            uint32 epochLen = budgetEpochLens[j];
+            if (epochLen < MIN_EPOCH_LENGTH || epochLen > MAX_EPOCH_LENGTH) {
+                revert PaymasterHubErrors.InvalidEpochLength();
+            }
+
+            Budget storage budget = budgets[budgetSubjectKeys[j]];
+            budget.capPerEpoch = budgetCapsPerEpoch[j];
+            budget.epochLen = epochLen;
+            budget.epochStart = uint32(block.timestamp);
+
+            emit PaymasterHubErrors.BudgetSet(
+                orgId, budgetSubjectKeys[j], budgetCapsPerEpoch[j], epochLen, uint32(block.timestamp)
+            );
+
+            unchecked {
+                ++j;
+            }
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════
+    // Internal helpers
+    // ═════════════════════════════════════════════════════════════════════════
+
+    function _writeTargetTypes(bytes32 orgId, address[] calldata targets, bytes32[] calldata typeIds) private {
+        uint256 len = targets.length;
+        for (uint256 i; i < len;) {
+            if (targets[i] == address(0)) revert PaymasterHubErrors.ZeroAddress();
+            _targetTypes()[orgId][targets[i]] = typeIds[i];
+            emit PaymasterHubErrors.TargetTypeSet(orgId, targets[i], typeIds[i]);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    function _writeLocalRulesBatch(
+        bytes32 orgId,
+        address[] calldata targets,
+        bytes4[] calldata selectors,
+        bool[] calldata allowed,
+        uint32[] calldata maxCallGasHints
+    ) private {
+        uint256 length = targets.length;
+        if (length != selectors.length || length != allowed.length || length != maxCallGasHints.length) {
+            revert PaymasterHubErrors.ArrayLengthMismatch();
+        }
+
+        mapping(address => mapping(bytes4 => Rule)) storage rules = _rules()[orgId];
+
+        for (uint256 i; i < length;) {
+            if (targets[i] == address(0)) revert PaymasterHubErrors.ZeroAddress();
+
+            rules[targets[i]][selectors[i]] = Rule({maxCallGasHint: maxCallGasHints[i], allowed: allowed[i]});
+
+            emit PaymasterHubErrors.RuleSet(orgId, targets[i], selectors[i], allowed[i], maxCallGasHints[i]);
+
+            // Explicit deny must actually deny for Mirror orgs: allowed=false also blocks the
+            // global fallback; allowed=true clears a standing block (fresh allow supersedes it).
+            bool blocked = _globalRuleBlocks()[orgId][targets[i]][selectors[i]];
+            if (!allowed[i] && !blocked) {
+                _globalRuleBlocks()[orgId][targets[i]][selectors[i]] = true;
+                emit PaymasterHubErrors.GlobalRuleBlockSet(orgId, targets[i], selectors[i], true);
+            } else if (allowed[i] && blocked) {
+                _globalRuleBlocks()[orgId][targets[i]][selectors[i]] = false;
+                emit PaymasterHubErrors.GlobalRuleBlockSet(orgId, targets[i], selectors[i], false);
+            }
+
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    function _snapshotGlobalRules(bytes32 orgId, address[] calldata targets) private {
+        uint256 tLen = targets.length;
+
+        // Cache each target's typeId once (avoids re-reading storage per rulebook entry)
+        bytes32[] memory targetTypeIds = new bytes32[](tLen);
+        for (uint256 t; t < tLen;) {
+            targetTypeIds[t] = _targetTypes()[orgId][targets[t]];
+            unchecked {
+                ++t;
+            }
+        }
+
+        GlobalRulesEnum storage en = _globalRuleKeys();
+        uint256 kLen = en.keys.length;
+        for (uint256 k; k < kLen;) {
+            GlobalRuleKey storage key = en.keys[k];
+            for (uint256 t; t < tLen;) {
+                if (targetTypeIds[t] == key.typeId) {
+                    Rule storage global = _globalRules()[key.typeId][key.selector];
+                    _rules()[orgId][targets[t]][key.selector] =
+                        Rule({maxCallGasHint: global.maxCallGasHint, allowed: true});
+                    emit PaymasterHubErrors.RuleSet(orgId, targets[t], key.selector, true, global.maxCallGasHint);
+                }
+                unchecked {
+                    ++t;
+                }
+            }
+            unchecked {
+                ++k;
+            }
+        }
+    }
+
+    /// @dev Mirror of PaymasterHub.onlyOrgOperator: org must be registered; poaManager bypasses;
+    ///      otherwise the caller must wear the org's admin or operator hat.
+    function _requireOrgOperator(bytes32 orgId) private view {
+        OrgConfig storage org = _orgs()[orgId];
+        if (org.adminHatId == 0) revert PaymasterHubErrors.OrgNotRegistered();
+
+        MainStorage storage m = _main();
+        if (msg.sender == m.poaManager) return;
+
+        bool isAdmin = IHats(m.hats).isWearerOfHat(msg.sender, org.adminHatId);
+        bool isOperator = org.operatorHatId != 0 && IHats(m.hats).isWearerOfHat(msg.sender, org.operatorHatId);
+        if (!isAdmin && !isOperator) revert PaymasterHubErrors.NotOperator();
+    }
+
+    /// @dev Same gate as adminBatchAddRules / setSolidarityFee: poaManager or protocolAdmin.
+    ///      protocolAdmin == address(0) can never authorize (msg.sender is nonzero).
+    function _requirePoaOrProtocolAdmin() private view {
+        MainStorage storage m = _main();
+        if (msg.sender != m.poaManager && msg.sender != m.protocolAdmin) revert PaymasterHubErrors.NotOperator();
+    }
+
+    // ── Storage accessors ──
+    function _main() private pure returns (MainStorage storage $) {
+        bytes32 slot = MAIN_STORAGE_LOCATION;
+        assembly {
+            $.slot := slot
+        }
+    }
+
+    function _orgs() private pure returns (mapping(bytes32 => OrgConfig) storage $) {
+        bytes32 slot = ORGS_STORAGE_LOCATION;
+        assembly {
+            $.slot := slot
+        }
+    }
+
+    function _rules() private pure returns (mapping(bytes32 => mapping(address => mapping(bytes4 => Rule))) storage $) {
+        bytes32 slot = RULES_STORAGE_LOCATION;
+        assembly {
+            $.slot := slot
+        }
+    }
+
+    function _feeCaps() private pure returns (mapping(bytes32 => FeeCaps) storage $) {
+        bytes32 slot = FEECAPS_STORAGE_LOCATION;
+        assembly {
+            $.slot := slot
+        }
+    }
+
+    function _budgets() private pure returns (mapping(bytes32 => mapping(bytes32 => Budget)) storage $) {
+        bytes32 slot = BUDGETS_STORAGE_LOCATION;
+        assembly {
+            $.slot := slot
+        }
+    }
+
+    function _globalRules() private pure returns (mapping(bytes32 => mapping(bytes4 => Rule)) storage $) {
+        bytes32 slot = GLOBAL_RULES_STORAGE_LOCATION;
+        assembly {
+            $.slot := slot
+        }
+    }
+
+    function _globalRuleKeys() private pure returns (GlobalRulesEnum storage $) {
+        bytes32 slot = GLOBAL_RULE_KEYS_STORAGE_LOCATION;
+        assembly {
+            $.slot := slot
+        }
+    }
+
+    function _targetTypes() private pure returns (mapping(bytes32 => mapping(address => bytes32)) storage $) {
+        bytes32 slot = TARGET_TYPES_STORAGE_LOCATION;
+        assembly {
+            $.slot := slot
+        }
+    }
+
+    function _rulesModes() private pure returns (mapping(bytes32 => uint8) storage $) {
+        bytes32 slot = RULES_MODES_STORAGE_LOCATION;
+        assembly {
+            $.slot := slot
+        }
+    }
+
+    function _globalRuleBlocks()
+        private
+        pure
+        returns (mapping(bytes32 => mapping(address => mapping(bytes4 => bool))) storage $)
+    {
+        bytes32 slot = GLOBAL_RULE_BLOCKS_STORAGE_LOCATION;
+        assembly {
+            $.slot := slot
+        }
+    }
+}

--- a/src/libs/PaymasterRuleLib.sol
+++ b/src/libs/PaymasterRuleLib.sol
@@ -24,9 +24,12 @@ import {PaymasterHubErrors} from "./PaymasterHubErrors.sol";
  *           resolves local only — the org votes new rules in, exactly like a pinned beacon.
  *         - Mirror orgs can veto a single global rule via `setGlobalRuleBlock` without leaving
  *           Mirror mode.
- *         Resolution order: local allowed → pass; org Static → deny; org block → deny;
- *         target typeId unset → deny; global rule allowed → pass; else deny. Fail-closed at
- *         every step, and fully inert for an org until its targetTypes are registered.
+ *         Resolution order: local allowed → pass; local {allowed:false, hint != 0} → deny
+ *         (explicit deny, incl. pre-v20 writes that predate the block mapping); org Static →
+ *         deny; org block → deny; target typeId unset → deny; global rule allowed → pass; else
+ *         deny. Fail-closed at every step, and fully inert for an org until its targetTypes are
+ *         registered. Pre-v20 zero-hint denies (zero struct — on-chain-indistinguishable from
+ *         unset) are preserved by the migration's event-log block reconstruction instead.
  *
  * @dev STORAGE: operates on the HUB's own ERC-7201 namespaced slots via delegatecall — struct
  *      definitions and slot derivations below MUST stay byte-identical to PaymasterHub's.
@@ -220,6 +223,14 @@ library PaymasterRuleLib {
     {
         Rule storage local = _rules()[orgId][target][selector];
         if (local.allowed) return (true, local.maxCallGasHint);
+
+        // A stored {allowed:false, hint != 0} rule is an EXPLICIT pre-v20 deny (written by the
+        // old setRule before the block mapping existed — post-v20 denies always pair with a
+        // block). Honor it: never fall through to the rulebook. Pre-v20 denies written with
+        // hint == 0 leave a zero struct (indistinguishable from unset on-chain) and are
+        // preserved by the migration's event-log block reconstruction instead — see
+        // UpgradePaymasterGlobalRules Step4.
+        if (local.maxCallGasHint != 0) return (false, 0);
 
         if (_rulesModes()[orgId] != RULES_MODE_MIRROR) return (false, 0);
         if (_globalRuleBlocks()[orgId][target][selector]) return (false, 0);

--- a/test/DeployerTest.t.sol
+++ b/test/DeployerTest.t.sol
@@ -42,6 +42,9 @@ import {SwitchableBeacon} from "../src/SwitchableBeacon.sol";
 import {IHats} from "@hats-protocol/src/Interfaces/IHats.sol";
 import {MockERC20} from "./mocks/MockERC20.sol";
 import {PaymasterHub} from "../src/PaymasterHub.sol";
+import {PaymasterRuleLib} from "../src/libs/PaymasterRuleLib.sol";
+import {PaymasterHubLens} from "../src/PaymasterHubLens.sol";
+import {DefaultGlobalRules} from "../script/helpers/DefaultGlobalRules.sol";
 import {PackedUserOperation, UserOpLib} from "../src/interfaces/PackedUserOperation.sol";
 import {PasskeyAccount} from "../src/PasskeyAccount.sol";
 import {PasskeyAccountFactory} from "../src/PasskeyAccountFactory.sol";
@@ -5906,99 +5909,174 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         assertEq(financials.deposited, 0.05 ether, "Org should have 0.05 ETH deposited");
     }
 
-    function _assertAutoWhitelistRules(bytes32 orgId, OrgDeployer.DeploymentResult memory result) internal view {
-        PaymasterHub.Rule memory rule;
+    /// @dev Seed the hub's global rulebook with the canonical default set (idempotent upserts),
+    ///      as Poa would once per chain. Deploy no longer writes per-org selector rules — orgs
+    ///      resolve through targetTypes + this rulebook.
+    function _seedGlobalRulebook() internal {
+        (bytes32[] memory typeIds, bytes4[] memory selectors, bool[] memory allowedFlags, uint32[] memory hints) =
+            DefaultGlobalRules.defaults();
+        vm.prank(address(poaManager));
+        paymasterHub.setGlobalRulesBatch(typeIds, selectors, allowedFlags, hints);
+    }
 
-        // Check QuickJoin quickJoinWithUser() is whitelisted
-        rule = paymasterHub.getRule(orgId, result.quickJoin, bytes4(keccak256("quickJoinWithUser()")));
-        assertTrue(rule.allowed, "QuickJoin quickJoinWithUser should be whitelisted");
+    PaymasterHubLens private _pmLens;
 
-        // Check TaskManager claimTask(uint256) is whitelisted
-        rule = paymasterHub.getRule(orgId, result.taskManager, bytes4(keccak256("claimTask(uint256)")));
-        assertTrue(rule.allowed, "TaskManager claimTask should be whitelisted");
+    /// @dev Lazily-deployed Lens; effectiveRuleOf is the production resolution path
+    ///      (local rule → Mirror-mode global rulebook), so assertions here exercise the
+    ///      same logic the frontend preflight uses instead of a test-side reimplementation.
+    function _effectiveAllowed(bytes32 orgId, address target, bytes4 sel) internal returns (bool allowed) {
+        if (address(_pmLens) == address(0)) _pmLens = new PaymasterHubLens(address(paymasterHub));
+        (allowed,,) = _pmLens.effectiveRuleOf(orgId, target, sel);
+    }
 
-        // Check TaskManager unclaimTask(uint256) is whitelisted (v7 claim release)
-        rule = paymasterHub.getRule(orgId, result.taskManager, bytes4(keccak256("unclaimTask(uint256)")));
-        assertTrue(rule.allowed, "TaskManager unclaimTask should be whitelisted");
-
-        // Check TaskManager setFolders is whitelisted (v4 bootstrap)
-        rule = paymasterHub.getRule(orgId, result.taskManager, bytes4(keccak256("setFolders(bytes32,bytes32)")));
-        assertTrue(rule.allowed, "TaskManager setFolders should be whitelisted (v4 bootstrap)");
-
-        // Check TaskManager v6 create selectors (deadline params appended) are whitelisted
-        rule = paymasterHub.getRule(
-            orgId,
-            result.taskManager,
-            bytes4(keccak256("createTask(uint256,bytes,bytes32,bytes32,address,uint256,bool,uint48,uint32)"))
+    function _assertAutoWhitelistRules(bytes32 orgId, OrgDeployer.DeploymentResult memory result) internal {
+        // The deployer registers module TYPE mappings + Mirror mode instead of per-selector
+        // local rules; sponsored selectors come from the Poa-managed global rulebook.
+        assertEq(paymasterHub.getRulesMode(orgId), 0, "autoUpgrade org should deploy in Mirror rules mode");
+        assertEq(paymasterHub.getTargetType(orgId, result.quickJoin), ModuleTypes.QUICK_JOIN_ID, "quickJoin type");
+        assertEq(paymasterHub.getTargetType(orgId, result.taskManager), ModuleTypes.TASK_MANAGER_ID, "taskManager type");
+        assertEq(
+            paymasterHub.getTargetType(orgId, result.hybridVoting), ModuleTypes.HYBRID_VOTING_ID, "hybridVoting type"
         );
-        assertTrue(rule.allowed, "TaskManager createTask should be whitelisted (v6 deadlines)");
-        rule = paymasterHub.getRule(
-            orgId,
-            result.taskManager,
-            bytes4(keccak256("createTasksBatch(bytes32,(uint256,bytes,bytes32,address,uint256,bool,uint48,uint32)[])"))
+        assertEq(
+            paymasterHub.getTargetType(orgId, result.directDemocracyVoting),
+            ModuleTypes.DIRECT_DEMOCRACY_VOTING_ID,
+            "ddVoting type"
         );
-        assertTrue(rule.allowed, "TaskManager createTasksBatch should be whitelisted (v6 deadlines)");
-        rule = paymasterHub.getRule(
-            orgId,
-            result.taskManager,
-            bytes4(
-                keccak256(
-                    "createAndAssignTask(uint256,bytes,bytes32,bytes32,address,address,uint256,bool,uint48,uint32)"
-                )
-            )
+        assertEq(
+            paymasterHub.getTargetType(orgId, result.paymentManager), ModuleTypes.PAYMENT_MANAGER_ID, "paymentMgr type"
         );
-        assertTrue(rule.allowed, "TaskManager createAndAssignTask should be whitelisted (v6 deadlines)");
-
-        // Check TaskManager v5 post-claim edit functions are whitelisted (v6 updateTask signature)
-        rule = paymasterHub.getRule(
-            orgId,
-            result.taskManager,
-            bytes4(keccak256("updateTask(uint256,uint256,bytes,bytes32,address,uint256,uint48,uint32)"))
+        assertEq(
+            paymasterHub.getTargetType(orgId, result.eligibilityModule),
+            ModuleTypes.ELIGIBILITY_MODULE_ID,
+            "eligibility type"
         );
-        assertTrue(rule.allowed, "TaskManager updateTask should be whitelisted (v5 edit)");
-        rule = paymasterHub.getRule(
-            orgId, result.taskManager, bytes4(keccak256("updateTaskMetadata(uint256,bytes,bytes32)"))
+        assertEq(
+            paymasterHub.getTargetType(orgId, result.participationToken),
+            ModuleTypes.PARTICIPATION_TOKEN_ID,
+            "token type"
         );
-        assertTrue(rule.allowed, "TaskManager updateTaskMetadata should be whitelisted (v5 edit)");
+        assertEq(
+            paymasterHub.getTargetType(orgId, accountRegProxy),
+            ModuleTypes.UNIVERSAL_ACCOUNT_REGISTRY_ID,
+            "account registry type"
+        );
+        assertEq(
+            paymasterHub.getTargetType(orgId, address(orgRegistry)), ModuleTypes.ORG_REGISTRY_ID, "org registry type"
+        );
+        assertEq(
+            paymasterHub.getTargetType(orgId, result.educationHub), ModuleTypes.EDUCATION_HUB_ID, "educationHub type"
+        );
 
-        // Check HybridVoting vote is whitelisted
-        bytes4 voteSel = bytes4(keccak256("vote(uint256,uint8[],uint8[])"));
-        rule = paymasterHub.getRule(orgId, result.hybridVoting, voteSel);
-        assertTrue(rule.allowed, "HybridVoting vote should be whitelisted");
+        // No per-org local rules are written at deploy anymore.
+        assertFalse(
+            paymasterHub.getRule(orgId, result.quickJoin, bytes4(keccak256("quickJoinWithUser()"))).allowed,
+            "deploy must not seed local rules"
+        );
 
-        // Check DDVoting vote is whitelisted
-        rule = paymasterHub.getRule(orgId, result.directDemocracyVoting, voteSel);
-        assertTrue(rule.allowed, "DDVoting vote should be whitelisted");
-
-        // Check PaymentManager optOut is whitelisted
-        rule = paymasterHub.getRule(orgId, result.paymentManager, bytes4(keccak256("optOut(bool)")));
-        assertTrue(rule.allowed, "PaymentManager optOut should be whitelisted");
-
-        // Check EducationHub completeModule is whitelisted
-        rule = paymasterHub.getRule(orgId, result.educationHub, bytes4(keccak256("completeModule(uint256,uint8)")));
-        assertTrue(rule.allowed, "EducationHub completeModule should be whitelisted");
-
-        // L-53 fix: updateOrgMetaAsAdmin lives on the OrgRegistry, NOT the
-        // UniversalAccountRegistry (account registry). The default rule must target
-        // the OrgRegistry so gasless org-metadata edits actually resolve to a
-        // contract that implements the selector.
-        bytes4 updateOrgMetaSel = bytes4(keccak256("updateOrgMetaAsAdmin(bytes32,bytes,bytes32)"));
-
-        rule = paymasterHub.getRule(orgId, address(orgRegistry), updateOrgMetaSel);
-        assertTrue(rule.allowed, "updateOrgMetaAsAdmin must be whitelisted against the OrgRegistry (L-53)");
-
-        // And it must NOT be whitelisted against the UniversalAccountRegistry (the old target).
-        rule = paymasterHub.getRule(orgId, accountRegProxy, updateOrgMetaSel);
-        assertFalse(rule.allowed, "updateOrgMetaAsAdmin must NOT target the UniversalAccountRegistry (old L-53 bug)");
-
-        // setProfileMetadata still lives on the UniversalAccountRegistry — unchanged by L-53.
-        rule = paymasterHub.getRule(orgId, accountRegProxy, bytes4(keccak256("setProfileMetadata(bytes32)")));
-        assertTrue(rule.allowed, "setProfileMetadata should be whitelisted against the account registry");
+        // Once Poa seeds the rulebook (one tx per chain), every default selector resolves.
+        _seedGlobalRulebook();
+        _assertEffectiveWhitelist(orgId, result);
 
         // C-01 wiring: after deploy the token's minters are wired through the executor.
         ParticipationToken token = ParticipationToken(result.participationToken);
         assertEq(token.taskManager(), result.taskManager, "token.taskManager should be wired to the TaskManager");
         assertEq(token.educationHub(), result.educationHub, "token.educationHub should be wired to the EducationHub");
+    }
+
+    /// @dev Effective-resolution checks for the same selector set the pre-rulebook tests
+    ///      asserted as local rules (split out for production-profile stack headroom).
+    function _assertEffectiveWhitelist(bytes32 orgId, OrgDeployer.DeploymentResult memory result) internal {
+        assertTrue(
+            _effectiveAllowed(orgId, result.quickJoin, bytes4(keccak256("quickJoinWithUser()"))),
+            "QuickJoin quickJoinWithUser should be whitelisted"
+        );
+        assertTrue(
+            _effectiveAllowed(orgId, result.taskManager, bytes4(keccak256("claimTask(uint256)"))),
+            "TaskManager claimTask should be whitelisted"
+        );
+        assertTrue(
+            _effectiveAllowed(orgId, result.taskManager, bytes4(keccak256("unclaimTask(uint256)"))),
+            "TaskManager unclaimTask should be whitelisted"
+        );
+        assertTrue(
+            _effectiveAllowed(orgId, result.taskManager, bytes4(keccak256("setFolders(bytes32,bytes32)"))),
+            "TaskManager setFolders should be whitelisted (v4 bootstrap)"
+        );
+        assertTrue(
+            _effectiveAllowed(
+                orgId,
+                result.taskManager,
+                bytes4(keccak256("createTask(uint256,bytes,bytes32,bytes32,address,uint256,bool,uint48,uint32)"))
+            ),
+            "TaskManager createTask should be whitelisted (v6 deadlines)"
+        );
+        assertTrue(
+            _effectiveAllowed(
+                orgId,
+                result.taskManager,
+                bytes4(
+                    keccak256("createTasksBatch(bytes32,(uint256,bytes,bytes32,address,uint256,bool,uint48,uint32)[])")
+                )
+            ),
+            "TaskManager createTasksBatch should be whitelisted (v6 deadlines)"
+        );
+        assertTrue(
+            _effectiveAllowed(
+                orgId,
+                result.taskManager,
+                bytes4(
+                    keccak256(
+                        "createAndAssignTask(uint256,bytes,bytes32,bytes32,address,address,uint256,bool,uint48,uint32)"
+                    )
+                )
+            ),
+            "TaskManager createAndAssignTask should be whitelisted (v6 deadlines)"
+        );
+        assertTrue(
+            _effectiveAllowed(
+                orgId,
+                result.taskManager,
+                bytes4(keccak256("updateTask(uint256,uint256,bytes,bytes32,address,uint256,uint48,uint32)"))
+            ),
+            "TaskManager updateTask should be whitelisted (v5 edit)"
+        );
+        assertTrue(
+            _effectiveAllowed(
+                orgId, result.taskManager, bytes4(keccak256("updateTaskMetadata(uint256,bytes,bytes32)"))
+            ),
+            "TaskManager updateTaskMetadata should be whitelisted (v5 edit)"
+        );
+
+        bytes4 voteSel = bytes4(keccak256("vote(uint256,uint8[],uint8[])"));
+        assertTrue(_effectiveAllowed(orgId, result.hybridVoting, voteSel), "HybridVoting vote should be whitelisted");
+        assertTrue(
+            _effectiveAllowed(orgId, result.directDemocracyVoting, voteSel), "DDVoting vote should be whitelisted"
+        );
+        assertTrue(
+            _effectiveAllowed(orgId, result.paymentManager, bytes4(keccak256("optOut(bool)"))),
+            "PaymentManager optOut should be whitelisted"
+        );
+        assertTrue(
+            _effectiveAllowed(orgId, result.educationHub, bytes4(keccak256("completeModule(uint256,uint8)"))),
+            "EducationHub completeModule should be whitelisted"
+        );
+
+        // L-53: updateOrgMetaAsAdmin resolves against the OrgRegistry, NOT the account registry
+        // (distinct typeIds keep the rulebook entries from bleeding across the two registries).
+        bytes4 updateOrgMetaSel = bytes4(keccak256("updateOrgMetaAsAdmin(bytes32,bytes,bytes32)"));
+        assertTrue(
+            _effectiveAllowed(orgId, address(orgRegistry), updateOrgMetaSel),
+            "updateOrgMetaAsAdmin must be whitelisted against the OrgRegistry (L-53)"
+        );
+        assertFalse(
+            _effectiveAllowed(orgId, accountRegProxy, updateOrgMetaSel),
+            "updateOrgMetaAsAdmin must NOT target the UniversalAccountRegistry (old L-53 bug)"
+        );
+        assertTrue(
+            _effectiveAllowed(orgId, accountRegProxy, bytes4(keccak256("setProfileMetadata(bytes32)"))),
+            "setProfileMetadata should be whitelisted against the account registry"
+        );
     }
 
     function testDeployFullOrgWithPaymasterFeeCaps() public {
@@ -6268,22 +6346,25 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         vm.prank(orgOwner);
         OrgDeployer.DeploymentResult memory result = deployer.deployFullOrg(params);
 
-        // Core contract rules should still be set
-        PaymasterHub.Rule memory rule;
-
-        rule = paymasterHub.getRule(orgId, result.quickJoin, bytes4(keccak256("quickJoinWithUser()")));
-        assertTrue(rule.allowed, "QuickJoin should be whitelisted");
-
-        rule = paymasterHub.getRule(orgId, result.taskManager, bytes4(keccak256("claimTask(uint256)")));
-        assertTrue(rule.allowed, "TaskManager should be whitelisted");
-
-        // v7 claim release — asserted on this branch too: educationEnabled=false is a
-        // distinct rule-array sizing path from the education-enabled test above.
-        rule = paymasterHub.getRule(orgId, result.taskManager, bytes4(keccak256("unclaimTask(uint256)")));
-        assertTrue(rule.allowed, "TaskManager unclaimTask should be whitelisted without education");
-
-        rule = paymasterHub.getRule(orgId, result.hybridVoting, bytes4(keccak256("vote(uint256,uint8[],uint8[])")));
-        assertTrue(rule.allowed, "HybridVoting should be whitelisted");
+        // Core contract type mappings should still be set (education disabled is a distinct
+        // array-sizing path in _buildTargetTypes from the education-enabled test above).
+        _seedGlobalRulebook();
+        assertTrue(
+            _effectiveAllowed(orgId, result.quickJoin, bytes4(keccak256("quickJoinWithUser()"))),
+            "QuickJoin should be whitelisted"
+        );
+        assertTrue(
+            _effectiveAllowed(orgId, result.taskManager, bytes4(keccak256("claimTask(uint256)"))),
+            "TaskManager should be whitelisted"
+        );
+        assertTrue(
+            _effectiveAllowed(orgId, result.taskManager, bytes4(keccak256("unclaimTask(uint256)"))),
+            "TaskManager unclaimTask should be whitelisted without education"
+        );
+        assertTrue(
+            _effectiveAllowed(orgId, result.hybridVoting, bytes4(keccak256("vote(uint256,uint8[],uint8[])"))),
+            "HybridVoting should be whitelisted"
+        );
 
         // EducationHub should NOT be whitelisted (disabled)
         // educationHub address is zero when disabled, so checking rule on address(0) is meaningless
@@ -6365,13 +6446,16 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         assertEq(feeCaps.maxPriorityFeePerGas, 1 gwei);
         assertEq(feeCaps.maxCallGas, 300_000);
 
-        // 3. Verify auto-whitelist (spot check)
-        PaymasterHub.Rule memory rule =
-            paymasterHub.getRule(orgId, result.quickJoin, bytes4(keccak256("quickJoinWithUser()")));
-        assertTrue(rule.allowed, "QuickJoin should be whitelisted");
-
-        rule = paymasterHub.getRule(orgId, result.taskManager, bytes4(keccak256("submitTask(uint256,bytes32)")));
-        assertTrue(rule.allowed, "TaskManager submitTask should be whitelisted");
+        // 3. Verify auto-whitelist (spot check via global-rulebook resolution)
+        _seedGlobalRulebook();
+        assertTrue(
+            _effectiveAllowed(orgId, result.quickJoin, bytes4(keccak256("quickJoinWithUser()"))),
+            "QuickJoin should be whitelisted"
+        );
+        assertTrue(
+            _effectiveAllowed(orgId, result.taskManager, bytes4(keccak256("submitTask(uint256,bytes32)"))),
+            "TaskManager submitTask should be whitelisted"
+        );
 
         // 4. Verify deposit
         PaymasterHub.OrgFinancials memory financials = paymasterHub.getOrgFinancials(orgId);
@@ -6380,7 +6464,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
 
     function testPaymasterSelectorAccuracy() public {
         // Verify ALL computed selectors match actual contract function selectors
-        // This catches selector string typos in _buildDefaultPaymasterRules
+        // This catches selector string typos in script/helpers/DefaultGlobalRules.sol
 
         // ── QuickJoin (3) ──
         assertEq(
@@ -6672,10 +6756,12 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         PaymasterHub.FeeCaps memory feeCaps = paymasterHub.getFeeCaps(orgId);
         assertEq(feeCaps.maxFeePerGas, 100 gwei, "maxFeePerGas should be set");
 
-        // Verify whitelist rules also set
-        PaymasterHub.Rule memory rule =
-            paymasterHub.getRule(orgId, result.quickJoin, bytes4(keccak256("quickJoinWithUser()")));
-        assertTrue(rule.allowed, "QuickJoin should be whitelisted");
+        // Verify whitelist resolution also works (target types + global rulebook)
+        _seedGlobalRulebook();
+        assertTrue(
+            _effectiveAllowed(orgId, result.quickJoin, bytes4(keccak256("quickJoinWithUser()"))),
+            "QuickJoin should be whitelisted"
+        );
 
         // Verify deposit
         PaymasterHub.OrgFinancials memory financials = paymasterHub.getOrgFinancials(orgId);
@@ -6837,7 +6923,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         uint32[] memory epochLens = new uint32[](1);
         epochLens[0] = 366 days; // Above MAX_EPOCH_LENGTH (365 days)
 
-        PaymasterHub.DeployConfig memory config = _emptyDeployConfig();
+        PaymasterRuleLib.DeployConfig memory config = _emptyDeployConfig();
         config.budgetSubjectKeys = keys;
         config.budgetCapsPerEpoch = caps;
         config.budgetEpochLens = epochLens;
@@ -6860,7 +6946,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         epochLens[0] = 1 days;
         epochLens[1] = 1 days;
 
-        PaymasterHub.DeployConfig memory config = _emptyDeployConfig();
+        PaymasterRuleLib.DeployConfig memory config = _emptyDeployConfig();
         config.budgetSubjectKeys = keys;
         config.budgetCapsPerEpoch = caps;
         config.budgetEpochLens = epochLens;
@@ -6881,7 +6967,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         uint32[] memory epochLens = new uint32[](1);
         epochLens[0] = 30 minutes; // Below MIN_EPOCH_LENGTH (1 hour)
 
-        PaymasterHub.DeployConfig memory config = _emptyDeployConfig();
+        PaymasterRuleLib.DeployConfig memory config = _emptyDeployConfig();
         config.budgetSubjectKeys = keys;
         config.budgetCapsPerEpoch = caps;
         config.budgetEpochLens = epochLens;
@@ -6891,11 +6977,11 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         paymasterHub.registerAndConfigureOrg(orgId, 1, config);
     }
 
-    /// @dev An empty PaymasterHub.DeployConfig. Extracted into its own frame so callers don't build the
+    /// @dev An empty PaymasterRuleLib.DeployConfig. Extracted into its own frame so callers don't build the
     ///      14-field struct (+ its abi-encoding) inline — that pushed `testRegisterAndConfigureOrgUnauthorized`
     ///      exactly 1 slot too deep under the production via-IR + optimizer profile.
-    function _emptyDeployConfig() internal pure returns (PaymasterHub.DeployConfig memory) {
-        return PaymasterHub.DeployConfig({
+    function _emptyDeployConfig() internal pure returns (PaymasterRuleLib.DeployConfig memory) {
+        return PaymasterRuleLib.DeployConfig({
             operatorHatId: 0,
             maxFeePerGas: 0,
             maxPriorityFeePerGas: 0,
@@ -6908,7 +6994,10 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
             ruleMaxCallGasHints: new uint32[](0),
             budgetSubjectKeys: new bytes32[](0),
             budgetCapsPerEpoch: new uint128[](0),
-            budgetEpochLens: new uint32[](0)
+            budgetEpochLens: new uint32[](0),
+            typeTargets: new address[](0),
+            typeIds: new bytes32[](0),
+            rulesMode: 0
         });
     }
 
@@ -6916,7 +7005,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         // Non-registrar cannot call registerAndConfigureOrg directly
         bytes32 orgId = keccak256("UNAUTH-ORG");
 
-        PaymasterHub.DeployConfig memory config = _emptyDeployConfig();
+        PaymasterRuleLib.DeployConfig memory config = _emptyDeployConfig();
 
         // Random address should be rejected
         vm.prank(address(0xBEEF));
@@ -6934,7 +7023,7 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         bytes4[] memory sels = new bytes4[](1); // Length mismatch!
         sels[0] = bytes4(0x12345678);
 
-        PaymasterHub.DeployConfig memory config = _emptyDeployConfig();
+        PaymasterRuleLib.DeployConfig memory config = _emptyDeployConfig();
         config.ruleTargets = targets;
         config.ruleSelectors = sels;
         config.ruleAllowed = new bool[](2);
@@ -7090,18 +7179,20 @@ contract DeployerTest is Test, IEligibilityModuleEvents {
         uint256 memberHatId = orgRegistry.getRoleHat(orgId, 0);
         assertTrue(memberHatId != 0, "member hat should exist");
 
-        // Verify autowhitelist rules
+        // Verify autowhitelist resolution (global rulebook — validates the batch path below
+        // resolves BOTH inner calls through the rulebook, with zero local rules seeded)
+        _seedGlobalRulebook();
         bytes4 rqjpSel = bytes4(
             keccak256(
                 "registerAndQuickJoinWithPasskey((bytes32,bytes32,bytes32,uint256),string,uint256,uint256,(bytes,bytes,uint256,uint256,bytes32,bytes32))"
             )
         );
-        PaymasterHub.Rule memory rule = paymasterHub.getRule(orgId, result.quickJoin, rqjpSel);
-        assertTrue(rule.allowed, "registerAndQuickJoinWithPasskey should be whitelisted");
+        assertTrue(
+            _effectiveAllowed(orgId, result.quickJoin, rqjpSel), "registerAndQuickJoinWithPasskey should be whitelisted"
+        );
 
         bytes4 cvhSel = bytes4(keccak256("claimVouchedHat(uint256)"));
-        rule = paymasterHub.getRule(orgId, result.eligibilityModule, cvhSel);
-        assertTrue(rule.allowed, "claimVouchedHat should be whitelisted");
+        assertTrue(_effectiveAllowed(orgId, result.eligibilityModule, cvhSel), "claimVouchedHat should be whitelisted");
 
         // Build executeBatch callData
         address[] memory targets = new address[](2);

--- a/test/PaymasterGlobalRules.t.sol
+++ b/test/PaymasterGlobalRules.t.sol
@@ -761,6 +761,60 @@ contract PaymasterGlobalRulesTest is Test {
         _validateExpectDenied(_rawOp(ORG, callData), TASK_MANAGER, bytes4(0));
     }
 
+    /*═══════════════════════ Pre-v20 explicit-denial preservation (P1) ═══════════════════════*/
+
+    /// @dev Storage slot of rules[ORG][target][selector] — used to plant PRE-v20 state that the
+    ///      post-v20 setters can no longer produce (they pair every deny with a block).
+    function _legacyRuleSlot(address target, bytes4 selector) internal pure returns (bytes32) {
+        bytes32 rulesLoc = keccak256(abi.encode(uint256(keccak256("poa.paymasterhub.rules")) - 1));
+        return keccak256(abi.encode(selector, keccak256(abi.encode(target, keccak256(abi.encode(ORG, rulesLoc))))));
+    }
+
+    /// @notice A pre-v20 explicit deny that stored a hint ({allowed:false, hint!=0}) must NEVER
+    ///         fall through to the rulebook — the resolver honors it with no block needed.
+    function testPreV20DenyWithHint_NeverFallsThrough() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+        _mapTaskManager();
+
+        // Plant the pre-v20 write directly: old setRule stored {false, 777} with NO block.
+        vm.store(address(hub), _legacyRuleSlot(TASK_MANAGER, SEL_CLAIM_TASK), bytes32(uint256(777)));
+        PaymasterHub.Rule memory planted = hub.getRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK);
+        assertFalse(planted.allowed);
+        assertEq(planted.maxCallGasHint, 777, "fixture must model the hinted pre-v20 deny");
+        assertFalse(hub.isGlobalRuleBlocked(ORG, TASK_MANAGER, SEL_CLAIM_TASK), "no block exists pre-v20");
+
+        // Denied by the RESOLVER alone — and the Lens agrees.
+        _validateExpectDenied(_op(TASK_MANAGER, SEL_CLAIM_TASK), TASK_MANAGER, SEL_CLAIM_TASK);
+        (bool allowed,, uint8 source) = lens.effectiveRuleOf(ORG, TASK_MANAGER, SEL_CLAIM_TASK);
+        assertFalse(allowed, "hinted pre-v20 deny must not resurrect via the rulebook");
+        assertEq(source, 0);
+
+        // clearRule still resets the pair to protocol default afterwards.
+        vm.prank(orgAdmin);
+        hub.clearRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK);
+        _validate(_op(TASK_MANAGER, SEL_CLAIM_TASK));
+    }
+
+    /// @notice A pre-v20 explicit deny written with hint=0 leaves a ZERO struct — on-chain state
+    ///         cannot distinguish it from unset, so the migration reconstructs it as a block from
+    ///         the RuleSet event log, applied BEFORE the target is typed (no sponsorship window).
+    function testPreV20DenyZeroHint_PreservedByReconstructedBlock() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+        // (Nothing to plant: {false, 0} IS the zero struct — exactly the migration's problem.)
+
+        // Step4 order: reconstruct the denial as a block FIRST...
+        vm.prank(poaManager);
+        hub.setGlobalRuleBlock(ORG, TASK_MANAGER, SEL_CLAIM_TASK, true);
+        // ...then type the target (this is what arms the rulebook fallback).
+        vm.prank(poaManager);
+        hub.setTargetTypesBatch(ORG, _oneAddr(TASK_MANAGER), _one32(ModuleTypes.TASK_MANAGER_ID));
+
+        // The denial survives typing; a sibling selector resolves via the rulebook as intended.
+        _validateExpectDenied(_op(TASK_MANAGER, SEL_CLAIM_TASK), TASK_MANAGER, SEL_CLAIM_TASK);
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_UNCLAIM_TASK, true, 0);
+        _validate(_op(TASK_MANAGER, SEL_UNCLAIM_TASK));
+    }
+
     /*═══════════════════════ Seed-list accuracy (reads DefaultGlobalRules itself) ═══════════════════════*/
 
     /// @dev Bijection check between DefaultGlobalRules.entries() and the REAL contract

--- a/test/PaymasterGlobalRules.t.sol
+++ b/test/PaymasterGlobalRules.t.sol
@@ -1,0 +1,1048 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {PaymasterHub} from "../src/PaymasterHub.sol";
+import {PaymasterHubLens} from "../src/PaymasterHubLens.sol";
+import {PaymasterHubErrors} from "../src/libs/PaymasterHubErrors.sol";
+import {PaymasterRuleLib} from "../src/libs/PaymasterRuleLib.sol";
+import {ModuleTypes} from "../src/libs/ModuleTypes.sol";
+import {DefaultGlobalRules} from "../script/helpers/DefaultGlobalRules.sol";
+import {PackedUserOperation} from "../src/interfaces/PackedUserOperation.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {MockEntryPoint, MockHats} from "./PaymasterHubSolidarity.t.sol";
+import {QuickJoin} from "../src/QuickJoin.sol";
+import {TaskManager} from "../src/TaskManager.sol";
+import {HybridVoting} from "../src/HybridVoting.sol";
+import {DirectDemocracyVoting} from "../src/DirectDemocracyVoting.sol";
+import {PaymentManager} from "../src/PaymentManager.sol";
+import {EligibilityModule} from "../src/EligibilityModule.sol";
+import {ParticipationToken} from "../src/ParticipationToken.sol";
+import {EducationHub} from "../src/EducationHub.sol";
+import {ZkEmailInvites} from "../src/ZkEmailInvites.sol";
+import {UniversalAccountRegistry} from "../src/UniversalAccountRegistry.sol";
+import {OrgRegistry} from "../src/OrgRegistry.sol";
+
+/// @title PaymasterGlobalRulesTest
+/// @notice Coverage for the type-keyed GLOBAL RULEBOOK (PaymasterRuleLib): rulebook admin +
+///         enumeration, per-org target-type mapping, Mirror/Static rules mode, per-pair block
+///         veto, validation-time resolution (single + batch paths), adopt/snapshot for Static
+///         orgs, deploy-time wiring via registerAndConfigureOrg, and Lens parity.
+contract PaymasterGlobalRulesTest is Test {
+    PaymasterHub public hub;
+    PaymasterHubLens public lens;
+    MockEntryPoint public ep;
+    MockHats public hats;
+
+    address public poaManager = address(0xA0A);
+    address public protocolAdmin = address(0xAD31);
+    address public orgAdmin = address(0xADACE);
+    address public orgOperator = address(0x09E7);
+    address public user = address(0xCAFE);
+    address public stranger = address(0xBAD);
+
+    uint256 constant ADMIN_HAT = 1;
+    uint256 constant OPERATOR_HAT = 2;
+    bytes32 constant ORG = keccak256("GLOBAL_RULES_ORG");
+
+    // Two org "module proxies" and a couple of selectors
+    address constant TASK_MANAGER = address(0x7A5C);
+    address constant QUICK_JOIN = address(0x9105);
+    bytes4 constant SEL_CLAIM_TASK = bytes4(keccak256("claimTask(uint256)"));
+    bytes4 constant SEL_UNCLAIM_TASK = bytes4(keccak256("unclaimTask(uint256)"));
+    bytes4 constant SEL_QUICK_JOIN = bytes4(keccak256("quickJoinWithUser()"));
+
+    uint8 constant SUBJECT_TYPE_ACCOUNT = 0x00;
+    uint8 constant MODE_MIRROR = 0;
+    uint8 constant MODE_STATIC = 1;
+
+    function setUp() public {
+        ep = new MockEntryPoint();
+        hats = new MockHats();
+
+        PaymasterHub impl = new PaymasterHub();
+        bytes memory initData =
+            abi.encodeWithSelector(PaymasterHub.initialize.selector, address(ep), address(hats), poaManager);
+        hub = PaymasterHub(payable(address(new ERC1967Proxy(address(impl), initData))));
+        lens = new PaymasterHubLens(address(hub));
+
+        hats.mintHat(ADMIN_HAT, orgAdmin);
+        hats.mintHat(OPERATOR_HAT, orgOperator);
+
+        vm.startPrank(poaManager);
+        hub.registerOrg(ORG, ADMIN_HAT, OPERATOR_HAT);
+        hub.unpauseSolidarityDistribution();
+        vm.stopPrank();
+
+        // Budget for the account subject so rule checks are the binding constraint.
+        bytes32 subjectKey = keccak256(abi.encodePacked(SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(user)))));
+        vm.prank(orgAdmin);
+        hub.setBudget(ORG, subjectKey, type(uint128).max, 7 days);
+
+        // Solidarity so the fresh org's grace period can draw during validation.
+        vm.deal(address(this), 100 ether);
+        hub.donateToSolidarity{value: 10 ether}();
+    }
+
+    /*═══════════════════════ Global rulebook admin ═══════════════════════*/
+
+    function testSetGlobalRules_PoaManagerCanSet() public {
+        vm.expectEmit(true, true, true, true);
+        emit PaymasterHubErrors.GlobalRuleSet(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 123);
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 123);
+
+        PaymasterHub.Rule memory r = hub.getGlobalRule(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK);
+        assertTrue(r.allowed);
+        assertEq(r.maxCallGasHint, 123);
+        assertEq(hub.getGlobalRuleCount(), 1);
+
+        (bytes32 typeId, bytes4 selector, PaymasterHub.Rule memory rule) = hub.getGlobalRuleAt(0);
+        assertEq(typeId, ModuleTypes.TASK_MANAGER_ID);
+        assertEq(selector, SEL_CLAIM_TASK);
+        assertTrue(rule.allowed);
+    }
+
+    function testSetGlobalRules_ProtocolAdminCanSet() public {
+        vm.prank(poaManager);
+        hub.setProtocolAdmin(protocolAdmin);
+
+        vm.prank(protocolAdmin);
+        hub.setGlobalRulesBatch(_one32(ModuleTypes.QUICK_JOIN_ID), _one4(SEL_QUICK_JOIN), _oneBool(true), _oneU32(0));
+        assertTrue(hub.getGlobalRule(ModuleTypes.QUICK_JOIN_ID, SEL_QUICK_JOIN).allowed);
+    }
+
+    function testSetGlobalRules_UnauthorizedReverts() public {
+        vm.prank(stranger);
+        vm.expectRevert(PaymasterHubErrors.NotOperator.selector);
+        hub.setGlobalRulesBatch(_one32(ModuleTypes.TASK_MANAGER_ID), _one4(SEL_CLAIM_TASK), _oneBool(true), _oneU32(0));
+
+        // Org admins manage LOCAL rules only — the global rulebook is protocol-level.
+        vm.prank(orgAdmin);
+        vm.expectRevert(PaymasterHubErrors.NotOperator.selector);
+        hub.setGlobalRulesBatch(_one32(ModuleTypes.TASK_MANAGER_ID), _one4(SEL_CLAIM_TASK), _oneBool(true), _oneU32(0));
+    }
+
+    function testSetGlobalRules_ZeroTypeIdReverts() public {
+        vm.prank(poaManager);
+        vm.expectRevert(PaymasterHubErrors.InvalidTypeId.selector);
+        hub.setGlobalRulesBatch(_one32(bytes32(0)), _one4(SEL_CLAIM_TASK), _oneBool(true), _oneU32(0));
+    }
+
+    function testSetGlobalRules_LengthMismatchReverts() public {
+        bytes32[] memory typeIds = new bytes32[](2);
+        typeIds[0] = ModuleTypes.TASK_MANAGER_ID;
+        typeIds[1] = ModuleTypes.QUICK_JOIN_ID;
+        vm.prank(poaManager);
+        vm.expectRevert(PaymasterHubErrors.ArrayLengthMismatch.selector);
+        hub.setGlobalRulesBatch(typeIds, _one4(SEL_CLAIM_TASK), _oneBool(true), _oneU32(0));
+    }
+
+    function testSetGlobalRules_UpsertDoesNotDuplicate() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 100);
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 200);
+        assertEq(hub.getGlobalRuleCount(), 1);
+        assertEq(hub.getGlobalRule(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK).maxCallGasHint, 200);
+    }
+
+    function testSetGlobalRules_RemoveDeletesAndUnenumerates() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_UNCLAIM_TASK, true, 0);
+        _setGlobal(ModuleTypes.QUICK_JOIN_ID, SEL_QUICK_JOIN, true, 0);
+        assertEq(hub.getGlobalRuleCount(), 3);
+
+        // Remove the middle entry — swap-remove must keep enumeration + index map consistent.
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_UNCLAIM_TASK, false, 0);
+        assertEq(hub.getGlobalRuleCount(), 2);
+        assertFalse(hub.getGlobalRule(ModuleTypes.TASK_MANAGER_ID, SEL_UNCLAIM_TASK).allowed);
+
+        // Remaining two entries are still enumerable exactly once each.
+        bool sawClaim;
+        bool sawQuickJoin;
+        for (uint256 i = 0; i < 2; i++) {
+            (bytes32 typeId, bytes4 selector,) = hub.getGlobalRuleAt(i);
+            if (typeId == ModuleTypes.TASK_MANAGER_ID && selector == SEL_CLAIM_TASK) sawClaim = true;
+            if (typeId == ModuleTypes.QUICK_JOIN_ID && selector == SEL_QUICK_JOIN) sawQuickJoin = true;
+        }
+        assertTrue(sawClaim && sawQuickJoin, "enumeration lost an entry after swap-remove");
+
+        // The moved entry's index stays valid: removing it again must work.
+        _setGlobal(ModuleTypes.QUICK_JOIN_ID, SEL_QUICK_JOIN, false, 0);
+        assertEq(hub.getGlobalRuleCount(), 1);
+        (bytes32 lastType, bytes4 lastSel,) = hub.getGlobalRuleAt(0);
+        assertEq(lastType, ModuleTypes.TASK_MANAGER_ID);
+        assertEq(lastSel, SEL_CLAIM_TASK);
+    }
+
+    function testSetGlobalRules_RemoveNonexistentIsNoop() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, false, 0);
+        assertEq(hub.getGlobalRuleCount(), 0);
+    }
+
+    function testSeedDefaultGlobalRules_IdempotentAndComplete() public {
+        (bytes32[] memory typeIds, bytes4[] memory selectors, bool[] memory allowed, uint32[] memory hints) =
+            DefaultGlobalRules.defaults();
+        vm.prank(poaManager);
+        hub.setGlobalRulesBatch(typeIds, selectors, allowed, hints);
+        assertEq(hub.getGlobalRuleCount(), typeIds.length);
+
+        // Re-seeding is idempotent (pure upserts).
+        vm.prank(poaManager);
+        hub.setGlobalRulesBatch(typeIds, selectors, allowed, hints);
+        assertEq(hub.getGlobalRuleCount(), typeIds.length);
+
+        // Spot checks: TaskManager claim + the zk-email gas hint.
+        assertTrue(hub.getGlobalRule(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK).allowed);
+        // Real compiler-derived selector (the old string-derived one was a latent bug).
+        bytes4 zkSel = ZkEmailInvites.claimRoleByDomain.selector;
+        assertEq(hub.getGlobalRule(ModuleTypes.ZKEMAIL_INVITES_ID, zkSel).maxCallGasHint, 800_000);
+    }
+
+    /*═══════════════════════ Target types / mode / block admin ═══════════════════════*/
+
+    function testSetTargetTypes_AdminOperatorAndPoaCanSet() public {
+        vm.expectEmit(true, true, true, true);
+        emit PaymasterHubErrors.TargetTypeSet(ORG, TASK_MANAGER, ModuleTypes.TASK_MANAGER_ID);
+        vm.prank(orgAdmin);
+        hub.setTargetTypesBatch(ORG, _oneAddr(TASK_MANAGER), _one32(ModuleTypes.TASK_MANAGER_ID));
+        assertEq(hub.getTargetType(ORG, TASK_MANAGER), ModuleTypes.TASK_MANAGER_ID);
+
+        vm.prank(orgOperator);
+        hub.setTargetTypesBatch(ORG, _oneAddr(QUICK_JOIN), _one32(ModuleTypes.QUICK_JOIN_ID));
+        assertEq(hub.getTargetType(ORG, QUICK_JOIN), ModuleTypes.QUICK_JOIN_ID);
+
+        // poaManager bypass (migration path for existing orgs) + clearing with bytes32(0).
+        vm.prank(poaManager);
+        hub.setTargetTypesBatch(ORG, _oneAddr(QUICK_JOIN), _one32(bytes32(0)));
+        assertEq(hub.getTargetType(ORG, QUICK_JOIN), bytes32(0));
+    }
+
+    function testSetTargetTypes_UnauthorizedReverts() public {
+        vm.prank(stranger);
+        vm.expectRevert(PaymasterHubErrors.NotOperator.selector);
+        hub.setTargetTypesBatch(ORG, _oneAddr(TASK_MANAGER), _one32(ModuleTypes.TASK_MANAGER_ID));
+    }
+
+    function testSetTargetTypes_UnregisteredOrgReverts() public {
+        vm.prank(poaManager);
+        vm.expectRevert(PaymasterHubErrors.OrgNotRegistered.selector);
+        hub.setTargetTypesBatch(keccak256("nope"), _oneAddr(TASK_MANAGER), _one32(ModuleTypes.TASK_MANAGER_ID));
+    }
+
+    function testSetTargetTypes_ZeroTargetReverts() public {
+        vm.prank(orgAdmin);
+        vm.expectRevert(PaymasterHubErrors.ZeroAddress.selector);
+        hub.setTargetTypesBatch(ORG, _oneAddr(address(0)), _one32(ModuleTypes.TASK_MANAGER_ID));
+    }
+
+    function testSetRulesMode_SwitchAndEvents() public {
+        assertEq(hub.getRulesMode(ORG), MODE_MIRROR);
+
+        vm.expectEmit(true, true, true, true);
+        emit PaymasterHubErrors.RulesModeSet(ORG, MODE_STATIC);
+        vm.prank(orgAdmin);
+        hub.setRulesMode(ORG, MODE_STATIC);
+        assertEq(hub.getRulesMode(ORG), MODE_STATIC);
+
+        vm.prank(orgAdmin);
+        hub.setRulesMode(ORG, MODE_MIRROR);
+        assertEq(hub.getRulesMode(ORG), MODE_MIRROR);
+    }
+
+    function testSetRulesMode_InvalidModeReverts() public {
+        vm.prank(orgAdmin);
+        vm.expectRevert(PaymasterHubErrors.InvalidRulesMode.selector);
+        hub.setRulesMode(ORG, 2);
+    }
+
+    function testSetRulesMode_UnauthorizedReverts() public {
+        vm.prank(stranger);
+        vm.expectRevert(PaymasterHubErrors.NotOperator.selector);
+        hub.setRulesMode(ORG, MODE_STATIC);
+    }
+
+    function testSetGlobalRuleBlock_SetUnsetAndAuth() public {
+        vm.expectEmit(true, true, true, true);
+        emit PaymasterHubErrors.GlobalRuleBlockSet(ORG, TASK_MANAGER, SEL_CLAIM_TASK, true);
+        vm.prank(orgAdmin);
+        hub.setGlobalRuleBlock(ORG, TASK_MANAGER, SEL_CLAIM_TASK, true);
+        assertTrue(hub.isGlobalRuleBlocked(ORG, TASK_MANAGER, SEL_CLAIM_TASK));
+
+        vm.prank(orgOperator);
+        hub.setGlobalRuleBlock(ORG, TASK_MANAGER, SEL_CLAIM_TASK, false);
+        assertFalse(hub.isGlobalRuleBlocked(ORG, TASK_MANAGER, SEL_CLAIM_TASK));
+
+        vm.prank(stranger);
+        vm.expectRevert(PaymasterHubErrors.NotOperator.selector);
+        hub.setGlobalRuleBlock(ORG, TASK_MANAGER, SEL_CLAIM_TASK, true);
+    }
+
+    /*═══════════════════════ Validation-time resolution ═══════════════════════*/
+
+    function testValidate_GlobalFallbackAllows() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+        _mapTaskManager();
+
+        // No local rule exists — resolution must come from the global rulebook.
+        assertFalse(hub.getRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK).allowed);
+        _validate(_op(TASK_MANAGER, SEL_CLAIM_TASK));
+    }
+
+    function testValidate_NoTargetTypeDenies() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+        // targetTypes NOT registered — the global rule must be unreachable.
+        _validateExpectDenied(_op(TASK_MANAGER, SEL_CLAIM_TASK), TASK_MANAGER, SEL_CLAIM_TASK);
+    }
+
+    function testValidate_StaticModeIgnoresGlobal() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+        _mapTaskManager();
+        vm.prank(orgAdmin);
+        hub.setRulesMode(ORG, MODE_STATIC);
+
+        _validateExpectDenied(_op(TASK_MANAGER, SEL_CLAIM_TASK), TASK_MANAGER, SEL_CLAIM_TASK);
+    }
+
+    function testValidate_BlockedGlobalDenies() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+        _mapTaskManager();
+        vm.prank(orgAdmin);
+        hub.setGlobalRuleBlock(ORG, TASK_MANAGER, SEL_CLAIM_TASK, true);
+
+        _validateExpectDenied(_op(TASK_MANAGER, SEL_CLAIM_TASK), TASK_MANAGER, SEL_CLAIM_TASK);
+
+        // Other selectors of the same target still resolve globally.
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_UNCLAIM_TASK, true, 0);
+        _validate(_op(TASK_MANAGER, SEL_UNCLAIM_TASK));
+
+        // Unblocking restores the fallback.
+        vm.prank(orgAdmin);
+        hub.setGlobalRuleBlock(ORG, TASK_MANAGER, SEL_CLAIM_TASK, false);
+        _validate(_op(TASK_MANAGER, SEL_CLAIM_TASK));
+    }
+
+    function testValidate_LocalRuleStillWins() public {
+        // Regression: pure local rule with no global machinery involved.
+        vm.prank(orgAdmin);
+        hub.setRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK, true, 0);
+        _validate(_op(TASK_MANAGER, SEL_CLAIM_TASK));
+    }
+
+    function testValidate_LocalAllowWinsOverBlock() public {
+        // An explicit local allow beats a global-rule block (block only vetoes the fallback).
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+        _mapTaskManager();
+        vm.startPrank(orgAdmin);
+        hub.setGlobalRuleBlock(ORG, TASK_MANAGER, SEL_CLAIM_TASK, true);
+        hub.setRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK, true, 0);
+        vm.stopPrank();
+        _validate(_op(TASK_MANAGER, SEL_CLAIM_TASK));
+    }
+
+    function testValidate_GlobalHintEnforced() public {
+        // Global hint caps callGasLimit exactly like a local hint.
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 50_000);
+        _mapTaskManager();
+
+        PackedUserOperation memory op = _op(TASK_MANAGER, SEL_CLAIM_TASK);
+        // callGas in _op is 100_000 > 50_000 hint
+        vm.prank(address(ep));
+        vm.expectRevert(PaymasterHubErrors.GasTooHigh.selector);
+        hub.validatePaymasterUserOp(op, bytes32(0), 0.001 ether);
+
+        // Raise the hint above callGas (100k) but BELOW verificationGas (300k) — must pass.
+        // A resolver comparing the wrong accountGasLimits half (300k > 150k) would revert here.
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 150_000);
+        _validate(_op(TASK_MANAGER, SEL_CLAIM_TASK));
+    }
+
+    function testValidate_GlobalRuleRemovalRevokes() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+        _mapTaskManager();
+        _validate(_op(TASK_MANAGER, SEL_CLAIM_TASK));
+
+        // Central kill-switch: removing the rulebook entry revokes sponsorship instantly.
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, false, 0);
+        _validateExpectDenied(_op(TASK_MANAGER, SEL_CLAIM_TASK), TASK_MANAGER, SEL_CLAIM_TASK);
+    }
+
+    function testValidate_UnknownSelectorStillDenied() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+        _mapTaskManager();
+        _validateExpectDenied(_op(TASK_MANAGER, SEL_UNCLAIM_TASK), TASK_MANAGER, SEL_UNCLAIM_TASK);
+    }
+
+    function testValidate_BatchInnerCallsResolveGlobal() public {
+        // Inner call 1 resolves via a LOCAL rule, inner call 2 via the GLOBAL rulebook.
+        vm.prank(orgAdmin);
+        hub.setRule(ORG, QUICK_JOIN, SEL_QUICK_JOIN, true, 0);
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+        _mapTaskManager();
+
+        _validate(_batchOp(QUICK_JOIN, SEL_QUICK_JOIN, TASK_MANAGER, SEL_CLAIM_TASK));
+
+        // If the global entry disappears, the whole batch is denied.
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, false, 0);
+        PackedUserOperation memory op = _batchOp(QUICK_JOIN, SEL_QUICK_JOIN, TASK_MANAGER, SEL_CLAIM_TASK);
+        _validateExpectDenied(op, TASK_MANAGER, SEL_CLAIM_TASK);
+    }
+
+    /*═══════════════════════ Adopt / snapshot (Static-org governance) ═══════════════════════*/
+
+    function testAdoptGlobalRules_CopiesEntry() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 77);
+        _mapTaskManager();
+
+        vm.expectEmit(true, true, true, true);
+        emit PaymasterHubErrors.RuleSet(ORG, TASK_MANAGER, SEL_CLAIM_TASK, true, 77);
+        vm.prank(orgAdmin);
+        hub.adoptGlobalRules(ORG, _oneAddr(TASK_MANAGER), _one4(SEL_CLAIM_TASK));
+
+        PaymasterHub.Rule memory local = hub.getRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK);
+        assertTrue(local.allowed);
+        assertEq(local.maxCallGasHint, 77);
+    }
+
+    function testAdoptGlobalRules_MissingGlobalReverts() public {
+        _mapTaskManager();
+        vm.prank(orgAdmin);
+        vm.expectRevert(PaymasterHubErrors.GlobalRuleUnknown.selector);
+        hub.adoptGlobalRules(ORG, _oneAddr(TASK_MANAGER), _one4(SEL_CLAIM_TASK));
+    }
+
+    function testAdoptGlobalRules_MissingTargetTypeReverts() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+        vm.prank(orgAdmin);
+        vm.expectRevert(PaymasterHubErrors.InvalidTypeId.selector);
+        hub.adoptGlobalRules(ORG, _oneAddr(TASK_MANAGER), _one4(SEL_CLAIM_TASK));
+    }
+
+    function testSnapshotGlobalRules_CopiesAllMatching() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 11);
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_UNCLAIM_TASK, true, 22);
+        _setGlobal(ModuleTypes.QUICK_JOIN_ID, SEL_QUICK_JOIN, true, 33);
+        _setGlobal(ModuleTypes.EDUCATION_HUB_ID, bytes4(keccak256("completeModule(uint256,uint8)")), true, 44);
+        _mapTaskManager();
+        vm.prank(orgAdmin);
+        hub.setTargetTypesBatch(ORG, _oneAddr(QUICK_JOIN), _one32(ModuleTypes.QUICK_JOIN_ID));
+
+        address[] memory targets = new address[](2);
+        targets[0] = TASK_MANAGER;
+        targets[1] = QUICK_JOIN;
+        vm.prank(orgAdmin);
+        hub.snapshotGlobalRules(ORG, targets);
+
+        assertEq(hub.getRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK).maxCallGasHint, 11);
+        assertEq(hub.getRule(ORG, TASK_MANAGER, SEL_UNCLAIM_TASK).maxCallGasHint, 22);
+        assertEq(hub.getRule(ORG, QUICK_JOIN, SEL_QUICK_JOIN).maxCallGasHint, 33);
+        assertTrue(hub.getRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK).allowed);
+        // The EducationHub entry has no matching target — nothing copied for it.
+        assertFalse(hub.getRule(ORG, TASK_MANAGER, bytes4(keccak256("completeModule(uint256,uint8)"))).allowed);
+    }
+
+    function testSnapshotThenStatic_KeepsSponsoring() public {
+        // The recommended "pin your paymaster rules" governance batch:
+        // snapshotGlobalRules + setRulesMode(Static) → sponsorship continues via local copies,
+        // and later global additions do NOT apply.
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+        _mapTaskManager();
+
+        vm.startPrank(orgAdmin);
+        hub.snapshotGlobalRules(ORG, _oneAddr(TASK_MANAGER));
+        hub.setRulesMode(ORG, MODE_STATIC);
+        vm.stopPrank();
+
+        _validate(_op(TASK_MANAGER, SEL_CLAIM_TASK));
+
+        // A new global rule added afterwards does not reach the Static org.
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_UNCLAIM_TASK, true, 0);
+        _validateExpectDenied(_op(TASK_MANAGER, SEL_UNCLAIM_TASK), TASK_MANAGER, SEL_UNCLAIM_TASK);
+    }
+
+    /*═══════════════════════ registerAndConfigureOrg wiring ═══════════════════════*/
+
+    function testRegisterAndConfigure_MirrorOrgResolvesGlobalImmediately() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+
+        bytes32 org2 = keccak256("MIRROR_ORG2");
+        _registerWithTypes(org2, MODE_MIRROR);
+
+        assertEq(hub.getRulesMode(org2), MODE_MIRROR);
+        assertEq(hub.getTargetType(org2, TASK_MANAGER), ModuleTypes.TASK_MANAGER_ID);
+        // Zero local rules were written…
+        assertFalse(hub.getRule(org2, TASK_MANAGER, SEL_CLAIM_TASK).allowed);
+        // …yet the op validates through the rulebook.
+        _validate(_opFor(org2, TASK_MANAGER, SEL_CLAIM_TASK));
+
+        // And a rule added later covers the org with NO further per-org action.
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_UNCLAIM_TASK, true, 0);
+        _validate(_opFor(org2, TASK_MANAGER, SEL_UNCLAIM_TASK));
+    }
+
+    function testRegisterAndConfigure_StaticOrgGetsSnapshot() public {
+        // Hint above the op's 100k callGas so the copied hint doesn't trip GasTooHigh.
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 150_000);
+
+        bytes32 org3 = keccak256("STATIC_ORG3");
+        _registerWithTypes(org3, MODE_STATIC);
+
+        assertEq(hub.getRulesMode(org3), MODE_STATIC);
+        // Deploy-time snapshot wrote a LOCAL copy of the rulebook entry.
+        PaymasterHub.Rule memory local = hub.getRule(org3, TASK_MANAGER, SEL_CLAIM_TASK);
+        assertTrue(local.allowed);
+        assertEq(local.maxCallGasHint, 150_000);
+        _validate(_opFor(org3, TASK_MANAGER, SEL_CLAIM_TASK));
+
+        // Later global additions do not reach the Static org…
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_UNCLAIM_TASK, true, 0);
+        _validateExpectDenied(_opFor(org3, TASK_MANAGER, SEL_UNCLAIM_TASK), TASK_MANAGER, SEL_UNCLAIM_TASK);
+    }
+
+    function testRegisterAndConfigure_InvalidModeReverts() public {
+        PaymasterRuleLib.DeployConfig memory config = _typeConfig(2);
+        vm.prank(poaManager);
+        vm.expectRevert(PaymasterHubErrors.InvalidRulesMode.selector);
+        hub.registerAndConfigureOrg(keccak256("BAD_MODE_ORG"), ADMIN_HAT, config);
+    }
+
+    function testRegisterAndConfigure_TypeArrayMismatchReverts() public {
+        PaymasterRuleLib.DeployConfig memory config = _typeConfig(MODE_MIRROR);
+        config.typeIds = new bytes32[](2); // mismatch vs 1 typeTarget
+        vm.prank(poaManager);
+        vm.expectRevert(PaymasterHubErrors.ArrayLengthMismatch.selector);
+        hub.registerAndConfigureOrg(keccak256("MISMATCH_TYPES_ORG"), ADMIN_HAT, config);
+    }
+
+    /*═══════════════════════ Lens parity ═══════════════════════*/
+
+    function testLens_EffectiveRuleOf() public {
+        // Denied
+        (bool allowed,, uint8 source) = lens.effectiveRuleOf(ORG, TASK_MANAGER, SEL_CLAIM_TASK);
+        assertFalse(allowed);
+        assertEq(source, 0);
+
+        // Global
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 42);
+        _mapTaskManager();
+        uint32 hint;
+        (allowed, hint, source) = lens.effectiveRuleOf(ORG, TASK_MANAGER, SEL_CLAIM_TASK);
+        assertTrue(allowed);
+        assertEq(hint, 42);
+        assertEq(source, 2);
+        assertTrue(lens.isAllowed(ORG, TASK_MANAGER, SEL_CLAIM_TASK));
+
+        // Local wins (different hint proves the source)
+        vm.prank(orgAdmin);
+        hub.setRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK, true, 43);
+        (allowed, hint, source) = lens.effectiveRuleOf(ORG, TASK_MANAGER, SEL_CLAIM_TASK);
+        assertTrue(allowed);
+        assertEq(hint, 43);
+        assertEq(source, 1);
+
+        // Blocked global (after clearing the local rule)
+        vm.startPrank(orgAdmin);
+        hub.clearRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK);
+        hub.setGlobalRuleBlock(ORG, TASK_MANAGER, SEL_CLAIM_TASK, true);
+        vm.stopPrank();
+        (allowed,, source) = lens.effectiveRuleOf(ORG, TASK_MANAGER, SEL_CLAIM_TASK);
+        assertFalse(allowed);
+        assertEq(source, 0);
+        assertFalse(lens.isAllowed(ORG, TASK_MANAGER, SEL_CLAIM_TASK));
+    }
+
+    function testLens_WouldValidateAgreesWithHub() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+        _mapTaskManager();
+
+        (bool valid, string memory reason) = lens.wouldValidate(ORG, _op(TASK_MANAGER, SEL_CLAIM_TASK), 0.001 ether);
+        assertTrue(valid, reason);
+
+        // Static flip: the predictor must deny exactly like the hub.
+        vm.prank(orgAdmin);
+        hub.setRulesMode(ORG, MODE_STATIC);
+        (valid, reason) = lens.wouldValidate(ORG, _op(TASK_MANAGER, SEL_CLAIM_TASK), 0.001 ether);
+        assertFalse(valid);
+        assertEq(reason, "RuleDenied");
+    }
+
+    /*═══════════════════════ Legacy ABI (live OrgDeployer compatibility) ═══════════════════════*/
+
+    /// @dev The deployed OrgDeployer proxies call the pre-rulebook 13-field selector. The v20
+    ///      hub must keep serving it (legacy overload) or org deployment bricks between the hub
+    ///      upgrade and a deployer upgrade.
+    function testLegacyRegisterAndConfigure_OldSelectorServed() public {
+        bytes4 legacySel = bytes4(
+            keccak256(
+                "registerAndConfigureOrg(bytes32,uint256,(uint256,uint256,uint256,uint32,uint32,uint32,address[],bytes4[],bool[],uint32[],bytes32[],uint128[],uint32[]))"
+            )
+        );
+        // Pin the exact selector the live OrgDeployer bytecode emits.
+        assertEq(legacySel, bytes4(0xc6f422d9), "legacy selector drifted from live OrgDeployer ABI");
+
+        bytes32 org2 = keccak256("LEGACY_ABI_ORG");
+        bytes32 subjectKey = keccak256(abi.encodePacked(SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(user)))));
+
+        PaymasterRuleLib.LegacyDeployConfig memory cfg;
+        cfg.ruleTargets = _oneAddr(TASK_MANAGER);
+        cfg.ruleSelectors = _one4(SEL_CLAIM_TASK);
+        cfg.ruleAllowed = _oneBool(true);
+        cfg.ruleMaxCallGasHints = _oneU32(0);
+        cfg.budgetSubjectKeys = _one32(subjectKey);
+        cfg.budgetCapsPerEpoch = new uint128[](1);
+        cfg.budgetCapsPerEpoch[0] = 1 ether;
+        cfg.budgetEpochLens = new uint32[](1);
+        cfg.budgetEpochLens[0] = 7 days;
+
+        vm.prank(poaManager);
+        (bool ok,) = address(hub).call(abi.encodeWithSelector(legacySel, org2, ADMIN_HAT, cfg));
+        assertTrue(ok, "legacy registerAndConfigureOrg reverted -- live OrgDeployer would brick");
+
+        // Pre-rulebook behavior: org registered, LOCAL rule + budget applied, no types, Mirror.
+        assertEq(hub.getOrgConfig(org2).adminHatId, ADMIN_HAT);
+        assertTrue(hub.getRule(org2, TASK_MANAGER, SEL_CLAIM_TASK).allowed, "legacy local rule not seeded");
+        assertEq(hub.getBudget(org2, subjectKey).capPerEpoch, 1 ether, "legacy budget not applied");
+        assertEq(hub.getRulesMode(org2), MODE_MIRROR);
+        assertEq(hub.getTargetType(org2, TASK_MANAGER), bytes32(0), "legacy path must not register types");
+
+        // And the legacy-seeded org validates through its local rule.
+        _validate(_opFor(org2, TASK_MANAGER, SEL_CLAIM_TASK));
+    }
+
+    /*═══════════════════════ Explicit deny / reset semantics ═══════════════════════*/
+
+    function testSetRuleFalse_ExplicitlyDeniesGlobal() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+        _mapTaskManager();
+        _validate(_op(TASK_MANAGER, SEL_CLAIM_TASK)); // sponsored via rulebook
+
+        // setRule(false) is an EXPLICIT DENY: it must actually revoke for a Mirror org
+        // (blocks the global fallback too), not silently fall through to the rulebook.
+        vm.prank(orgAdmin);
+        hub.setRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK, false, 0);
+        assertTrue(hub.isGlobalRuleBlocked(ORG, TASK_MANAGER, SEL_CLAIM_TASK), "explicit deny must block fallback");
+        _validateExpectDenied(_op(TASK_MANAGER, SEL_CLAIM_TASK), TASK_MANAGER, SEL_CLAIM_TASK);
+
+        // Re-allowing clears the standing block.
+        vm.prank(orgAdmin);
+        hub.setRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK, true, 0);
+        assertFalse(hub.isGlobalRuleBlocked(ORG, TASK_MANAGER, SEL_CLAIM_TASK), "fresh allow must clear the block");
+        _validate(_op(TASK_MANAGER, SEL_CLAIM_TASK));
+    }
+
+    function testClearRule_ResetsToProtocolDefault() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+        _mapTaskManager();
+
+        vm.prank(orgAdmin);
+        hub.setRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK, true, 150_000);
+        _validate(_op(TASK_MANAGER, SEL_CLAIM_TASK)); // local
+
+        // clearRule = reset to protocol default: the pair falls BACK to the rulebook
+        // (documented Mirror-org footgun — pinned here on the hub, not just the Lens).
+        vm.prank(orgAdmin);
+        hub.clearRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK);
+        (bool allowed,, uint8 source) = lens.effectiveRuleOf(ORG, TASK_MANAGER, SEL_CLAIM_TASK);
+        assertTrue(allowed, "cleared pair must fall back to the global rulebook");
+        assertEq(source, 2);
+        _validate(_op(TASK_MANAGER, SEL_CLAIM_TASK));
+
+        // clearRule after an explicit deny also resets (removes the block).
+        vm.prank(orgAdmin);
+        hub.setRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK, false, 0);
+        _validateExpectDenied(_op(TASK_MANAGER, SEL_CLAIM_TASK), TASK_MANAGER, SEL_CLAIM_TASK);
+        vm.prank(orgAdmin);
+        hub.clearRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK);
+        assertFalse(hub.isGlobalRuleBlocked(ORG, TASK_MANAGER, SEL_CLAIM_TASK), "clear must remove the block");
+        _validate(_op(TASK_MANAGER, SEL_CLAIM_TASK));
+    }
+
+    /*═══════════════════════ Snapshot / deploy-config edge semantics ═══════════════════════*/
+
+    function testSnapshotOverwritesCustomLocalHint() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 200_000);
+        _mapTaskManager();
+        vm.prank(orgAdmin);
+        hub.setRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK, true, 50_000); // stricter custom hint
+
+        // Documented catch-up semantics: snapshot unconditionally overwrites with the global copy.
+        vm.prank(orgAdmin);
+        hub.snapshotGlobalRules(ORG, _oneAddr(TASK_MANAGER));
+        assertEq(
+            hub.getRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK).maxCallGasHint,
+            200_000,
+            "snapshot must overwrite a customized local hint"
+        );
+    }
+
+    function testDeployConfig_ExplicitRulesOverrideSnapshot() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 111);
+
+        PaymasterRuleLib.DeployConfig memory config = _typeConfig(MODE_STATIC);
+        config.ruleTargets = _oneAddr(TASK_MANAGER);
+        config.ruleSelectors = _one4(SEL_CLAIM_TASK);
+        config.ruleAllowed = _oneBool(true);
+        config.ruleMaxCallGasHints = _oneU32(222);
+
+        bytes32 org2 = keccak256("EXPLICIT_OVERRIDE_ORG");
+        vm.prank(poaManager);
+        hub.registerAndConfigureOrg(org2, ADMIN_HAT, config);
+
+        // Explicit deploy-time rules are applied AFTER the Static snapshot and must win.
+        assertEq(
+            hub.getRule(org2, TASK_MANAGER, SEL_CLAIM_TASK).maxCallGasHint,
+            222,
+            "explicit deploy rule must override the snapshot copy"
+        );
+    }
+
+    /*═══════════════════════ Isolation / mode / batch edges ═══════════════════════*/
+
+    function testCrossOrgIsolation_SharedTarget() public {
+        // The same physical address (a shared registry) typed by org A only: org B's resolution
+        // for that address must be unaffected by anything org A does.
+        _setGlobal(ModuleTypes.UNIVERSAL_ACCOUNT_REGISTRY_ID, SEL_QUICK_JOIN, true, 0);
+        address sharedReg = address(0x5EE9);
+        bytes32 orgB = keccak256("ISOLATION_ORG_B");
+        _registerWithTypes(orgB, MODE_MIRROR); // types TASK_MANAGER only, not sharedReg
+
+        vm.prank(orgAdmin);
+        hub.setTargetTypesBatch(ORG, _oneAddr(sharedReg), _one32(ModuleTypes.UNIVERSAL_ACCOUNT_REGISTRY_ID));
+
+        assertTrue(lens.isAllowed(ORG, sharedReg, SEL_QUICK_JOIN), "org A should resolve via rulebook");
+        assertFalse(lens.isAllowed(orgB, sharedReg, SEL_QUICK_JOIN), "org B must NOT inherit org A's typing");
+        _validate(_op(sharedReg, SEL_QUICK_JOIN));
+        _validateExpectDenied(_opFor(orgB, sharedReg, SEL_QUICK_JOIN), sharedReg, SEL_QUICK_JOIN);
+
+        // Org A's block is equally org-scoped.
+        vm.prank(orgAdmin);
+        hub.setGlobalRuleBlock(ORG, sharedReg, SEL_QUICK_JOIN, true);
+        _validateExpectDenied(_op(sharedReg, SEL_QUICK_JOIN), sharedReg, SEL_QUICK_JOIN);
+        assertFalse(hub.isGlobalRuleBlocked(orgB, sharedReg, SEL_QUICK_JOIN), "block must not leak across orgs");
+    }
+
+    function testCoarseMode_SenderScopedResolution() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+        _mapTaskManager();
+
+        // Coarse mode checks (sender, outer selector). The sender has no typeId mapping, so the
+        // TASK_MANAGER rulebook entry must NOT apply — fail-closed.
+        PackedUserOperation memory op =
+            _rawOpWithRuleId(ORG, abi.encodeWithSelector(SEL_CLAIM_TASK, uint256(1)), 0x000000FF);
+        _validateExpectDenied(op, user, SEL_CLAIM_TASK);
+
+        // A local rule keyed on the SENDER allows coarse ops (pre-existing behavior).
+        vm.prank(orgAdmin);
+        hub.setRule(ORG, user, SEL_CLAIM_TASK, true, 0);
+        _validate(op);
+
+        // Typing the sender address (unusual but legal) resolves coarse via the rulebook too.
+        vm.startPrank(orgAdmin);
+        hub.clearRule(ORG, user, SEL_CLAIM_TASK);
+        hub.setTargetTypesBatch(ORG, _oneAddr(user), _one32(ModuleTypes.TASK_MANAGER_ID));
+        vm.stopPrank();
+        _validate(op);
+    }
+
+    function testBatch_RawInnerCallDenied() public {
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+        _mapTaskManager();
+
+        // Inner call with <4-byte data resolves as selector bytes4(0) — no rulebook entry uses
+        // it (DefaultGlobalRules has none), so a raw ETH transfer inside a batch stays denied
+        // even when the target itself is typed.
+        address[] memory targets = new address[](2);
+        targets[0] = TASK_MANAGER;
+        targets[1] = TASK_MANAGER;
+        uint256[] memory values = new uint256[](2);
+        bytes[] memory datas = new bytes[](2);
+        datas[0] = abi.encodeWithSelector(SEL_CLAIM_TASK, uint256(1));
+        datas[1] = ""; // raw transfer -> bytes4(0)
+        bytes memory callData =
+            abi.encodeWithSignature("executeBatch(address[],uint256[],bytes[])", targets, values, datas);
+        _validateExpectDenied(_rawOp(ORG, callData), TASK_MANAGER, bytes4(0));
+    }
+
+    /*═══════════════════════ Seed-list accuracy (reads DefaultGlobalRules itself) ═══════════════════════*/
+
+    /// @dev Bijection check between DefaultGlobalRules.entries() and the REAL contract
+    ///      selectors (`X.f.selector`, resolved by the compiler — not re-derived strings).
+    ///      A typo'd signature string in the seed file fails here.
+    function testDefaultGlobalRules_MatchRealContractSelectors() public {
+        DefaultGlobalRules.Entry[] memory e = DefaultGlobalRules.entries();
+        bytes32[] memory expected = _expectedRulebookPairs();
+        assertEq(e.length, expected.length, "rulebook entry count drifted");
+
+        for (uint256 i = 0; i < e.length; i++) {
+            bytes32 pair = keccak256(abi.encodePacked(e[i].typeId, e[i].selector));
+            bool found;
+            for (uint256 j = 0; j < expected.length; j++) {
+                if (expected[j] == pair) {
+                    expected[j] = bytes32(0); // consume: catches duplicates too
+                    found = true;
+                    break;
+                }
+            }
+            assertTrue(found, "rulebook entry does not match any real contract selector (typo?)");
+        }
+    }
+
+    function _expectedRulebookPairs() internal pure returns (bytes32[] memory p) {
+        p = new bytes32[](52);
+        uint256 n;
+        bytes32 t = ModuleTypes.QUICK_JOIN_ID;
+        p[n++] = _pair(t, QuickJoin.quickJoinWithUser.selector);
+        p[n++] = _pair(t, QuickJoin.registerAndQuickJoin.selector);
+        p[n++] = _pair(t, QuickJoin.registerAndQuickJoinWithPasskey.selector);
+        p[n++] = _pair(t, QuickJoin.claimHatsWithUser.selector);
+        p[n++] = _pair(t, QuickJoin.registerAndClaimHats.selector);
+        p[n++] = _pair(t, QuickJoin.registerAndClaimHatsWithPasskey.selector);
+        t = ModuleTypes.TASK_MANAGER_ID;
+        p[n++] = _pair(t, TaskManager.createTask.selector);
+        p[n++] = _pair(t, TaskManager.createTasksBatch.selector);
+        p[n++] = _pair(t, TaskManager.claimTask.selector);
+        p[n++] = _pair(t, TaskManager.unclaimTask.selector);
+        p[n++] = _pair(t, TaskManager.submitTask.selector);
+        p[n++] = _pair(t, TaskManager.completeTask.selector);
+        p[n++] = _pair(t, TaskManager.applyForTask.selector);
+        p[n++] = _pair(t, TaskManager.approveApplication.selector);
+        p[n++] = _pair(t, TaskManager.assignTask.selector);
+        p[n++] = _pair(t, TaskManager.rejectTask.selector);
+        p[n++] = _pair(t, TaskManager.cancelTask.selector);
+        p[n++] = _pair(t, TaskManager.createAndAssignTask.selector);
+        p[n++] = _pair(t, TaskManager.createProject.selector);
+        p[n++] = _pair(t, TaskManager.deleteProject.selector);
+        p[n++] = _pair(t, TaskManager.setFolders.selector);
+        p[n++] = _pair(t, TaskManager.updateTask.selector);
+        p[n++] = _pair(t, TaskManager.updateTaskMetadata.selector);
+        p[n++] = _pair(ModuleTypes.HYBRID_VOTING_ID, HybridVoting.vote.selector);
+        p[n++] = _pair(ModuleTypes.HYBRID_VOTING_ID, HybridVoting.announceWinner.selector);
+        p[n++] = _pair(ModuleTypes.HYBRID_VOTING_ID, HybridVoting.createProposal.selector);
+        p[n++] = _pair(ModuleTypes.DIRECT_DEMOCRACY_VOTING_ID, DirectDemocracyVoting.vote.selector);
+        p[n++] = _pair(ModuleTypes.DIRECT_DEMOCRACY_VOTING_ID, DirectDemocracyVoting.announceWinner.selector);
+        p[n++] = _pair(ModuleTypes.DIRECT_DEMOCRACY_VOTING_ID, DirectDemocracyVoting.createProposal.selector);
+        t = ModuleTypes.PAYMENT_MANAGER_ID;
+        p[n++] = _pair(t, PaymentManager.claimDistribution.selector);
+        p[n++] = _pair(t, PaymentManager.claimMultiple.selector);
+        p[n++] = _pair(t, PaymentManager.optOut.selector);
+        p[n++] = _pair(t, PaymentManager.createDistribution.selector);
+        p[n++] = _pair(t, PaymentManager.finalizeDistribution.selector);
+        t = ModuleTypes.ELIGIBILITY_MODULE_ID;
+        p[n++] = _pair(t, EligibilityModule.claimVouchedHat.selector);
+        p[n++] = _pair(t, EligibilityModule.vouchFor.selector);
+        p[n++] = _pair(t, EligibilityModule.revokeVouch.selector);
+        p[n++] = _pair(t, EligibilityModule.applyForRole.selector);
+        p[n++] = _pair(t, EligibilityModule.withdrawApplication.selector);
+        t = ModuleTypes.PARTICIPATION_TOKEN_ID;
+        p[n++] = _pair(t, ParticipationToken.requestTokens.selector);
+        p[n++] = _pair(t, ParticipationToken.approveRequest.selector);
+        p[n++] = _pair(t, ParticipationToken.cancelRequest.selector);
+        p[n++] = _pair(ModuleTypes.UNIVERSAL_ACCOUNT_REGISTRY_ID, UniversalAccountRegistry.setProfileMetadata.selector);
+        p[n++] = _pair(ModuleTypes.ORG_REGISTRY_ID, OrgRegistry.updateOrgMetaAsAdmin.selector);
+        t = ModuleTypes.EDUCATION_HUB_ID;
+        p[n++] = _pair(t, EducationHub.completeModule.selector);
+        p[n++] = _pair(t, EducationHub.createModule.selector);
+        p[n++] = _pair(t, EducationHub.updateModule.selector);
+        p[n++] = _pair(t, EducationHub.removeModule.selector);
+        t = ModuleTypes.ZKEMAIL_INVITES_ID;
+        p[n++] = _pair(t, ZkEmailInvites.claimRoleByDomain.selector);
+        p[n++] = _pair(t, ZkEmailInvites.claimRoleByEmail.selector);
+        p[n++] = _pair(t, ZkEmailInvites.registerAndClaimByDomainWithPasskey.selector);
+        p[n++] = _pair(t, ZkEmailInvites.registerAndClaimByEmailWithPasskey.selector);
+        require(n == p.length, "expected-pair count mismatch");
+    }
+
+    function _pair(bytes32 typeId, bytes4 selector) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(typeId, selector));
+    }
+
+    /*═══════════════════════ Differential Lens-vs-hub parity ═══════════════════════*/
+
+    /// @dev The Lens's _effectiveRule is a hand-mirrored copy of PaymasterRuleLib._resolveRule.
+    ///      Drive BOTH through every resolution state and require identical outcomes — a
+    ///      divergence in either copy fails here regardless of which one is "right".
+    function testLens_DifferentialAgainstHub() public {
+        // Deposit so grace/solidarity limits never bound the repeated validations below.
+        hub.depositForOrg{value: 1 ether}(ORG);
+
+        _setGlobal(ModuleTypes.TASK_MANAGER_ID, SEL_CLAIM_TASK, true, 0);
+        _mapTaskManager();
+        PackedUserOperation memory op = _op(TASK_MANAGER, SEL_CLAIM_TASK);
+
+        _assertLensMatchesHub(op, true); // global allowed
+        _assertLensMatchesHub(_op(TASK_MANAGER, SEL_UNCLAIM_TASK), false); // no rulebook entry
+
+        vm.prank(orgAdmin);
+        hub.setGlobalRuleBlock(ORG, TASK_MANAGER, SEL_CLAIM_TASK, true);
+        _assertLensMatchesHub(op, false); // blocked
+
+        vm.prank(orgAdmin);
+        hub.setRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK, true, 0);
+        _assertLensMatchesHub(op, true); // local allow wins over block
+
+        vm.prank(orgAdmin);
+        hub.clearRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK);
+        _assertLensMatchesHub(op, true); // clear resets block -> global again
+
+        vm.prank(orgAdmin);
+        hub.setRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK, false, 0);
+        _assertLensMatchesHub(op, false); // explicit deny
+
+        vm.startPrank(orgAdmin);
+        hub.clearRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK);
+        hub.setRulesMode(ORG, MODE_STATIC);
+        vm.stopPrank();
+        _assertLensMatchesHub(op, false); // static ignores global
+
+        vm.prank(orgAdmin);
+        hub.setRulesMode(ORG, MODE_MIRROR);
+        _assertLensMatchesHub(op, true);
+    }
+
+    function _assertLensMatchesHub(PackedUserOperation memory op, bool expected) internal {
+        (bool lensValid,) = lens.wouldValidate(ORG, op, 0.001 ether);
+        vm.prank(address(ep));
+        (bool hubOk,) =
+            address(hub).call(abi.encodeCall(PaymasterHub.validatePaymasterUserOp, (op, bytes32(0), 0.001 ether)));
+        assertEq(lensValid, hubOk, "lens/hub resolution divergence");
+        assertEq(hubOk, expected, "hub outcome differs from scenario expectation");
+    }
+
+    /*═══════════════════════ Helpers ═══════════════════════*/
+
+    function _setGlobal(bytes32 typeId, bytes4 selector, bool allowed, uint32 hint) internal {
+        vm.prank(poaManager);
+        hub.setGlobalRulesBatch(_one32(typeId), _one4(selector), _oneBool(allowed), _oneU32(hint));
+    }
+
+    function _mapTaskManager() internal {
+        vm.prank(orgAdmin);
+        hub.setTargetTypesBatch(ORG, _oneAddr(TASK_MANAGER), _one32(ModuleTypes.TASK_MANAGER_ID));
+    }
+
+    /// @dev Run validation as the EntryPoint; asserts success by absence of revert.
+    function _validate(PackedUserOperation memory op) internal {
+        vm.prank(address(ep));
+        (, uint256 validationData) = hub.validatePaymasterUserOp(op, bytes32(0), 0.001 ether);
+        assertEq(validationData, 0);
+    }
+
+    /// @dev Run validation as the EntryPoint expecting RuleDenied(target, selector).
+    function _validateExpectDenied(PackedUserOperation memory op, address target, bytes4 selector) internal {
+        vm.prank(address(ep));
+        vm.expectRevert(abi.encodeWithSelector(PaymasterHubErrors.RuleDenied.selector, target, selector));
+        hub.validatePaymasterUserOp(op, bytes32(0), 0.001 ether);
+    }
+
+    function _op(address target, bytes4 selector) internal view returns (PackedUserOperation memory) {
+        return _opFor(ORG, target, selector);
+    }
+
+    function _opFor(bytes32 orgId, address target, bytes4 selector) internal view returns (PackedUserOperation memory) {
+        bytes memory innerCall = abi.encodeWithSelector(selector);
+        bytes memory callData = abi.encodeWithSignature("execute(address,uint256,bytes)", target, 0, innerCall);
+        return _rawOp(orgId, callData);
+    }
+
+    function _batchOp(address t1, bytes4 s1, address t2, bytes4 s2) internal view returns (PackedUserOperation memory) {
+        address[] memory targets = new address[](2);
+        targets[0] = t1;
+        targets[1] = t2;
+        uint256[] memory values = new uint256[](2);
+        bytes[] memory datas = new bytes[](2);
+        datas[0] = abi.encodeWithSelector(s1);
+        datas[1] = abi.encodeWithSelector(s2);
+        bytes memory callData =
+            abi.encodeWithSignature("executeBatch(address[],uint256[],bytes[])", targets, values, datas);
+        return _rawOp(ORG, callData);
+    }
+
+    function _rawOp(bytes32 orgId, bytes memory callData) internal view returns (PackedUserOperation memory) {
+        return _rawOpWithRuleId(orgId, callData, 0);
+    }
+
+    function _rawOpWithRuleId(bytes32 orgId, bytes memory callData, uint32 ruleId)
+        internal
+        view
+        returns (PackedUserOperation memory)
+    {
+        // Asymmetric on purpose: verificationGas != callGas so any hint/cap check comparing the
+        // WRONG half of accountGasLimits (the historical deployed-hub unpack swap) fails tests.
+        uint128 verificationGas = 300_000;
+        uint128 callGas = 100_000;
+        uint128 pmVerificationGas = 200_000;
+        uint128 pmPostOpGas = 100_000;
+
+        bytes memory paymasterData =
+            abi.encodePacked(uint8(1), orgId, SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(user))), ruleId, uint64(0));
+
+        return PackedUserOperation({
+            sender: user,
+            nonce: 0,
+            initCode: "",
+            callData: callData,
+            accountGasLimits: bytes32(uint256(verificationGas) << 128 | uint256(callGas)),
+            preVerificationGas: 50_000,
+            gasFees: bytes32(uint256(1 gwei) << 128 | uint256(1 gwei)),
+            paymasterAndData: abi.encodePacked(address(hub), pmVerificationGas, pmPostOpGas, paymasterData),
+            signature: ""
+        });
+    }
+
+    /// @dev Register `orgId` through the registrar path with TASK_MANAGER mapped and the given
+    ///      rules mode, plus a max budget for `user` so rule checks stay the binding constraint.
+    function _registerWithTypes(bytes32 orgId, uint8 mode) internal {
+        PaymasterRuleLib.DeployConfig memory config = _typeConfig(mode);
+        vm.prank(poaManager);
+        hub.registerAndConfigureOrg(orgId, ADMIN_HAT, config);
+
+        bytes32 subjectKey = keccak256(abi.encodePacked(SUBJECT_TYPE_ACCOUNT, bytes32(uint256(uint160(user)))));
+        vm.prank(orgAdmin);
+        hub.setBudget(orgId, subjectKey, type(uint128).max, 7 days);
+    }
+
+    function _typeConfig(uint8 mode) internal pure returns (PaymasterRuleLib.DeployConfig memory) {
+        return PaymasterRuleLib.DeployConfig({
+            operatorHatId: 0,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            maxCallGas: 0,
+            maxVerificationGas: 0,
+            maxPreVerificationGas: 0,
+            ruleTargets: new address[](0),
+            ruleSelectors: new bytes4[](0),
+            ruleAllowed: new bool[](0),
+            ruleMaxCallGasHints: new uint32[](0),
+            budgetSubjectKeys: new bytes32[](0),
+            budgetCapsPerEpoch: new uint128[](0),
+            budgetEpochLens: new uint32[](0),
+            typeTargets: _oneAddr(TASK_MANAGER),
+            typeIds: _one32(ModuleTypes.TASK_MANAGER_ID),
+            rulesMode: mode
+        });
+    }
+
+    // ── tiny array builders ──
+    function _one32(bytes32 v) internal pure returns (bytes32[] memory a) {
+        a = new bytes32[](1);
+        a[0] = v;
+    }
+
+    function _one4(bytes4 v) internal pure returns (bytes4[] memory a) {
+        a = new bytes4[](1);
+        a[0] = v;
+    }
+
+    function _oneBool(bool v) internal pure returns (bool[] memory a) {
+        a = new bool[](1);
+        a[0] = v;
+    }
+
+    function _oneU32(uint32 v) internal pure returns (uint32[] memory a) {
+        a = new uint32[](1);
+        a[0] = v;
+    }
+
+    function _oneAddr(address v) internal pure returns (address[] memory a) {
+        a = new address[](1);
+        a[0] = v;
+    }
+}

--- a/test/PaymasterGlobalRules.t.sol
+++ b/test/PaymasterGlobalRules.t.sol
@@ -761,6 +761,43 @@ contract PaymasterGlobalRulesTest is Test {
         _validateExpectDenied(_rawOp(ORG, callData), TASK_MANAGER, bytes4(0));
     }
 
+    /*═══════════════════════ adminBatchAddRules event parity ═══════════════════════*/
+
+    /// @notice adminBatchAddRules must EMIT RuleSet for every write (the old inline write was
+    ///         event-less — subgraph-invisible state) and share writeLocalRule's allow
+    ///         semantics: a fresh allow clears any standing global-rule block for the pair.
+    ///         Unregistered orgs are still skipped silently (no write, no event).
+    function testAdminBatchAddRules_EmitsAndClearsBlocks() public {
+        // Standing block from an earlier explicit deny — the batch allow must clear it.
+        vm.prank(orgAdmin);
+        hub.setGlobalRuleBlock(ORG, TASK_MANAGER, SEL_CLAIM_TASK, true);
+
+        bytes32[] memory orgIds = new bytes32[](2);
+        address[] memory targets = new address[](2);
+        bytes4[] memory selectors = new bytes4[](2);
+        orgIds[0] = ORG;
+        targets[0] = TASK_MANAGER;
+        selectors[0] = SEL_CLAIM_TASK;
+        orgIds[1] = keccak256("NEVER_REGISTERED_ORG"); // must be skipped: no write, no event
+        targets[1] = TASK_MANAGER;
+        selectors[1] = SEL_CLAIM_TASK;
+
+        vm.expectEmit(true, true, true, true);
+        emit PaymasterHubErrors.RuleSet(ORG, TASK_MANAGER, SEL_CLAIM_TASK, true, 0);
+        vm.expectEmit(true, true, true, true);
+        emit PaymasterHubErrors.GlobalRuleBlockSet(ORG, TASK_MANAGER, SEL_CLAIM_TASK, false);
+        vm.prank(poaManager);
+        hub.adminBatchAddRules(orgIds, targets, selectors);
+
+        assertTrue(hub.getRule(ORG, TASK_MANAGER, SEL_CLAIM_TASK).allowed);
+        assertFalse(hub.isGlobalRuleBlocked(ORG, TASK_MANAGER, SEL_CLAIM_TASK), "batch allow must clear the block");
+        assertFalse(
+            hub.getRule(keccak256("NEVER_REGISTERED_ORG"), TASK_MANAGER, SEL_CLAIM_TASK).allowed,
+            "unregistered org must be skipped"
+        );
+        _validate(_op(TASK_MANAGER, SEL_CLAIM_TASK));
+    }
+
     /*═══════════════════════ Pre-v20 explicit-denial preservation (P1) ═══════════════════════*/
 
     /// @dev Storage slot of rules[ORG][target][selector] — used to plant PRE-v20 state that the

--- a/test/PaymasterGracePeriod.t.sol
+++ b/test/PaymasterGracePeriod.t.sol
@@ -5,6 +5,7 @@ import "forge-std/Test.sol";
 import "forge-std/console.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {PaymasterHub} from "../src/PaymasterHub.sol";
+import {PaymasterRuleLib} from "../src/libs/PaymasterRuleLib.sol";
 import {IPaymaster} from "../src/interfaces/IPaymaster.sol";
 import {IEntryPoint} from "../src/interfaces/IEntryPoint.sol";
 import {PackedUserOperation} from "../src/interfaces/PackedUserOperation.sol";
@@ -92,7 +93,7 @@ contract PaymasterGracePeriodTest is Test {
         budgetCaps[0] = BUDGET_CAP;
         budgetEpochLens[0] = BUDGET_EPOCH_LEN;
 
-        PaymasterHub.DeployConfig memory config = PaymasterHub.DeployConfig({
+        PaymasterRuleLib.DeployConfig memory config = PaymasterRuleLib.DeployConfig({
             operatorHatId: 0,
             maxFeePerGas: 100 gwei,
             maxPriorityFeePerGas: 100 gwei,
@@ -105,7 +106,10 @@ contract PaymasterGracePeriodTest is Test {
             ruleMaxCallGasHints: gasHints,
             budgetSubjectKeys: budgetKeys,
             budgetCapsPerEpoch: budgetCaps,
-            budgetEpochLens: budgetEpochLens
+            budgetEpochLens: budgetEpochLens,
+            typeTargets: new address[](0),
+            typeIds: new bytes32[](0),
+            rulesMode: 0
         });
 
         // Register and configure org (as registrar, this sets rules/budgets/caps)
@@ -909,7 +913,7 @@ contract PaymasterGracePeriodTest is Test {
         budgetCaps[0] = BUDGET_CAP;
         budgetEpochLens[0] = BUDGET_EPOCH_LEN;
 
-        PaymasterHub.DeployConfig memory config = PaymasterHub.DeployConfig({
+        PaymasterRuleLib.DeployConfig memory config = PaymasterRuleLib.DeployConfig({
             operatorHatId: 0,
             maxFeePerGas: 100 gwei,
             maxPriorityFeePerGas: 100 gwei,
@@ -922,7 +926,10 @@ contract PaymasterGracePeriodTest is Test {
             ruleMaxCallGasHints: gasHints,
             budgetSubjectKeys: budgetKeys,
             budgetCapsPerEpoch: budgetCaps,
-            budgetEpochLens: budgetEpochLens
+            budgetEpochLens: budgetEpochLens,
+            typeTargets: new address[](0),
+            typeIds: new bytes32[](0),
+            rulesMode: 0
         });
 
         pm2.registerAndConfigureOrg{value: 0.1 ether}(orgId2, ADMIN_HAT, config);
@@ -999,7 +1006,7 @@ contract PaymasterGracePeriodTest is Test {
         budgetCaps[0] = BUDGET_CAP;
         budgetEpochLens[0] = BUDGET_EPOCH_LEN;
 
-        PaymasterHub.DeployConfig memory config = PaymasterHub.DeployConfig({
+        PaymasterRuleLib.DeployConfig memory config = PaymasterRuleLib.DeployConfig({
             operatorHatId: 0,
             maxFeePerGas: 100 gwei,
             maxPriorityFeePerGas: 100 gwei,
@@ -1012,7 +1019,10 @@ contract PaymasterGracePeriodTest is Test {
             ruleMaxCallGasHints: gasHints,
             budgetSubjectKeys: budgetKeys,
             budgetCapsPerEpoch: budgetCaps,
-            budgetEpochLens: budgetEpochLens
+            budgetEpochLens: budgetEpochLens,
+            typeTargets: new address[](0),
+            typeIds: new bytes32[](0),
+            rulesMode: 0
         });
 
         // Register WITHOUT deposit

--- a/test/ZkEmailOrgFlow.t.sol
+++ b/test/ZkEmailOrgFlow.t.sol
@@ -35,6 +35,7 @@ import {EligibilityModule} from "../src/EligibilityModule.sol";
 import {RoleConfigStructs} from "../src/libs/RoleConfigStructs.sol";
 import {IHybridVotingInit} from "../src/libs/ModuleDeploymentLib.sol";
 import {PaymasterHub} from "../src/PaymasterHub.sol";
+import {PaymasterHubLens} from "../src/PaymasterHubLens.sol";
 
 /*──────────────────────────────  Mocks  ──────────────────────────────*/
 
@@ -432,47 +433,47 @@ contract ZkEmailOrgFlowTest is DeployerTest {
         _wireZkInfra();
 
         // Deploy with autoWhitelistContracts = true and assert that all FOUR ZkEmailInvites claim
-        // selectors are now allowed rules on PaymasterHub for our org. These four selector strings
-        // are copied verbatim from OrgDeployer._appendZkEmailInvitesRules.
+        // selectors resolve as allowed for our org via the global rulebook (the module gets the
+        // ZKEMAIL_INVITES_ID target type at deploy; selector strings live in DefaultGlobalRules).
         OrgDeployer.DeploymentResult memory result = _deployZkOrgWithPaymaster(ZK_ORG_ID);
-
-        bytes4 selClaimDomain = bytes4(
-            keccak256(
-                "claimRoleByDomain((uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string),address,uint256[],bytes32[])"
-            )
+        assertEq(
+            paymasterHub.getTargetType(ZK_ORG_ID, result.zkEmailInvites),
+            ModuleTypes.ZKEMAIL_INVITES_ID,
+            "zkEmailInvites target type registered at deploy"
         );
-        bytes4 selClaimEmail = bytes4(
-            keccak256(
-                "claimRoleByEmail((uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string,bytes32),address,uint256[],bytes32[])"
-            )
-        );
-        bytes4 selRegisterClaimDomain = bytes4(
-            keccak256(
-                "registerAndClaimByDomainWithPasskey((bytes32,bytes32,bytes32,uint256),string,uint256,uint256,(bytes,bytes,uint256,uint256,bytes32,bytes32),(uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string),uint256[],bytes32[])"
-            )
-        );
-        bytes4 selRegisterClaimEmail = bytes4(
-            keccak256(
-                "registerAndClaimByEmailWithPasskey((bytes32,bytes32,bytes32,uint256),string,uint256,uint256,(bytes,bytes,uint256,uint256,bytes32,bytes32),(uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string,bytes32),uint256[],bytes32[])"
-            )
-        );
+        _seedGlobalRulebook();
 
-        PaymasterHub.Rule memory rClaimDomain = paymasterHub.getRule(ZK_ORG_ID, result.zkEmailInvites, selClaimDomain);
-        PaymasterHub.Rule memory rClaimEmail = paymasterHub.getRule(ZK_ORG_ID, result.zkEmailInvites, selClaimEmail);
-        PaymasterHub.Rule memory rRegisterDomain =
-            paymasterHub.getRule(ZK_ORG_ID, result.zkEmailInvites, selRegisterClaimDomain);
-        PaymasterHub.Rule memory rRegisterEmail =
-            paymasterHub.getRule(ZK_ORG_ID, result.zkEmailInvites, selRegisterClaimEmail);
+        // Compiler-derived selectors: the old hand-written strings here used `string` where the
+        // real proof tuple has `bytes32` (domain hash) — a latent bug this test used to share
+        // with the deployer's whitelist builder (string compared against the same string).
+        bytes4 selClaimDomain = ZkEmailInvites.claimRoleByDomain.selector;
+        bytes4 selClaimEmail = ZkEmailInvites.claimRoleByEmail.selector;
+        bytes4 selRegisterClaimDomain = ZkEmailInvites.registerAndClaimByDomainWithPasskey.selector;
+        bytes4 selRegisterClaimEmail = ZkEmailInvites.registerAndClaimByEmailWithPasskey.selector;
 
-        assertTrue(rClaimDomain.allowed, "claimRoleByDomain allowed");
-        assertTrue(rClaimEmail.allowed, "claimRoleByEmail allowed");
-        assertTrue(rRegisterDomain.allowed, "registerAndClaimByDomainWithPasskey allowed");
-        assertTrue(rRegisterEmail.allowed, "registerAndClaimByEmailWithPasskey allowed");
+        (bool aDomain, uint32 hDomain,) = _pmLensZk().effectiveRuleOf(ZK_ORG_ID, result.zkEmailInvites, selClaimDomain);
+        (bool aEmail, uint32 hEmail,) = _pmLensZk().effectiveRuleOf(ZK_ORG_ID, result.zkEmailInvites, selClaimEmail);
+        (bool aRegDomain, uint32 hRegDomain,) =
+            _pmLensZk().effectiveRuleOf(ZK_ORG_ID, result.zkEmailInvites, selRegisterClaimDomain);
+        (bool aRegEmail, uint32 hRegEmail,) =
+            _pmLensZk().effectiveRuleOf(ZK_ORG_ID, result.zkEmailInvites, selRegisterClaimEmail);
 
-        assertEq(uint256(rClaimDomain.maxCallGasHint), 800_000, "domain claim gas hint");
-        assertEq(uint256(rClaimEmail.maxCallGasHint), 800_000, "email claim gas hint");
-        assertEq(uint256(rRegisterDomain.maxCallGasHint), 1_200_000, "combined domain claim gas hint");
-        assertEq(uint256(rRegisterEmail.maxCallGasHint), 1_200_000, "combined email claim gas hint");
+        assertTrue(aDomain, "claimRoleByDomain allowed");
+        assertTrue(aEmail, "claimRoleByEmail allowed");
+        assertTrue(aRegDomain, "registerAndClaimByDomainWithPasskey allowed");
+        assertTrue(aRegEmail, "registerAndClaimByEmailWithPasskey allowed");
+
+        assertEq(uint256(hDomain), 800_000, "domain claim gas hint");
+        assertEq(uint256(hEmail), 800_000, "email claim gas hint");
+        assertEq(uint256(hRegDomain), 1_200_000, "combined domain claim gas hint");
+        assertEq(uint256(hRegEmail), 1_200_000, "combined email claim gas hint");
+    }
+
+    PaymasterHubLens private _zkLens;
+
+    function _pmLensZk() internal returns (PaymasterHubLens) {
+        if (address(_zkLens) == address(0)) _zkLens = new PaymasterHubLens(address(paymasterHub));
+        return _zkLens;
     }
 
     function testPaymasterRules_unaffected_whenInfraNotWired() public {
@@ -481,11 +482,7 @@ contract ZkEmailOrgFlowTest is DeployerTest {
         assertEq(result.zkEmailInvites, address(0), "ZkEmailInvites not deployed");
 
         // Even if we query for the selector, it should be unset (allowed=false, cap=0).
-        bytes4 selClaimDomain = bytes4(
-            keccak256(
-                "claimRoleByDomain((uint256[2],uint256[2][2],uint256[2],bytes32,bytes32,string),address,uint256[],bytes32[])"
-            )
-        );
+        bytes4 selClaimDomain = ZkEmailInvites.claimRoleByDomain.selector;
         PaymasterHub.Rule memory rClaim = paymasterHub.getRule(ZK_ORG_ID, address(0), selClaimDomain);
         assertFalse(rClaim.allowed, "no rule for address(0)");
         assertEq(uint256(rClaim.maxCallGasHint), 0, "no gas hint");


### PR DESCRIPTION
Replaces the per-org, address-keyed paymaster whitelist with a Poa-managed **global rulebook** keyed by `(module typeId, selector)`: orgs map their proxies to typeIds and resolve rules local-first then (in default Mirror mode) through the rulebook, so sponsoring a new/changed function is one `setGlobalRulesBatch` per chain instead of a vote in every org plus an OrgDeployer redeploy — Static-mode orgs instead pin their rules and vote changes in like a pinned upgrade, with per-pair block vetoes, explicit-deny semantics (`setRule(false)` now actually revokes for Mirror orgs), and `adopt`/`snapshot` helpers. All rule logic moves to a new delegatecall `PaymasterRuleLib` (hub runtime 22,422 B, +2,154 headroom at runs=200), OrgDeployer's ~300-line hardcoded selector table is deleted in favor of `_buildTargetTypes` + the canonical seed list in `script/helpers/DefaultGlobalRules.sol` (which also carries the corrected ZkEmailInvites signatures, reconciled with #190's fix on main), and the hub keeps a legacy 13-field `registerAndConfigureOrg` overload so live OrgDeployer proxies keep working across the upgrade with no lockstep. `UpgradePaymasterGlobalRules.s.sol` ships the full v20 runbook — impl deploys, beacon upgrades, rulebook seeding, target-type migration data for all 10 live orgs, pre-v20 explicit-denial reconstruction from the RuleSet event log (applied before typing so revoked pairs are never resurrected), Lens redeploy, and the v20 type-registering OrgDeployer — validated by SimGnosis/SimArbitrum fork sims (PASS under the production profile, including legacy-ABI, denial-preservation, and #153-healing legs: Poa/Argus/Decentral Park regain the v6 TaskManager selectors via the rulebook with zero governance). The Lens gains a global-aware `effectiveRuleOf`/`wouldValidate`, infra deploy scripts seed the rulebook on fresh chains, and coverage grows to 1,809 passing tests including a 52-entry seed-list bijection against compiler-derived selectors, differential Lens-vs-hub parity, and `vm.store`-planted pre-v20 denial regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)