### PR TITLE
docs: fix unrenderable ZK Email mermaid sequence diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ sequenceDiagram
     participant Z as ZkEmailInvites
     participant D as PoaDKIMRegistry
     participant E as Executor / EligibilityModule
-    U->>B: Send/forward an email; paste the raw .eml
+    U->>B: Send/forward an email, paste the raw .eml
     B->>B: Generate Groth16 proof (domain or specific-address circuit)
     B->>Z: claimRoleByDomain / claimRoleByEmail (proof, hatIds, merkleProof)
     Z->>Z: Verify Groth16 proof


### PR DESCRIPTION
The "Role Invitations via ZK Email" sequence diagram failed to render on GitHub with `Parse error on line 7`. Mermaid treats `;` as a statement separator, so the message text `Send/forward an email; paste the raw .eml` was parsed as two statements — the arrow, then a dangling `paste the raw .eml` fragment that the parser rejected when it hit the newline expecting an arrow operator.

Replaced the semicolon with a comma. Verified by parsing the README's mermaid blocks with `mermaid@11` + `jsdom`: the pre-fix string reproduces the exact error, and post-fix all 5 blocks parse clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)